### PR TITLE
docs: document SpecialFunction vs FunctionCall distinction for downst…

### DIFF
--- a/docs/ast-json-reference.md
+++ b/docs/ast-json-reference.md
@@ -141,7 +141,7 @@ Full list of all variants: `Select`, `Insert`, `InsertAll`, `InsertFirst`, `Upda
 | `RowConstructor` | `(1, 'a', TRUE)` | `{ "RowConstructor": [...] }` |
 | `Prior` | `PRIOR x` (hierarchical query) | `{ "Prior": {...} }` |
 | `Default` | `DEFAULT` | `"Default"` |
-| `SpecialFunction` | `EXTRACT(YEAR FROM d)`, `SUBSTRING(s FROM 1 FOR 3)` | `{ "SpecialFunction": { "name": "extract", "args": [...] } }` |
+| `SpecialFunction` | `EXTRACT(YEAR FROM d)`, `SUBSTRING(s FROM 1 FOR 3)`, `SUBSTR('hello', 1, 3)` | `{ "SpecialFunction": { "name": "extract", "args": [...] } }` |
 | `CurrentOf` | `WHERE CURRENT OF cursor` | `{ "CurrentOf": { "cursor_name": "c1" } }` |
 | `XmlElement` | `XMLELEMENT(...)` | `{ "XmlElement": { "name": ..., "content": [...] } }` |
 | `XmlConcat` | `XMLCONCAT(...)` | `{ "XmlConcat": [...] }` |
@@ -155,7 +155,10 @@ Full list of all variants: `Select`, `Insert`, `InsertAll`, `InsertFirst`, `Upda
 
 ## FunctionCall
 
-The most complex and important expression node:
+The most complex and important expression node. Covers all user-defined functions and most
+built-in functions. For functions with keyword-separated syntax (e.g. `EXTRACT`, `SUBSTRING`,
+`SUBSTR`), see [SpecialFunction](#specialfunction) — JSON consumers must handle **both**
+node types when looking for "all function calls".
 
 ```json
 {
@@ -218,17 +221,57 @@ When `window_name` is set, it's a reference to a named window (`OVER w`), and ot
 
 ### SpecialFunction
 
-Functions with keyword-separated syntax (not comma-separated):
+SQL functions that use keyword-separated syntax instead of commas, or have multiple syntax
+forms that must be unified into a single AST type. When walking the AST for "all function
+calls", you **must** handle both `FunctionCall` and `SpecialFunction`.
 
-| Function | SQL Syntax | `name` value |
-|----------|-----------|--------------|
-| `EXTRACT` | `EXTRACT(year FROM date_col)` | `"extract"` |
-| `SUBSTRING` | `SUBSTRING(str FROM 1 FOR 3)` | `"substring"` |
-| `OVERLAY` | `OVERLAY(str PLACING 'x' FROM 2 FOR 1)` | `"overlay"` |
-| `POSITION` | `POSITION('x' IN str)` | `"position"` |
-| `TRIM` | `TRIM(LEADING ' ' FROM str)` | `"trim"` |
+**Why `substr` is SpecialFunction:** `substr` is an alias of `substring`, which supports
+both keyword syntax (`SUBSTRING(str FROM 1 FOR 3)`) and comma syntax (`SUBSTR(str, 1, 3)`).
+To avoid splitting one semantic function across two different AST node types, `substr` is
+always parsed as `SpecialFunction`, even when written with pure comma-separated arguments.
+
+#### Complete List
+
+| Function | `name` value | SQL Syntax | Notes |
+|----------|-------------|------------|-------|
+| `SUBSTRING` / `SUBSTR` | `"substring"` or `"substr"` | `SUBSTRING(str FROM pos [FOR len])` or `SUBSTR(str, pos [, len])` | Both keyword and comma forms → SpecialFunction |
+| `OVERLAY` | `"overlay"` | `OVERLAY(str PLACING repl FROM pos [FOR len])` | |
+| `POSITION` | `"position"` | `POSITION(substr IN str)` | |
+| `EXTRACT` | `"extract"` | `EXTRACT(field FROM expr)` | First arg is the field name as `ColumnRef` |
+| `TRIM` | `"trim"` | `TRIM([LEADING\|TRAILING\|BOTH] [chars] FROM str)` | Only keyword form; `TRIM(expr)` without `FROM` → `FunctionCall` |
+| `CONVERT` | `"convert"` | `CONVERT(expr USING charset)` | Only `USING` form; `CONVERT(a, b)` → `FunctionCall` |
+| `INTERVAL` | `"interval"` | `INTERVAL '1' DAY`, `INTERVAL '2:30' HOUR TO MINUTE` | |
+| `CURRENT_TIME` | `"current_time"` | `CURRENT_TIME` or `CURRENT_TIME(precision)` | Without `()` → `ColumnRef`, not SpecialFunction |
+| `CURRENT_TIMESTAMP` | `"current_timestamp"` | `CURRENT_TIMESTAMP` or `CURRENT_TIMESTAMP(precision)` | Without `()` → `ColumnRef`, not SpecialFunction |
+| `LOCALTIME` | `"localtime"` | `LOCALTIME` or `LOCALTIME(precision)` | Without `()` → `ColumnRef`, not SpecialFunction |
+| `LOCALTIMESTAMP` | `"localtimestamp"` | `LOCALTIMESTAMP` or `LOCALTIMESTAMP(precision)` | Without `()` → `ColumnRef`, not SpecialFunction |
 
 `SpecialFunction` nodes do **not** have `_meta` annotation — they are recognized by the `name` field.
+
+#### Consumer Guidance
+
+To find all function calls in the JSON tree, check for **both** keys:
+
+```javascript
+function isFunctionCall(node) {
+  return node.FunctionCall !== undefined || node.SpecialFunction !== undefined;
+}
+
+function getFunctionName(node) {
+  if (node.FunctionCall) {
+    return node.FunctionCall.name[node.FunctionCall.name.length - 1]; // last element
+  }
+  if (node.SpecialFunction) {
+    return node.SpecialFunction.name;
+  }
+  return null;
+}
+```
+
+**Key differences from `FunctionCall`:**
+- `name` is a **string** (not an array) — these functions are never schema-qualified
+- No `distinct`, `over`, `filter`, `within_group`, `separator` fields
+- No `_meta` annotation — use `function_registry` to check if built-in
 
 ---
 
@@ -335,7 +378,13 @@ Variants: `Union`, `Intersect`, `Except`. Each has `all` (boolean) and `right` (
 
 ### Identify all function calls
 
-Walk the JSON tree recursively. Any object with a `FunctionCall` key contains a function call node. The `name` array's last element is the function name.
+Walk the JSON tree recursively. Any object with a `FunctionCall` **or** `SpecialFunction` key
+contains a function call node. You must handle both — `SpecialFunction` covers functions like
+`SUBSTRING`, `SUBSTR`, `EXTRACT`, `OVERLAY`, `POSITION`, `TRIM` (with `FROM`), `CONVERT` (with
+`USING`), and `INTERVAL`.
+
+- `FunctionCall`: `name` is an array (last element is the function name)
+- `SpecialFunction`: `name` is a string (never schema-qualified)
 
 ### Check if a function is built-in
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1201,6 +1201,12 @@ pub enum Expr {
         op: String,
         expr: Box<Expr>,
     },
+    /// Standard function call with comma-separated arguments.
+    ///
+    /// Covers all user-defined functions and most built-in functions.
+    /// For functions with keyword-separated syntax (e.g. `EXTRACT`, `SUBSTRING`),
+    /// see [`SpecialFunction`](Expr::SpecialFunction) — downstream consumers must
+    /// handle **both** variants when looking for "all function calls" in the AST.
     FunctionCall {
         name: ObjectName,
         args: Vec<Expr>,
@@ -1302,10 +1308,53 @@ pub enum Expr {
         expr: Box<Expr>,
         type_name: DataType,
     },
-    /// Special SQL functions with keyword-separated syntax instead of commas:
-    /// - overlay(string PLACING string FROM int [FOR int])
-    /// - position(string IN string)
-    /// - substring(string FROM int [FOR int]) / substring(string FOR int)
+    /// SQL functions that use keyword-separated syntax (or have ambiguous syntax forms)
+    /// and therefore cannot be represented as a regular [`FunctionCall`].
+    ///
+    /// # Why SpecialFunction instead of FunctionCall?
+    ///
+    /// Standard function calls use comma-separated arguments: `func(a, b, c)`.
+    /// Some SQL functions use **keywords** to separate arguments instead of commas,
+    /// e.g. `SUBSTRING(str FROM 1 FOR 3)`, `EXTRACT(year FROM date)`. These require
+    /// dedicated parsing logic and a simplified AST representation that only captures
+    /// positional arguments (the keywords are implied by position).
+    ///
+    /// Additionally, `substr` is treated as an alias of `substring` and always produces
+    /// `SpecialFunction`, even when written with comma syntax (`substr('hello', 1, 3)`).
+    /// This avoids having the same semantic function produce two different AST node types.
+    ///
+    /// # Complete list of functions that produce SpecialFunction
+    ///
+    /// | Function | `name` value | Syntax forms | Notes |
+    /// |----------|-------------|--------------|-------|
+    /// | `SUBSTRING` / `SUBSTR` | `"substring"` or `"substr"` | `FROM`/`FOR` keywords **or** commas | `substr` is always SpecialFunction |
+    /// | `OVERLAY` | `"overlay"` | `PLACING`/`FROM`/`FOR` keywords | |
+    /// | `POSITION` | `"position"` | `IN` keyword | |
+    /// | `EXTRACT` | `"extract"` | `field FROM expr` | |
+    /// | `TRIM` | `"trim"` | `LEADING`/`TRAILING`/`BOTH` + `FROM` | Only when keyword syntax is used; `TRIM(expr)` becomes `FunctionCall` |
+    /// | `CONVERT` | `"convert"` | `expr USING charset` | Only with `USING` keyword; `CONVERT(a, b)` becomes `FunctionCall` |
+    /// | `INTERVAL` | `"interval"` | `'value' unit` | |
+    /// | `CURRENT_TIME` | `"current_time"` | Optional precision `(n)` | Without parentheses → `ColumnRef` |
+    /// | `CURRENT_TIMESTAMP` | `"current_timestamp"` | Optional precision `(n)` | Without parentheses → `ColumnRef` |
+    /// | `LOCALTIME` | `"localtime"` | Optional precision `(n)` | Without parentheses → `ColumnRef` |
+    /// | `LOCALTIMESTAMP` | `"localtimestamp"` | Optional precision `(n)` | Without parentheses → `ColumnRef` |
+    ///
+    /// # Downstream consumer guidance
+    ///
+    /// When walking the AST for "all function calls", you **must** handle both
+    /// `Expr::FunctionCall` and `Expr::SpecialFunction`. For example:
+    ///
+    /// ```rust,ignore
+    /// match expr {
+    ///     Expr::FunctionCall { name, args, .. } => { /* regular function */ }
+    ///     Expr::SpecialFunction { name, args } => { /* special function */ }
+    ///     _ => {}
+    /// }
+    /// ```
+    ///
+    /// `SpecialFunction` does **not** carry `builtin` metadata, `over`, `filter`,
+    /// or `within_group` clauses. If you need to check whether a function is built-in,
+    /// use the `function_registry` module to look up the name.
     SpecialFunction {
         name: String,
         args: Vec<Expr>,

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1279,6 +1279,13 @@ impl Parser {
         }
     }
 
+    /// Parse a function call after the opening `(` has been consumed.
+    ///
+    /// Certain functions with keyword-separated syntax (SUBSTRING, OVERLAY, POSITION,
+    /// EXTRACT, TRIM, CONVERT) are routed to dedicated parsers that produce
+    /// `Expr::SpecialFunction` instead of `Expr::FunctionCall`. See the
+    /// [`SpecialFunction`](crate::ast::Expr::SpecialFunction) variant documentation
+    /// for the complete list and rationale.
     fn parse_function_call(&mut self, name: ObjectName) -> Result<Expr, ParserError> {
         self.expect_token(&Token::LParen)?;
 
@@ -1290,6 +1297,9 @@ impl Parser {
         if lower_name == "position" {
             return self.parse_position_function(name);
         }
+        // Both `substring` and `substr` are handled by the same parser.
+        // Even `substr(a, 1, 3)` with pure comma syntax becomes SpecialFunction
+        // to avoid splitting one semantic function across two AST node types.
         if lower_name == "substring" || lower_name == "substr" {
             return self.parse_substring_function(name);
         }


### PR DESCRIPTION
…ream consumers

- Expand SpecialFunction rustdoc: complete list of 11 functions that produce SpecialFunction (was only 3), explain why substr always becomes SpecialFunction, add downstream consumer guidance with code example
- Add cross-reference on FunctionCall variant pointing to SpecialFunction
- Add doc comment on parse_function_call explaining the routing logic and inline comment on the substr/substring dispatch
- Rewrite docs/ast-json-reference.md SpecialFunction section: full function table with Notes column, explain substr/substring relationship, add JSON consumer guidance with JavaScript example, update 'Identify all function calls' pattern to mention both node types