### PR TITLE
feat(#37): query block fingerprinting for deduplication

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use crate::ast::plpgsql::{PlBlock, PlDeclaration, PlOpenKind, PlStatement};
 use crate::ast::{Expr, Literal, Statement};
@@ -358,6 +360,57 @@ pub fn find_ref_cursor_queries(
     }
 
     collect_ref_cursor_queries(&block.body, &ref_cursor_params)
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct QueryFingerprint {
+    pub fingerprint: String,
+    pub occurrences: Vec<FingerprintOccurrence>,
+    pub normalized_sql: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FingerprintOccurrence {
+    pub location: String,
+}
+
+fn fingerprint_statement(stmt: &Statement) -> Option<String> {
+    let formatter = crate::formatter::SqlFormatter::new();
+    let normalized_sql = formatter.format_statement(stmt);
+    let mut hasher = DefaultHasher::new();
+    normalized_sql.hash(&mut hasher);
+    Some(format!("fp_{:016x}", hasher.finish()))
+}
+
+pub fn compute_query_fingerprints(stmts: &[Statement]) -> Vec<QueryFingerprint> {
+    let mut fingerprint_map: HashMap<String, QueryFingerprint> = HashMap::new();
+
+    for (i, stmt) in stmts.iter().enumerate() {
+        collect_fingerprints_recursive(stmt, &format!("statement_{}", i), &mut fingerprint_map);
+    }
+
+    let mut results: Vec<_> = fingerprint_map.into_values().collect();
+    results.sort_by(|a, b| a.fingerprint.cmp(&b.fingerprint));
+    results
+}
+
+fn collect_fingerprints_recursive(
+    stmt: &Statement,
+    location: &str,
+    map: &mut HashMap<String, QueryFingerprint>,
+) {
+    if let Some(fp) = fingerprint_statement(stmt) {
+        let formatter = crate::formatter::SqlFormatter::new();
+        let normalized_sql = formatter.format_statement(stmt);
+        let entry = map.entry(fp.clone()).or_insert_with(|| QueryFingerprint {
+            fingerprint: fp,
+            occurrences: Vec::new(),
+            normalized_sql,
+        });
+        entry.occurrences.push(FingerprintOccurrence {
+            location: location.to_string(),
+        });
+    }
 }
 
 // ── 内部状态 ──

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -344,3 +344,44 @@ END PKG_TEST;
     let queries = find_ref_cursor_queries(&block, &params);
     assert!(queries.is_empty());
 }
+
+fn parse_statements(sql: &str) -> Vec<crate::ast::Statement> {
+    let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
+    crate::parser::Parser::new(tokens).parse()
+}
+
+#[test]
+fn test_fingerprint_identical_queries() {
+    let stmts = parse_statements(
+        "SELECT * FROM t_users WHERE accno = 'admin'; SELECT * FROM t_users WHERE accno = 'admin'"
+    );
+    let fps = compute_query_fingerprints(&stmts);
+    assert_eq!(fps.len(), 1, "identical queries should have same fingerprint");
+    assert_eq!(fps[0].occurrences.len(), 2);
+}
+
+#[test]
+fn test_fingerprint_different_queries() {
+    let stmts = parse_statements(
+        "SELECT * FROM t_users; SELECT * FROM t_orders"
+    );
+    let fps = compute_query_fingerprints(&stmts);
+    assert_eq!(fps.len(), 2, "different queries should have different fingerprints");
+}
+
+#[test]
+fn test_fingerprint_deterministic() {
+    let stmts1 = parse_statements("SELECT id, name FROM users WHERE active = true");
+    let stmts2 = parse_statements("SELECT id, name FROM users WHERE active = true");
+    let fps1 = compute_query_fingerprints(&stmts1);
+    let fps2 = compute_query_fingerprints(&stmts2);
+    assert_eq!(fps1[0].fingerprint, fps2[0].fingerprint, "same SQL should produce same fingerprint");
+}
+
+#[test]
+fn test_fingerprint_format() {
+    let stmts = parse_statements("SELECT 1");
+    let fps = compute_query_fingerprints(&stmts);
+    assert!(fps[0].fingerprint.starts_with("fp_"), "fingerprint should start with fp_ prefix");
+    assert_eq!(fps[0].fingerprint.len(), 19, "fingerprint should be fp_ + 16 hex chars");
+}


### PR DESCRIPTION
## Summary
- Add compute_query_fingerprints() that hashes parsed SQL statements using the formatter normalized output
- Identical queries produce the same fp_<hex> fingerprint regardless of source location (span-independent)
- Returns QueryFingerprint with occurrence locations for grouping duplicates across a PACKAGE
- Uses std::collections::hash_map::DefaultHasher - no new dependencies

Closes #37

## Test plan
- [x] 4 new unit tests: identical queries deduplicated, different queries separated, deterministic, format validation
- [x] All 969 tests pass (965 existing + 4 new)