### PR TITLE
fix(#70): decode XML entities inside CDATA sections

### DIFF
--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -130,7 +130,8 @@ fn read_node_tree(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Vec<SqlNode> {
                 };
             }
             Ok(Event::CData(e)) => {
-                text_buf.push_str(&String::from_utf8_lossy(&e));
+                let raw = String::from_utf8_lossy(&e);
+                text_buf.push_str(&decode_xml_entities(&raw));
             }
             Ok(Event::Start(e)) => {
                 flush_text_to_nodes(&mut text_buf, &mut nodes);
@@ -424,6 +425,38 @@ fn format_attributes(element: &quick_xml::events::BytesStart<'_>) -> String {
         let key = String::from_utf8_lossy(ln.as_ref());
         let value = String::from_utf8_lossy(&attr.value);
         result.push_str(&format!(" {}=\"{}\"", key, value));
+    }
+    result
+}
+
+fn decode_xml_entities(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '&' {
+            let rest = &s[i..];
+            if let Some(entity) = rest.find(';') {
+                let name = &rest[1..entity];
+                let decoded = match name {
+                    "lt" => Some('<'),
+                    "gt" => Some('>'),
+                    "amp" => Some('&'),
+                    "apos" => Some('\''),
+                    "quot" => Some('"'),
+                    _ => None,
+                };
+                if let Some(ch) = decoded {
+                    result.push(ch);
+                    for _ in 0..entity {
+                        chars.next();
+                    }
+                    continue;
+                }
+            }
+            result.push(c);
+        } else {
+            result.push(c);
+        }
     }
     result
 }

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -493,3 +493,53 @@ fn test_xml_entity_decoding() {
     assert!(result.statements[2].flat_sql.contains(">="));
     assert!(result.statements[2].flat_sql.contains("<="));
 }
+
+#[test]
+fn test_cdata_with_xml_entities_issue70() {
+    // Issue #70: parse_mapper_bytes_with_path infinite loop on SQL with &gt;= / &lt;= in CDATA
+    let xml = br#"<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="test">
+    <select id="queryVModeNeedAndVInstNeed" parameterType="map" resultType="map">
+        <![CDATA[
+        	select t.model_need "modelNeed"
+        	from dat_inst_oper_type_mode t where t.operation_no = #{vOperationNo}
+        	and t.inure_begin_date &gt;= #{date} and t.inure_end_date &lt;= #{date}
+        ]]>
+    </select>
+</mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert_eq!(result.statements.len(), 1, "should parse 1 statement, errors: {:?}", result.errors);
+    assert!(result.errors.is_empty());
+    let sql = &result.statements[0].flat_sql;
+    assert!(sql.contains(">="), "should decode &gt;= to >=, got: {}", sql);
+    assert!(sql.contains("<="), "should decode &lt;= to <=, got: {}", sql);
+}
+
+#[test]
+fn test_cdata_with_actual_operators() {
+    // CDATA with actual >= and <= operators (not entity-encoded)
+    let xml = br#"<mapper namespace="test">
+    <select id="rangeQuery">
+        <![CDATA[SELECT * FROM t WHERE id >= 1 AND id <= 100]]>
+    </select>
+</mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert_eq!(result.statements.len(), 1, "errors: {:?}", result.errors);
+    assert!(result.statements[0].flat_sql.contains(">="));
+    assert!(result.statements[0].flat_sql.contains("<="));
+}
+
+#[test]
+fn test_entity_outside_cdata_operators() {
+    // Entities outside CDATA (standard MyBatis practice for >= / <=)
+    let xml = br#"<mapper namespace="test">
+    <select id="rangeQuery">
+        SELECT * FROM t WHERE id &gt;= #{min} AND id &lt;= #{max}
+    </select>
+</mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert_eq!(result.statements.len(), 1, "errors: {:?}", result.errors);
+    assert!(result.statements[0].flat_sql.contains(">="), "got: {}", result.statements[0].flat_sql);
+    assert!(result.statements[0].flat_sql.contains("<="), "got: {}", result.statements[0].flat_sql);
+}


### PR DESCRIPTION
## Summary

Closes #70

- Decode standard XML entities (`&lt;`, `&gt;`, `&amp;`, `&apos;`, `&quot;`) inside CDATA sections to handle the common MyBatis pattern where developers use entity-encoded comparison operators (`&gt;=`, `&lt;=`) within `<![CDATA[...]]>` blocks
- Add `decode_xml_entities()` helper in `src/ibatis/parser.rs` and apply it to the `Event::CData` handler
- Add 3 regression tests covering CDATA with entities, CDATA with literal operators, and entities outside CDATA