### PR TITLE
feat(#43): structured SET TRANSACTION statement parsing

### DIFF
--- a/src/ast/plpgsql.rs
+++ b/src/ast/plpgsql.rs
@@ -195,6 +195,11 @@ pub enum PlStatement {
     ReleaseSavepoint {
         name: String,
     },
+    SetTransaction {
+        isolation_level: Option<PlIsolationLevel>,
+        read_only: Option<bool>,
+        deferrable: Option<bool>,
+    },
     Null,
 
     Goto {
@@ -522,4 +527,11 @@ pub struct PlExceptionBlock {
 pub struct PlExceptionHandler {
     pub conditions: Vec<String>,
     pub statements: Vec<PlStatement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PlIsolationLevel {
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -4790,6 +4790,32 @@ impl SqlFormatter {
             PlStatement::Assignment { target, expression } => {
                 format!("{} := {};", self.format_expr(target), self.format_expr(expression))
             }
+            PlStatement::SetTransaction { isolation_level, read_only, deferrable } => {
+                let mut s = format!("{} {}", self.kw("SET"), self.kw("TRANSACTION"));
+                if let Some(ref il) = isolation_level {
+                    s.push_str(&format!(" {} {}", self.kw("ISOLATION"), self.kw("LEVEL")));
+                    match il {
+                        PlIsolationLevel::ReadCommitted => s.push_str(&format!(" {} {}", self.kw("READ"), self.kw("COMMITTED"))),
+                        PlIsolationLevel::RepeatableRead => s.push_str(&format!(" {} {}", self.kw("REPEATABLE"), self.kw("READ"))),
+                        PlIsolationLevel::Serializable => s.push_str(&format!(" {}", self.kw("SERIALIZABLE"))),
+                    }
+                }
+                if let Some(ro) = read_only {
+                    if *ro {
+                        s.push_str(&format!(" {} {}", self.kw("READ"), self.kw("ONLY")));
+                    } else {
+                        s.push_str(&format!(" {} {}", self.kw("READ"), self.kw("WRITE")));
+                    }
+                }
+                if let Some(d) = deferrable {
+                    if *d {
+                        s.push_str(&format!(" {}", self.kw("DEFERRABLE")));
+                    } else {
+                        s.push_str(&format!(" {} {}", self.kw("NOT"), self.kw("DEFERRABLE")));
+                    }
+                }
+                format!("{};", s)
+            }
             PlStatement::Null => format!("{};", self.kw("NULL")),
             PlStatement::If(i) => self.format_pl_if(i, indent),
             PlStatement::Case(c) => self.format_pl_case(c, indent),

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -688,6 +688,10 @@ impl Parser {
             result
         } else if let Some(stmt) = self.try_parse_dml_as_pl_statement() {
             Ok(stmt)
+        } else if self.match_ident_str("set") && self.lookahead_is_transaction() {
+            self.advance();
+            self.advance();
+            self.parse_pl_set_transaction()
         } else {
             self.parse_pl_sql_or_assignment()
         }?;
@@ -976,6 +980,70 @@ impl Parser {
             name,
             arguments,
         }, None)))
+    }
+
+    fn lookahead_is_transaction(&self) -> bool {
+        if self.pos + 1 >= self.tokens.len() {
+            return false;
+        }
+        match &self.tokens[self.pos + 1] {
+            crate::token::TokenWithSpan { token: Token::Ident(s), .. } => s.eq_ignore_ascii_case("transaction"),
+            crate::token::TokenWithSpan { token: Token::Keyword(kw), .. } => kw.as_str().eq_ignore_ascii_case("transaction"),
+            _ => false,
+        }
+    }
+
+    fn parse_pl_set_transaction(&mut self) -> Result<PlStatement, ParserError> {
+        use crate::ast::plpgsql::PlIsolationLevel;
+
+        let mut isolation_level = None;
+        let mut read_only = None;
+        let mut deferrable = None;
+
+        if self.match_ident_str("isolation") {
+            self.advance();
+            self.expect_ident_str("level")?;
+            if self.match_ident_str("read") {
+                self.advance();
+                if self.match_ident_str("committed") {
+                    self.advance();
+                    isolation_level = Some(PlIsolationLevel::ReadCommitted);
+                } else {
+                    self.expect_ident_str("uncommitted")?;
+                    isolation_level = Some(PlIsolationLevel::ReadCommitted);
+                }
+            } else if self.match_ident_str("repeatable") {
+                self.advance();
+                self.expect_ident_str("read")?;
+                isolation_level = Some(PlIsolationLevel::RepeatableRead);
+            } else if self.match_ident_str("serializable") {
+                self.advance();
+                isolation_level = Some(PlIsolationLevel::Serializable);
+            }
+        }
+
+        if self.match_ident_str("read") {
+            self.advance();
+            if self.match_ident_str("only") {
+                self.advance();
+                read_only = Some(true);
+            } else {
+                self.expect_ident_str("write")?;
+                read_only = Some(false);
+            }
+        }
+
+        if self.match_ident_str("not") {
+            self.advance();
+            self.expect_ident_str("deferrable")?;
+            deferrable = Some(false);
+        } else if self.match_ident_str("deferrable") {
+            self.advance();
+            deferrable = Some(true);
+        }
+
+        self.try_consume_semicolon();
+        Ok(PlStatement::SetTransaction { isolation_level, read_only, deferrable })
     }
 
     fn parse_pl_sql_or_assignment(&mut self) -> Result<PlStatement, ParserError> {

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -477,3 +477,42 @@ $$ LANGUAGE plpgsql"#;
         other => panic!("expected CreateProcedure, got {:?}", other),
     }
 }
+
+#[test]
+fn test_set_transaction_isolation_level() {
+    let block = parse_do_block("DO $$ BEGIN SET TRANSACTION ISOLATION LEVEL READ COMMITTED; END $$");
+    match &block.body[0] {
+        PlStatement::SetTransaction { isolation_level, read_only, deferrable } => {
+            assert!(matches!(isolation_level, Some(PlIsolationLevel::ReadCommitted)));
+            assert!(read_only.is_none());
+            assert!(deferrable.is_none());
+        }
+        other => panic!("expected SetTransaction, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_set_transaction_read_only() {
+    let block = parse_do_block("DO $$ BEGIN SET TRANSACTION READ ONLY; END $$");
+    match &block.body[0] {
+        PlStatement::SetTransaction { isolation_level, read_only, deferrable } => {
+            assert!(isolation_level.is_none());
+            assert_eq!(*read_only, Some(true));
+            assert!(deferrable.is_none());
+        }
+        other => panic!("expected SetTransaction, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_set_transaction_serializable_deferrable() {
+    let block = parse_do_block("DO $$ BEGIN SET TRANSACTION ISOLATION LEVEL SERIALIZABLE READ WRITE DEFERRABLE; END $$");
+    match &block.body[0] {
+        PlStatement::SetTransaction { isolation_level, read_only, deferrable } => {
+            assert!(matches!(isolation_level, Some(PlIsolationLevel::Serializable)));
+            assert_eq!(*read_only, Some(false));
+            assert_eq!(*deferrable, Some(true));
+        }
+        other => panic!("expected SetTransaction, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- New `PlStatement::SetTransaction` variant with `isolation_level`, `read_only`, `deferrable` fields
- New `PlIsolationLevel` enum: `ReadCommitted`, `RepeatableRead`, `Serializable`
- Supports ISOLATION LEVEL, READ ONLY/WRITE, DEFERRABLE/NOT DEFERRABLE

Closes #43

## Test plan
- [x] New tests: isolation level, read only, combined serializable+read write+deferrable
- [x] All 979 tests pass