### PR TITLE
fix(#41): support multiple target variables in FETCH INTO

### DIFF
--- a/src/ast/plpgsql.rs
+++ b/src/ast/plpgsql.rs
@@ -490,7 +490,8 @@ pub struct PlFetchStmt {
     pub direction: Option<FetchDirection>,
     #[serde(default)]
     pub bulk_collect: bool,
-    pub into: crate::ast::Expr,
+    #[serde(default)]
+    pub into: Vec<crate::ast::Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -362,7 +362,12 @@ pub fn walk_pl_statement(visitor: &mut dyn Visitor, stmt: &crate::ast::plpgsql::
                     VisitorResult::Continue
                 }
                 crate::ast::plpgsql::PlStatement::Fetch(fetch_stmt) => {
-                    walk_expr(visitor, &fetch_stmt.into)
+                    for expr in &fetch_stmt.into {
+                        if walk_expr(visitor, expr) == VisitorResult::Stop {
+                            return VisitorResult::Stop;
+                        }
+                    }
+                    VisitorResult::Continue
                 }
                 crate::ast::plpgsql::PlStatement::ProcedureCall(proc_call) => {
                     if visitor.visit_procedure_call(proc_call) == VisitorResult::Stop {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -4957,7 +4957,7 @@ impl SqlFormatter {
                 s.push_str(&format!(
                     " {} {};",
                     self.kw("INTO"),
-                    self.format_expr(&f.into)
+                    f.into.iter().map(|e| self.format_expr(e)).collect::<Vec<_>>().join(", ")
                 ));
                 s
             }

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -1814,14 +1814,18 @@ impl Parser {
         };
 
         self.expect_ident_str("into")?;
-        let into = self.parse_expr()?;
+        let mut into_vars = vec![self.parse_expr()?];
+        while self.match_token(&Token::Comma) {
+            self.advance();
+            into_vars.push(self.parse_expr()?);
+        }
         self.try_consume_semicolon();
 
         Ok(PlStatement::Fetch(Spanned::new(PlFetchStmt {
             cursor,
             direction,
             bulk_collect,
-            into,
+            into: into_vars,
         }, None)))
     }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1072,7 +1072,8 @@ fn test_plpgsql_fetch_cursor() {
     match &block.body[0] {
         PlStatement::Fetch(f) => {
             assert!(matches!(&f.cursor, Expr::ColumnRef(n) if n == &["cur"]));
-            assert!(matches!(&f.into, Expr::ColumnRef(name) if name == &["x".to_string()]));
+            assert_eq!(f.into.len(), 1);
+            assert!(matches!(&f.into[0], Expr::ColumnRef(name) if name == &["x".to_string()]));
         }
         _ => panic!("expected Fetch"),
     }
@@ -4523,7 +4524,8 @@ fn test_plpgsql_fetch_with_direction() {
         PlStatement::Fetch(f) => {
             assert!(matches!(&f.cursor, Expr::ColumnRef(n) if n == &["cur"]));
             assert!(matches!(f.direction, Some(plpgsql::FetchDirection::Next)));
-            assert!(matches!(&f.into, Expr::ColumnRef(name) if name == &["x".to_string()]));
+            assert_eq!(f.into.len(), 1);
+            assert!(matches!(&f.into[0], Expr::ColumnRef(name) if name == &["x".to_string()]));
         }
         _ => panic!("expected Fetch"),
     }

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -19,22 +19,21 @@ fn parse_one(sql: &str) -> Statement {
         .expect("expected at least one statement")
 }
 
+fn parse_do_block(sql: &str) -> PlBlock {
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::Do(d) => d.node
+            .block
+            .expect("DO statement should have parsed a PL/pgSQL block"),
+        _ => panic!("expected DO statement"),
+    }
+}
+
 fn parse_err(sql: &str) -> Statement {
     let tokens = Tokenizer::new(sql).tokenize().unwrap();
     let mut parser = Parser::new(tokens);
     let stmts = parser.parse();
     stmts.into_iter().next().unwrap()
-}
-
-fn parse_do_block(sql: &str) -> PlBlock {
-    let stmt = parse_one(sql);
-    match stmt {
-        Statement::Do(d) => d
-            .node
-            .block
-            .expect("DO statement should have parsed a PL/pgSQL block"),
-        _ => panic!("expected DO statement"),
-    }
 }
 
 #[test]
@@ -380,4 +379,24 @@ fn test_case_alias_in_package_spec_cursor() {
 END test_pkg;"#;
     let stmts = parse(sql);
     assert_eq!(stmts.len(), 1, "should parse one statement");
+}
+
+#[test]
+fn test_fetch_into_multiple_variables() {
+    let block = parse_do_block("DO $$ BEGIN FETCH cur INTO x, y, z; END $$");
+    match &block.body[0] {
+        PlStatement::Fetch(f) => {
+            assert_eq!(f.into.len(), 3, "expected 3 INTO targets");
+            assert!(matches!(
+                &f.into[0], Expr::ColumnRef(name) if name == &["x".to_string()]
+            ));
+            assert!(matches!(
+                &f.into[1], Expr::ColumnRef(name) if name == &["y".to_string()]
+            ));
+            assert!(matches!(
+                &f.into[2], Expr::ColumnRef(name) if name == &["z".to_string()]
+            ));
+        }
+        _ => panic!("expected Fetch"),
+    }
 }


### PR DESCRIPTION
## Summary
- Change `PlFetchStmt.into` from single `Expr` to `Vec<Expr>` for multi-variable FETCH INTO support
- Parser now loops on comma-separated expressions after INTO keyword
- Updates formatter, visitor, and existing tests to match new Vec-based structure

Closes #41

## Test plan
- [x] New test: `test_fetch_into_multiple_variables` — FETCH cur INTO x, y, z
- [x] Updated 2 existing FETCH tests to use Vec access pattern
- [x] All 974 tests pass (973 baseline + 1 new)