### PR TITLE
feat(#49): transaction flow analysis for PL/pgSQL procedures

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -725,5 +725,251 @@ pub fn analyze_pl_block(block: &PlBlock) -> DynamicSqlReport {
     DynamicSqlAnalyzer::new().analyze(block)
 }
 
+// ── Transaction Analysis ──
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TransactionReport {
+    pub has_explicit_commit: bool,
+    pub has_explicit_rollback: bool,
+    pub has_autonomous_transaction: bool,
+    pub transaction_segments: Vec<TransactionSegment>,
+    pub cross_procedure_calls: Vec<CrossProcedureCall>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TransactionSegment {
+    pub index: usize,
+    pub start_reason: TransactionBoundary,
+    pub end_reason: TransactionBoundary,
+    pub statement_range: (usize, usize),
+    pub sub_transactions: Vec<SubTransaction>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum TransactionBoundary {
+    ProcedureEntry,
+    PostCommit,
+    PostRollback,
+    Commit,
+    Rollback,
+    ProcedureExit,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SubTransaction {
+    pub block_path: Vec<usize>,
+    pub implicit_savepoint: bool,
+    pub body_range: (usize, usize),
+    pub exception_handlers: Vec<ExceptionHandlerInfo>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExceptionHandlerInfo {
+    pub conditions: Vec<String>,
+    pub statement_count: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CrossProcedureCall {
+    pub call_path: Vec<usize>,
+    pub callee: String,
+    pub callee_may_commit: bool,
+}
+
+pub fn analyze_transactions(block: &PlBlock) -> TransactionReport {
+    let mut analyzer = TransactionAnalyzer::new();
+    analyzer.analyze(block)
+}
+
+struct TransactionAnalyzer {
+    has_explicit_commit: bool,
+    has_explicit_rollback: bool,
+    has_autonomous_transaction: bool,
+    segments: Vec<TransactionSegment>,
+    cross_procedure_calls: Vec<CrossProcedureCall>,
+    current_segment_start: usize,
+    current_segment_start_reason: TransactionBoundary,
+    current_segment_stmts: Vec<(usize, SubTransactionInfo)>,
+    global_idx: usize,
+}
+
+struct SubTransactionInfo {
+    block_path: Vec<usize>,
+    implicit_savepoint: bool,
+    body_range: (usize, usize),
+    handlers: Vec<ExceptionHandlerInfo>,
+}
+
+impl TransactionAnalyzer {
+    fn new() -> Self {
+        Self {
+            has_explicit_commit: false,
+            has_explicit_rollback: false,
+            has_autonomous_transaction: false,
+            segments: Vec::new(),
+            cross_procedure_calls: Vec::new(),
+            current_segment_start: 0,
+            current_segment_start_reason: TransactionBoundary::ProcedureEntry,
+            current_segment_stmts: Vec::new(),
+            global_idx: 0,
+        }
+    }
+
+    fn analyze(&mut self, block: &PlBlock) -> TransactionReport {
+        for decl in &block.declarations {
+            if let PlDeclaration::Pragma { name, .. } = decl {
+                if name.eq_ignore_ascii_case("AUTONOMOUS_TRANSACTION") {
+                    self.has_autonomous_transaction = true;
+                }
+            }
+        }
+        self.scan_statements(&block.body, &[]);
+        self.flush_segment(TransactionBoundary::ProcedureExit);
+        TransactionReport {
+            has_explicit_commit: self.has_explicit_commit,
+            has_explicit_rollback: self.has_explicit_rollback,
+            has_autonomous_transaction: self.has_autonomous_transaction,
+            transaction_segments: std::mem::take(&mut self.segments),
+            cross_procedure_calls: std::mem::take(&mut self.cross_procedure_calls),
+        }
+    }
+
+    fn scan_statements(&mut self, stmts: &[PlStatement], path: &[usize]) {
+        for (i, stmt) in stmts.iter().enumerate() {
+            let mut sub_tx = None;
+            self.scan_statement(stmt, &path.iter().copied().chain(std::iter::once(i)).collect::<Vec<_>>(), &mut sub_tx);
+            self.current_segment_stmts.push((self.global_idx, sub_tx.unwrap_or(SubTransactionInfo {
+                block_path: path.iter().copied().chain(std::iter::once(i)).collect(),
+                implicit_savepoint: false,
+                body_range: (0, 0),
+                handlers: Vec::new(),
+            })));
+            self.global_idx += 1;
+        }
+    }
+
+    fn scan_statement(&mut self, stmt: &PlStatement, path: &[usize], sub_tx: &mut Option<SubTransactionInfo>) {
+        match stmt {
+            PlStatement::Commit { .. } => {
+                self.has_explicit_commit = true;
+                let end = if self.global_idx > 0 { self.global_idx } else { 0 };
+                let sub_transactions = self.drain_sub_transactions();
+                self.segments.push(TransactionSegment {
+                    index: self.segments.len(),
+                    start_reason: std::mem::replace(&mut self.current_segment_start_reason, TransactionBoundary::PostCommit),
+                    end_reason: TransactionBoundary::Commit,
+                    statement_range: (self.current_segment_start, end),
+                    sub_transactions,
+                });
+                self.current_segment_start = self.global_idx + 1;
+            }
+            PlStatement::Rollback { .. } => {
+                self.has_explicit_rollback = true;
+                let end = if self.global_idx > 0 { self.global_idx } else { 0 };
+                let sub_transactions = self.drain_sub_transactions();
+                self.segments.push(TransactionSegment {
+                    index: self.segments.len(),
+                    start_reason: std::mem::replace(&mut self.current_segment_start_reason, TransactionBoundary::PostRollback),
+                    end_reason: TransactionBoundary::Rollback,
+                    statement_range: (self.current_segment_start, end),
+                    sub_transactions,
+                });
+                self.current_segment_start = self.global_idx + 1;
+            }
+            PlStatement::ProcedureCall(call) => {
+                let callee = call.name.join(".");
+                self.cross_procedure_calls.push(CrossProcedureCall {
+                    call_path: path.to_vec(),
+                    callee: callee.clone(),
+                    callee_may_commit: false,
+                });
+            }
+            PlStatement::Block(inner_block) => {
+                if inner_block.exception_block.is_some() {
+                    let handler_count = inner_block.exception_block.as_ref().map_or(0, |eb| eb.handlers.len());
+                    let handlers: Vec<ExceptionHandlerInfo> = inner_block
+                        .exception_block
+                        .as_ref()
+                        .map(|eb| {
+                            eb.handlers
+                                .iter()
+                                .map(|h| ExceptionHandlerInfo {
+                                    conditions: h.conditions.clone(),
+                                    statement_count: h.statements.len(),
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    *sub_tx = Some(SubTransactionInfo {
+                        block_path: path.to_vec(),
+                        implicit_savepoint: true,
+                        body_range: (0, inner_block.body.len().saturating_sub(1)),
+                        handlers,
+                    });
+                }
+                self.scan_statements(&inner_block.body, path);
+            }
+            PlStatement::If(if_stmt) => {
+                self.scan_statements(&if_stmt.then_stmts, path);
+                for elsif in &if_stmt.elsifs {
+                    self.scan_statements(&elsif.stmts, path);
+                }
+                self.scan_statements(&if_stmt.else_stmts, path);
+            }
+            PlStatement::Case(case_stmt) => {
+                for when in &case_stmt.whens {
+                    self.scan_statements(&when.stmts, path);
+                }
+                self.scan_statements(&case_stmt.else_stmts, path);
+            }
+            PlStatement::Loop(loop_stmt) => {
+                self.scan_statements(&loop_stmt.body, path);
+            }
+            PlStatement::While(while_stmt) => {
+                self.scan_statements(&while_stmt.body, path);
+            }
+            PlStatement::For(for_stmt) => {
+                self.scan_statements(&for_stmt.body, path);
+            }
+            PlStatement::ForEach(foreach_stmt) => {
+                self.scan_statements(&foreach_stmt.body, path);
+            }
+            _ => {}
+        }
+    }
+
+    fn drain_sub_transactions(&mut self) -> Vec<SubTransaction> {
+        self.current_segment_stmts
+            .drain(..)
+            .filter_map(|(_, info)| {
+                if info.implicit_savepoint {
+                    Some(SubTransaction {
+                        block_path: info.block_path,
+                        implicit_savepoint: true,
+                        body_range: info.body_range,
+                        exception_handlers: info.handlers,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn flush_segment(&mut self, end_reason: TransactionBoundary) {
+        if !self.current_segment_stmts.is_empty() || !self.segments.is_empty() {
+            let end = self.global_idx.saturating_sub(1);
+            let sub_transactions = self.drain_sub_transactions();
+            self.segments.push(TransactionSegment {
+                index: self.segments.len(),
+                start_reason: std::mem::replace(&mut self.current_segment_start_reason, TransactionBoundary::ProcedureEntry),
+                end_reason,
+                statement_range: (self.current_segment_start, end),
+                sub_transactions,
+            });
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -261,7 +261,7 @@ fn test_for_loop_variable_does_not_leak() {
     ));
 }
 
-fn parse_procedure_block(sql: &str) -> (crate::ast::plpgsql::PlBlock, Vec<(String, String, Option<String>)>) {
+fn parse_proc_block(sql: &str) -> (crate::ast::plpgsql::PlBlock, Vec<(String, String, Option<String>)>) {
     let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
     let stmts = Parser::new(tokens).parse();
     if let Some(crate::ast::Statement::CreatePackageBody(pkg)) = stmts.into_iter().next() {
@@ -280,7 +280,7 @@ fn parse_procedure_block(sql: &str) -> (crate::ast::plpgsql::PlBlock, Vec<(Strin
 
 #[test]
 fn test_ref_cursor_out_param_detected() {
-    let (block, params) = parse_procedure_block(
+    let (block, params) = parse_proc_block(
         r#"CREATE OR REPLACE PACKAGE BODY PKG_TEST AS
   PROCEDURE prc_query(p_acnt VARCHAR, out_list OUT REFCURSOR) AS
   BEGIN
@@ -298,7 +298,7 @@ END PKG_TEST;
 
 #[test]
 fn test_ref_cursor_not_matched_for_non_out() {
-    let (block, params) = parse_procedure_block(
+    let (block, params) = parse_proc_block(
         r#"CREATE OR REPLACE PACKAGE BODY PKG_TEST AS
   PROCEDURE prc_query(cur IN REFCURSOR) AS
   BEGIN
@@ -313,7 +313,7 @@ END PKG_TEST;
 
 #[test]
 fn test_ref_cursor_for_execute() {
-    let (block, params) = parse_procedure_block(
+    let (block, params) = parse_proc_block(
         r#"CREATE OR REPLACE PACKAGE BODY PKG_TEST AS
   PROCEDURE prc_query(p_acnt VARCHAR, out_list OUT REFCURSOR) AS
     v_sql VARCHAR;
@@ -332,7 +332,7 @@ END PKG_TEST;
 
 #[test]
 fn test_no_ref_cursor_params() {
-    let (block, params) = parse_procedure_block(
+    let (block, params) = parse_proc_block(
         r#"CREATE OR REPLACE PACKAGE BODY PKG_TEST AS
   PROCEDURE prc_query(p_acnt VARCHAR) AS
   BEGIN
@@ -384,4 +384,103 @@ fn test_fingerprint_format() {
     let fps = compute_query_fingerprints(&stmts);
     assert!(fps[0].fingerprint.starts_with("fp_"), "fingerprint should start with fp_ prefix");
     assert_eq!(fps[0].fingerprint.len(), 19, "fingerprint should be fp_ + 16 hex chars");
+}
+
+fn parse_tx_proc_block(sql: &str) -> crate::ast::plpgsql::PlBlock {
+    let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
+    let stmts = Parser::new(tokens).parse();
+    match &stmts[0] {
+        crate::ast::Statement::CreateProcedure(proc) => {
+            proc.node.block.as_ref().expect("procedure should have a block").clone()
+        }
+        crate::ast::Statement::Do(d) => d.node.block.as_ref().expect("block should parse").clone(),
+        _ => panic!("expected CreateProcedure or DO, got {:?}", stmts[0]),
+    }
+}
+
+#[test]
+fn test_single_segment_no_commit() {
+    let block = parse_block("DO $$ BEGIN INSERT INTO t(id) VALUES(1); UPDATE t SET x = 1; END $$");
+    let report = analyze_transactions(&block);
+    assert!(!report.has_explicit_commit);
+    assert!(!report.has_explicit_rollback);
+    assert!(!report.has_autonomous_transaction);
+    assert_eq!(report.transaction_segments.len(), 1, "single procedure with no COMMIT = 1 segment");
+    assert!(matches!(report.transaction_segments[0].start_reason, TransactionBoundary::ProcedureEntry));
+    assert!(matches!(report.transaction_segments[0].end_reason, TransactionBoundary::ProcedureExit));
+}
+
+#[test]
+fn test_commit_splits_segments() {
+    let block = parse_block("DO $$ BEGIN INSERT INTO t(id) VALUES(1); COMMIT; DELETE FROM t; END $$");
+    let report = analyze_transactions(&block);
+    assert!(report.has_explicit_commit);
+    assert_eq!(report.transaction_segments.len(), 2, "COMMIT should split into 2 segments");
+    assert!(matches!(report.transaction_segments[0].end_reason, TransactionBoundary::Commit));
+    assert!(matches!(report.transaction_segments[1].start_reason, TransactionBoundary::PostCommit));
+    assert!(matches!(report.transaction_segments[1].end_reason, TransactionBoundary::ProcedureExit));
+}
+
+#[test]
+fn test_commit_and_rollback_three_segments() {
+    let block = parse_block("DO $$ BEGIN INSERT INTO t VALUES(1); COMMIT; DELETE FROM t; ROLLBACK; UPDATE t SET x = 1; END $$");
+    let report = analyze_transactions(&block);
+    assert!(report.has_explicit_commit);
+    assert!(report.has_explicit_rollback);
+    assert_eq!(report.transaction_segments.len(), 3);
+    assert!(matches!(report.transaction_segments[0].end_reason, TransactionBoundary::Commit));
+    assert!(matches!(report.transaction_segments[1].end_reason, TransactionBoundary::Rollback));
+    assert!(matches!(report.transaction_segments[2].start_reason, TransactionBoundary::PostRollback));
+}
+
+#[test]
+fn test_exception_block_creates_subtransaction() {
+    let block = parse_tx_proc_block(
+        r#"CREATE OR REPLACE PROCEDURE test_exc()
+AS $$
+BEGIN
+    INSERT INTO t(id) VALUES(1);
+    BEGIN
+        UPDATE t SET x = 1;
+    EXCEPTION
+        WHEN OTHERS THEN
+            INSERT INTO err_log(msg) VALUES('error');
+    END;
+    DELETE FROM t;
+END;
+$$ LANGUAGE plpgsql"#
+    );
+    let report = analyze_transactions(&block);
+    assert_eq!(report.transaction_segments.len(), 1);
+    let seg = &report.transaction_segments[0];
+    assert_eq!(seg.sub_transactions.len(), 1, "EXCEPTION block should create sub-transaction");
+    assert!(seg.sub_transactions[0].implicit_savepoint);
+    assert_eq!(seg.sub_transactions[0].exception_handlers.len(), 1);
+    assert_eq!(seg.sub_transactions[0].exception_handlers[0].conditions, vec!["OTHERS"]);
+}
+
+#[test]
+fn test_pragma_autonomous_transaction_detected() {
+    let block = parse_tx_proc_block(
+        r#"CREATE OR REPLACE PROCEDURE test_auto()
+AS $$
+DECLARE
+    PRAGMA AUTONOMOUS_TRANSACTION;
+BEGIN
+    INSERT INTO t_log(id) VALUES(1);
+    COMMIT;
+END;
+$$ LANGUAGE plpgsql"#
+    );
+    let report = analyze_transactions(&block);
+    assert!(report.has_autonomous_transaction, "PRAGMA AUTONOMOUS_TRANSACTION should be detected");
+    assert!(report.has_explicit_commit);
+}
+
+#[test]
+fn test_cross_procedure_call_tracked() {
+    let block = parse_block("DO $$ BEGIN pkg_tx.commit_inside_proc(); INSERT INTO t VALUES(1); END $$");
+    let report = analyze_transactions(&block);
+    assert_eq!(report.cross_procedure_calls.len(), 1);
+    assert_eq!(report.cross_procedure_calls[0].callee, "pkg_tx.commit_inside_proc");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod parser;
 pub mod token;
 pub mod token_formatter;
 
-pub use analyzer::{analyze_pl_block, compute_query_fingerprints, DynamicSqlReport, QueryFingerprint};
+pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, DynamicSqlReport, QueryFingerprint, TransactionReport};
 
 pub use ast::visitor::{
     walk_statement,


### PR DESCRIPTION
## Summary
- New `TransactionAnalyzer` in `src/analyzer/mod.rs` following the `DynamicSqlAnalyzer` pattern
- `analyze_transactions(block: &PlBlock) -> TransactionReport` public API
- Detects transaction segments split by COMMIT/ROLLBACK
- Identifies EXCEPTION blocks as implicit sub-transactions (savepoints)
- Detects PRAGMA AUTONOMOUS_TRANSACTION in declarations
- Tracks cross-procedure calls with callee names

Closes #49

## Test plan
- [x] 6 new tests: single segment, commit splitting, 3-segment flow, exception sub-tx, pragma detection, cross-procedure calls
- [x] All 988 tests pass (982 baseline + 6 new)