### PR TITLE
fix(#65): restore wildcard match for guarded Procedure/Function arms …

### DIFF
--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -554,8 +554,7 @@ fn find_error_sub_item(stmt: &Statement, error_line: usize) -> (Option<String>, 
                         let name = f.name.join(".");
                         return (Some(format!("FUNCTION {}", name)), f.start_line, f.end_line);
                     }
-                    PackageItem::Variable(_)
-                    | PackageItem::Raw(_) => {}
+                    _ => {}
                 }
             }
             (None, 0, 0)
@@ -579,8 +578,7 @@ fn find_error_sub_item(stmt: &Statement, error_line: usize) -> (Option<String>, 
                         let name = f.name.join(".");
                         return (Some(format!("FUNCTION {}", name)), f.start_line, f.end_line);
                     }
-                    PackageItem::Variable(_)
-                    | PackageItem::Raw(_) => {}
+                    _ => {}
                 }
             }
             (None, 0, 0)


### PR DESCRIPTION
…in CLI

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)