### PR TITLE
fix(#72): dollar-quoting no longer swallows subsequent statements

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -360,7 +360,14 @@ impl Parser {
                 Token::Eof => return if i > 0 { i - 1 } else { 0 },
                 Token::LParen => depth += 1,
                 Token::RParen => depth = (depth - 1).max(0),
-                Token::DollarString { .. } => {}
+                Token::DollarString { .. } => {
+                    // Dollar-quoted body contains its own BEGIN/END internally
+                    // (not as separate tokens), so clear in_routine_decl to
+                    // prevent subsequent semicolons from being swallowed.
+                    if in_routine_decl && begin_depth == 0 {
+                        in_routine_decl = false;
+                    }
+                }
                 Token::Keyword(Keyword::CASE) => {
                     case_depth += 1;
                 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2752,6 +2752,58 @@ fn test_create_function_dollar_quoted_not_consume_next() {
     assert!(matches!(&stmts[2], Statement::CreateFunction(_)));
 }
 
+// Regression test for #72: parse_sql (parse_with_text) must not swallow
+// statements after a dollar-quoted CREATE FUNCTION/PROCEDURE body.
+// The root cause was find_statement_end_pos() never clearing in_routine_decl
+// when the BEGIN/END pair is inside a DollarString token.
+#[test]
+fn test_issue_72_dollar_quoting_parse_sql_multi_statement() {
+    // Case 1: two CREATE PROCEDURE with $$
+    let sql = r#"CREATE PROCEDURE p1() AS $$
+BEGIN
+    SELECT * FROM aas_account;
+END;
+$$;
+
+CREATE PROCEDURE p2() AS $$
+BEGIN
+    INSERT INTO aas_account VALUES (1);
+END;
+$$;"#;
+    let (infos, errs) = Parser::parse_sql(sql);
+    assert!(errs.is_empty(), "unexpected errors: {:?}", errs);
+    assert_eq!(infos.len(), 2, "expected 2 statements, got {}: {:?}", infos.len(), infos.iter().map(|i| format!("{:?}", std::mem::discriminant(&i.statement))).collect::<Vec<_>>());
+    assert!(matches!(infos[0].statement, Statement::CreateProcedure(_)));
+    assert!(matches!(infos[1].statement, Statement::CreateProcedure(_)));
+
+    // Case 2: CREATE FUNCTION + CREATE TRIGGER
+    let sql2 = r#"CREATE OR REPLACE FUNCTION trg_func() RETURNS TRIGGER AS $$
+BEGIN
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_after_insert
+AFTER INSERT ON t_users
+FOR EACH ROW EXECUTE PROCEDURE trg_func();"#;
+    let (infos2, errs2) = Parser::parse_sql(sql2);
+    assert!(errs2.is_empty(), "unexpected errors: {:?}", errs2);
+    assert_eq!(infos2.len(), 2, "expected 2 statements, got {}", infos2.len());
+    assert!(matches!(infos2[0].statement, Statement::CreateFunction(_)));
+    assert!(matches!(infos2[1].statement, Statement::CreateTrigger(_)));
+
+    // Case 3: CREATE FUNCTION + SELECT + CREATE FUNCTION (the original passing test, but via parse_sql)
+    let sql3 = "CREATE FUNCTION f1() RETURNS void AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql;\n\
+                SELECT 1;\n\
+                CREATE FUNCTION f2() RETURNS void AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql;";
+    let (infos3, errs3) = Parser::parse_sql(sql3);
+    assert!(errs3.is_empty(), "unexpected errors: {:?}", errs3);
+    assert_eq!(infos3.len(), 3, "expected 3 statements, got {}", infos3.len());
+    assert!(matches!(infos3[0].statement, Statement::CreateFunction(_)));
+    assert!(matches!(infos3[1].statement, Statement::Select(_)));
+    assert!(matches!(infos3[2].statement, Statement::CreateFunction(_)));
+}
+
 #[test]
 fn test_create_procedure_dollar_quoted_body() {
     let sql = "CREATE PROCEDURE my_proc() AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql";


### PR DESCRIPTION
## Summary

- Fix `find_statement_end_pos()` in parser: when encountering a `DollarString` token while `in_routine_decl` is true, clear the flag so subsequent semicolons are correctly treated as statement terminators
- Add regression test covering all 3 scenarios from the issue report

## Root Cause

`find_statement_end_pos()` sets `in_routine_decl = true` when it sees `AS`/`IS` as a routine body marker. Normally this flag is cleared when a `BEGIN` keyword token is encountered. However, with dollar-quoted bodies (`$$ BEGIN ... END $$`), the entire body is a single `DollarString` token — `BEGIN` is not a separate token. This means `in_routine_decl` is never cleared, causing all subsequent semicolons to be skipped and the entire remaining input to be treated as one statement.

## Test Plan

- New test `test_issue_72_dollar_quoting_parse_sql_multi_statement` covers:
  - Two `CREATE PROCEDURE` with `$$` bodies
  - `CREATE FUNCTION` + `CREATE TRIGGER`
  - `CREATE FUNCTION` + `SELECT` + `CREATE FUNCTION`
- All 1048 tests pass, 0 regressions

Fixes #72