### PR TITLE
test: add regression tests for CASE WHEN in PL/SQL SELECT (#18)

### DIFF
--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -12309,3 +12309,96 @@ fn test_pl_variable_in_update_where() {
     assert!(found_t_data_key, "t.data_key should remain as ColumnRef (qualified)");
     assert!(found_rownum, "rownum should remain as ColumnRef (not in scope)");
 }
+
+// --- Issue #18: CASE WHEN inside PL/SQL SELECT ---
+
+#[test]
+fn test_issue18_case_when_in_package_select() {
+    let sql = r#"CREATE OR REPLACE PACKAGE BODY test_pkg IS
+  PROCEDURE prc_test IS
+  BEGIN
+    OPEN out_cur FOR
+    SELECT t.id,
+      CASE t.status
+        WHEN '1' THEN 'active'
+        WHEN '2' THEN 'inactive'
+        ELSE 'unknown'
+      END AS status_text
+    FROM users t;
+  END;
+END test_pkg;
+/"#;
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackageBody(pkg) => {
+            let proc = pkg.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            assert_eq!(proc.name, vec!["prc_test"]);
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert!(!block.body.is_empty(), "procedure body should not be empty");
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_issue18_case_when_select_into() {
+    let sql = r#"CREATE OR REPLACE PACKAGE BODY test_pkg IS
+  PROCEDURE prc_test IS
+  BEGIN
+    SELECT CASE t.status
+        WHEN '1' THEN 'active'
+        WHEN '2' THEN 'inactive'
+        ELSE 'unknown'
+      END AS status_text
+    INTO v_result
+    FROM users t;
+  END;
+END test_pkg;
+/"#;
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackageBody(pkg) => {
+            let proc = pkg.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert!(!block.body.is_empty(), "procedure body should not be empty");
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_issue18_searched_case_in_package() {
+    let sql = r#"CREATE OR REPLACE PACKAGE BODY test_pkg IS
+  PROCEDURE prc_test IS
+  BEGIN
+    OPEN out_cur FOR
+    SELECT t.id,
+      CASE
+        WHEN t.status = '1' THEN 'active'
+        WHEN t.status = '2' THEN 'inactive'
+        ELSE 'unknown'
+      END AS status_text
+    FROM users t;
+  END;
+END test_pkg;
+/"#;
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackageBody(pkg) => {
+            let proc = pkg.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            assert_eq!(proc.name, vec!["prc_test"]);
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert!(!block.body.is_empty(), "procedure body should not be empty");
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}


### PR DESCRIPTION
Add tests verifying CASE WHEN expressions parse correctly inside PL/SQL package body procedures — in OPEN FOR, SELECT INTO, and searched CASE forms. These cases already pass on main; the tests guard against future regressions.