### PR TITLE
fix: PL/SQL parser error fixes (12 root causes, ~200 errors resolved)

### DIFF
--- a/src/ast/plpgsql.rs
+++ b/src/ast/plpgsql.rs
@@ -521,6 +521,8 @@ impl fmt::Display for GetDiagItemKind {
 pub struct PlFetchStmt {
     pub cursor: crate::ast::Expr,
     pub direction: Option<FetchDirection>,
+    #[serde(default)]
+    pub bulk_collect: bool,
     pub into: crate::ast::Expr,
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -4948,8 +4948,14 @@ impl SqlFormatter {
                     s.push_str(&format!(" {} ", dir));
                 }
                 s.push_str(&format!(
-                    "{} {} {};",
-                    self.format_expr(&f.cursor),
+                    "{}",
+                    self.format_expr(&f.cursor)
+                ));
+                if f.bulk_collect {
+                    s.push_str(&format!(" {} {}", self.kw("BULK"), self.kw("COLLECT")));
+                }
+                s.push_str(&format!(
+                    " {} {};",
                     self.kw("INTO"),
                     self.format_expr(&f.into)
                 ));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -104,11 +104,23 @@ impl Parser {
     /// Otherwise, emit ColumnRef (may be resolved later by the analyzer).
     pub(crate) fn parse_pl_variable_or_column(&mut self) -> Result<crate::ast::Expr, ParserError> {
         let name = self.parse_object_name()?;
-        if !name.is_empty() && self.is_var_declared(&name[0]) {
-            Ok(crate::ast::Expr::PlVariable(name))
+        let base = if !name.is_empty() && self.is_var_declared(&name[0]) {
+            crate::ast::Expr::PlVariable(name)
         } else {
-            Ok(crate::ast::Expr::ColumnRef(name))
+            crate::ast::Expr::ColumnRef(name)
+        };
+
+        let mut expr = base;
+        while self.match_token(&Token::LParen) {
+            self.advance();
+            let index = self.parse_expr()?;
+            self.expect_token(&Token::RParen)?;
+            expr = crate::ast::Expr::Subscript {
+                object: Box::new(expr),
+                index: Box::new(index),
+            };
         }
+        Ok(expr)
     }
 
     fn enter_scope(&mut self) -> Result<(), ParserError> {

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -224,6 +224,10 @@ impl Parser {
 
         if matches!(self.peek(), Token::Percent) {
             self.advance();
+            if self.match_ident_str("rowtype") {
+                self.advance();
+                return Ok(PlDataType::PercentRowType(name));
+            }
             if self.match_ident_str("type") {
                 self.advance();
             }

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -1805,6 +1805,15 @@ impl Parser {
         };
 
         let cursor = self.parse_expr()?;
+
+        let bulk_collect = if self.match_ident_str("bulk") {
+            self.advance();
+            self.expect_ident_str("collect")?;
+            true
+        } else {
+            false
+        };
+
         self.expect_ident_str("into")?;
         let into = self.parse_expr()?;
         self.try_consume_semicolon();
@@ -1812,6 +1821,7 @@ impl Parser {
         Ok(PlStatement::Fetch(PlFetchStmt {
             cursor,
             direction,
+            bulk_collect,
             into,
         }))
     }

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -2421,7 +2421,8 @@ impl Parser {
     }
 
     pub(crate) fn try_parse_oracle_var_decl(&mut self) -> Option<PlDeclaration> {
-        if !matches!(self.peek(), Token::Ident(_)) {
+        let is_unreserved_kw = matches!(self.peek(), Token::Keyword(kw) if kw.category() == crate::token::keyword::KeywordCategory::Unreserved);
+        if !matches!(self.peek(), Token::Ident(_)) && !is_unreserved_kw {
             return None;
         }
 
@@ -2429,6 +2430,7 @@ impl Parser {
 
         let name = match self.peek() {
             Token::Ident(s) => s.clone(),
+            Token::Keyword(kw) => kw.as_str().to_string(),
             _ => return None,
         };
 
@@ -2437,6 +2439,8 @@ impl Parser {
             || name.eq_ignore_ascii_case("procedure")
             || name.eq_ignore_ascii_case("function")
             || name.eq_ignore_ascii_case("exception")
+            || name.eq_ignore_ascii_case("declare")
+            || name.eq_ignore_ascii_case("cursor")
         {
             return None;
         }

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -304,3 +304,79 @@ END;"#;
         other => panic!("expected CreateProcedure, got {:?}", other),
     }
 }
+
+#[test]
+fn test_fetch_bulk_collect_into() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  v_cur SYS_REFCURSOR;
+  v_list VARCHAR2_ARRAY;
+BEGIN
+  OPEN v_cur FOR 'SELECT id FROM t';
+  FETCH v_cur BULK COLLECT INTO v_list;
+  CLOSE v_cur;
+END;"#;
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            match &block.body[1] {
+                PlStatement::Fetch(f) => {
+                    assert!(f.bulk_collect, "expected bulk_collect = true");
+                }
+                other => panic!("expected Fetch, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_fetch_bulk_collect_into_multiple_targets() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  v_cur SYS_REFCURSOR;
+  v_ids VARCHAR2_ARRAY;
+  v_names VARCHAR2_ARRAY;
+BEGIN
+  OPEN v_cur FOR 'SELECT id, name FROM t';
+  FETCH v_cur BULK COLLECT INTO v_ids, v_names;
+  CLOSE v_cur;
+END;"#;
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1, "should parse one statement");
+}
+
+#[test]
+fn test_execute_immediate_after_bulk_collect() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  v_sql VARCHAR2(4000);
+BEGIN
+  v_sql := 'UPDATE t SET x = 1';
+  EXECUTE IMMEDIATE v_sql;
+END;"#;
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            match &block.body[1] {
+                PlStatement::Execute(e) => {
+                    assert!(e.immediate, "expected immediate = true");
+                }
+                other => panic!("expected Execute, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_case_alias_in_package_spec_cursor() {
+    let sql = r#"CREATE OR REPLACE PACKAGE test_pkg IS
+  CURSOR c_test IS
+    SELECT xwdm,
+           CASE WHEN v = 1 THEN 'A' ELSE 'B' END check_type,
+           '' account_date
+    FROM t1;
+END test_pkg;"#;
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1, "should parse one statement");
+}

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -203,3 +203,39 @@ fn test_package_body_error_recovery_preserves_remaining_items() {
         other => panic!("expected CreatePackageBody, got {:?}", other),
     }
 }
+
+#[test]
+fn test_subscripted_into_target() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  v_value VARCHAR2_ARRAY;
+BEGIN
+  SELECT v_value(1) || to_char(COUNT(1)) || ','
+    INTO v_value(1)
+    FROM tranlog t;
+END;"#;
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1, "should parse one statement");
+}
+
+#[test]
+fn test_subscripted_into_target_simple() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  v_value VARCHAR2_ARRAY;
+BEGIN
+  SELECT 1 INTO v_value(1) FROM dual;
+END;"#;
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1, "should parse one statement");
+}
+
+#[test]
+fn test_subscripted_into_multiple_targets() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  v_arr VARCHAR2_ARRAY;
+  v_cnt NUMBER;
+BEGIN
+  SELECT v_cnt + 1, v_arr(2) INTO v_cnt, v_arr(1) FROM dual;
+END;"#;
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1, "should parse one statement");
+}

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -263,3 +263,44 @@ END;"#;
         other => panic!("expected CreateProcedure, got {:?}", other),
     }
 }
+
+#[test]
+fn test_percent_rowtype_in_inner_block() {
+    // %ROWTYPE was previously not handled in parse_pl_data_type, causing
+    // ROWTYPE_P keyword to remain unconsumed and cascade parse failures
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+BEGIN
+  DECLARE
+    CURSOR c IS SELECT id, name FROM t;
+    r c%ROWTYPE;
+    w NUMBER;
+  BEGIN
+    SELECT COUNT(1) INTO w FROM t;
+  END;
+END;"#;
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::Block(inner) => {
+                    assert_eq!(inner.declarations.len(), 3);
+                    match &inner.declarations[1] {
+                        PlDeclaration::Variable(v) => {
+                            assert_eq!(v.name, "r");
+                            assert!(
+                                matches!(v.data_type, PlDataType::PercentRowType(ref t) if t == "c"),
+                                "expected PercentRowType(\"c\"), got {:?}",
+                                v.data_type
+                            );
+                        }
+                        other => panic!("expected Variable, got {:?}", other),
+                    }
+                }
+                other => panic!("expected Block, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -239,3 +239,27 @@ END;"#;
     let stmts = parse(sql);
     assert_eq!(stmts.len(), 1, "should parse one statement");
 }
+
+#[test]
+fn test_unreserved_keyword_as_variable_name() {
+    // RESULT is an unreserved keyword in openGauss/GaussDB and can be used as a variable name
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_proc IS
+  result INTEGER;
+BEGIN
+  result := 1;
+END;"#;
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            assert_eq!(block.declarations.len(), 1);
+            match &block.declarations[0] {
+                PlDeclaration::Variable(v) => {
+                    assert_eq!(v.name, "result");
+                }
+                other => panic!("expected Var, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}

--- a/src/parser/utility/functions.rs
+++ b/src/parser/utility/functions.rs
@@ -690,8 +690,30 @@ impl Parser {
                         self.advance();
                     } else {
                         self.advance();
-                        while matches!(self.peek(), Token::Ident(_) | Token::Keyword(_)) {
+                        // END IF / END LOOP / END CASE — compound ends, skip them
+                        if self.match_keyword(Keyword::IF_P)
+                            || self.match_keyword(Keyword::LOOP)
+                            || self.match_keyword(Keyword::CASE)
+                        {
                             self.advance();
+                            continue;
+                        }
+                        // END followed by ident and then semicolon/EOF = final END pkg_name;
+                        // END followed by comma or other = CASE alias or similar, keep going
+                        if matches!(self.peek(), Token::Ident(_) | Token::Keyword(_)) {
+                            // Peek further: if the token after the ident is ; or EOF, this is END package_name
+                            let after_name = self.tokens.get(self.pos + 1);
+                            if after_name.is_none()
+                                || matches!(after_name.map(|t| &t.token), Some(Token::Semicolon) | Some(Token::Slash))
+                            {
+                                while matches!(self.peek(), Token::Ident(_) | Token::Keyword(_)) {
+                                    self.advance();
+                                }
+                                break;
+                            }
+                            // Otherwise it's something like END check_type, — skip ident and continue
+                            self.advance();
+                            continue;
                         }
                         break;
                     }


### PR DESCRIPTION
## Summary

- Fix 12 root causes of parse errors across Oracle/PL-SQL grammar, resolving ~200 errors from batch validation against GaussDB SQL files
- All 955 tests pass (12 new regression tests added)

## Changes

### New PL/SQL Features
- **`TYPE ... IS REF CURSOR`** — support ref cursor type declarations in PL/SQL blocks
- **`MINUS` set operator** — map to `SetOperation::Except` (Oracle synonym)
- **`%ROWTYPE`** — handle `table%ROWTYPE` in `parse_pl_data_type`
- **`FETCH BULK COLLECT INTO`** — support bulk collect syntax in FETCH statements

### Bug Fixes
- **Fullwidth comma `，`** — tokenize U+FF0C as comma (Chinese input)
- **Qualified `%TYPE`** — support `schema.table.col%TYPE` (3-part dotted names)
- **Infinite loop** — prevent hang on bare `=` token (e.g. CDATA with `&gt;=`)
- **Subscripted INTO targets** — parse `SELECT ... INTO v(i)` correctly
- **Unreserved keywords as variable names** — allow `RESULT`, `TYPE`, etc. in declarations
- **CASE alias in package spec** — `CASE ... END alias,` no longer terminates package parsing prematurely

### Infrastructure
- **Formatter** — add missing `RefCursor` and `PercentRowType` arms
- **Regression tests** — 12 tests in `tests_plsql_fixes.rs` covering all fixes

## Test Plan
- [x] `cargo test` — 955 passed, 0 failed
- [x] All 3 error logs (error-1, error-2, error-3) validated and root causes confirmed fixed
- [x] TDD approach: failing test → implement → verify pass for each fix