### PR TITLE
fix(#40): support FOR...IN SELECT...LOOP query result traversal

### DIFF
--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -123,6 +123,7 @@ impl Parser {
 
         if self.match_ident_str("record") && !self.is_next_token_type_name() {
             self.advance();
+            self.try_consume_semicolon();
             return Ok(PlDeclaration::Record(PlRecordDecl { name }));
         }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -505,6 +505,56 @@ fn test_plpgsql_for_query() {
     }
 }
 
+#[test]
+fn test_plpgsql_for_query_with_order_by_loop() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_for_query()
+AS $$
+DECLARE
+    v_rec RECORD;
+    v_count INTEGER := 0;
+BEGIN
+    FOR v_rec IN SELECT id, name, amount FROM t_orders WHERE status = 'PENDING' ORDER BY id LOOP
+        v_count := v_count + 1;
+        UPDATE t_orders SET processed = true WHERE id = v_rec.id;
+        INSERT INTO t_audit(order_id, action) VALUES(v_rec.id, 'PROCESSED');
+    END LOOP;
+    INSERT INTO t_log(id, msg) VALUES(1, 'done');
+END;
+$$ LANGUAGE plpgsql"#;
+
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(proc) => {
+            let block = proc.node.block.expect("procedure should have a parsed block");
+            assert_eq!(block.body.len(), 2, "expected FOR loop and INSERT after it");
+            match &block.body[0] {
+                PlStatement::For(f) => {
+                    assert_eq!(f.variable, "v_rec");
+                    match &f.kind {
+                        PlForKind::Query { query, parsed_query, .. } => {
+                            assert!(query.to_lowercase().contains("select"));
+                            assert!(query.to_lowercase().contains("order by"));
+                            assert!(
+                                parsed_query.is_some(),
+                                "SELECT should be structurally parsed, not just raw text"
+                            );
+                        }
+                        _ => panic!("expected Query kind, got {:?}", f.kind),
+                    }
+                    assert_eq!(f.body.len(), 3, "expected 3 statements inside loop body");
+                }
+                _ => panic!("expected For statement, got {:?}", block.body[0]),
+            }
+            assert!(
+                matches!(&block.body[1], PlStatement::SqlStatement { .. }),
+                "expected SqlStatement (INSERT) after loop, got {:?}",
+                block.body[1]
+            );
+        }
+        _ => panic!("expected CreateProcedure, got {:?}", stmt),
+    }
+}
+
 // --- EXIT/CONTINUE ---
 
 #[test]

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -400,3 +400,51 @@ fn test_fetch_into_multiple_variables() {
         _ => panic!("expected Fetch"),
     }
 }
+
+#[test]
+fn test_for_in_select_loop_in_procedure() {
+    let sql = r#"CREATE OR REPLACE PROCEDURE test_for_query()
+AS $$
+DECLARE
+    v_rec RECORD;
+    v_count INTEGER := 0;
+BEGIN
+    FOR v_rec IN SELECT id, name, amount FROM t_orders WHERE status = 'PENDING' ORDER BY id LOOP
+        v_count := v_count + 1;
+        UPDATE t_orders SET processed = true WHERE id = v_rec.id;
+        INSERT INTO t_audit(order_id, action) VALUES(v_rec.id, 'PROCESSED');
+    END LOOP;
+    INSERT INTO t_log(id, msg) VALUES(1, 'done');
+END;
+$$ LANGUAGE plpgsql"#;
+
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1, "should parse one statement, got {}", stmts.len());
+
+    match &stmts[0] {
+        Statement::CreateProcedure(proc) => {
+            let block = proc.block.as_ref().expect("procedure should have a body (block should not be null)");
+            assert!(block.body.len() >= 1, "block body should have statements");
+
+            // The first statement should be a FOR loop
+            match &block.body[0] {
+                PlStatement::For(for_stmt) => {
+                    assert_eq!(for_stmt.node.variable, "v_rec");
+                    match &for_stmt.node.kind {
+                        PlForKind::Query { query, parsed_query, .. } => {
+                            assert!(query.to_uppercase().contains("SELECT"), "query should contain SELECT, got: {:?}", query);
+                            assert!(parsed_query.is_some(), "parsed_query should be Some");
+                        }
+                        other => panic!("expected PlForKind::Query, got {:?}", other),
+                    }
+                    assert_eq!(for_stmt.node.body.len(), 3, "FOR loop body should have 3 statements");
+                }
+                other => panic!("expected FOR statement, got {:?}", other),
+            }
+
+            // Second statement should be the INSERT after the loop
+            assert!(block.body.len() >= 2, "block should have at least 2 statements (FOR + INSERT)");
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `RECORD` declaration parsing not consuming trailing semicolon, causing cascading failure that nulled the entire procedure block
- FOR...IN SELECT...LOOP parsing itself was correct — root cause was RECORD semicolon consumption
- Adds `try_consume_semicolon()` after RECORD declaration parsing

Closes #40

## Test plan
- [x] New test: `test_plpgsql_for_query_with_order_by_loop` — full procedure with FOR IN SELECT ORDER BY LOOP
- [x] New test: `test_for_in_select_loop_in_procedure` — procedure-level block validation
- [x] All 975 tests pass (973 baseline + 2 new)