### PR TITLE
fix: non-SQL text before CREATE PACKAGE no longer corrupts package pa…

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -391,6 +391,13 @@ impl Parser {
                         return i;
                     }
                 }
+                Token::Keyword(Keyword::CREATE)
+                    if !is_package && depth <= 0 && begin_depth <= 0 =>
+                {
+                    if self.detect_package_context_at(i) {
+                        return if i > self.pos { i - 1 } else { i };
+                    }
+                }
                 _ => {}
             }
         }
@@ -501,7 +508,12 @@ impl Parser {
     }
 
     fn detect_package_context(&self) -> bool {
-        let mut i = self.pos;
+        self.detect_package_context_at(self.pos)
+    }
+
+    /// Check if tokens at `pos` form `CREATE [OR REPLACE] PACKAGE [BODY]`.
+    fn detect_package_context_at(&self, pos: usize) -> bool {
+        let mut i = pos;
         if i >= self.tokens.len() {
             return false;
         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2093,6 +2093,45 @@ end pkg_test;";
     assert!(matches!(&stmts[1], Statement::CreatePackageBody(_)));
 }
 
+// ========== Non-SQL text before CREATE PACKAGE (issue #12) ==========
+
+#[test]
+fn test_non_sql_text_before_create_package() {
+    let sql = "some_file.sql
+=========================================
+create or replace package pkg_test is
+ TYPE refcur IS REF CURSOR;
+ PROCEDURE prc_one(p1 in varchar2, out_code OUT VARCHAR2);
+end pkg_test;";
+    let (infos, _errs) = Parser::parse_sql(sql);
+    assert_eq!(infos.len(), 2, "expected 2 statements (garbage + package), got {}", infos.len());
+    assert!(matches!(infos[0].statement, Statement::Empty), "first statement should be Empty (garbage), got {:?}", infos[0].statement);
+    match &infos[1].statement {
+        Statement::CreatePackage(p) => {
+            assert_eq!(p.name, vec!["pkg_test"]);
+            assert_eq!(p.items.len(), 1);
+        }
+        other => panic!("expected CreatePackage, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_clean_create_package_unchanged() {
+    let sql = "create or replace package pkg_test is
+ TYPE refcur IS REF CURSOR;
+ PROCEDURE prc_one(p1 in varchar2, out_code OUT VARCHAR2);
+end pkg_test;";
+    let (infos, _errs) = Parser::parse_sql(sql);
+    assert_eq!(infos.len(), 1, "clean package should produce exactly 1 statement");
+    match &infos[0].statement {
+        Statement::CreatePackage(p) => {
+            assert_eq!(p.name, vec!["pkg_test"]);
+            assert_eq!(p.items.len(), 1);
+        }
+        other => panic!("expected CreatePackage, got {:?}", other),
+    }
+}
+
 // ========== P4: Embedded SQL text in PL/pgSQL blocks ==========
 
 #[test]


### PR DESCRIPTION
…rsing

When garbage text (e.g. filename, separator lines) appears before a CREATE PACKAGE statement, find_statement_end_pos now detects the CREATE PACKAGE boundary and stops the garbage statement there, instead of scanning past it and splitting the package at an internal semicolon.

Fixes #12