### PR TITLE
fix(#77): parse TYPE RECORD/VARRAY declarations as proper type nodes in package specs

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2032,6 +2032,7 @@ pub enum PackageItem {
     Procedure(PackageProcedure),
     Function(PackageFunction),
     Variable(crate::ast::plpgsql::PlVarDecl),
+    Type(crate::ast::plpgsql::PlTypeDecl),
     Raw(String),
 }
 

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -395,6 +395,13 @@ pub fn walk_pl_statement(visitor: &mut dyn Visitor, stmt: &crate::ast::plpgsql::
 }
 
 /// Walk a PL/pgSQL declaration.
+pub fn walk_pl_type_decl(visitor: &mut dyn Visitor, decl: &crate::ast::plpgsql::PlTypeDecl) -> VisitorResult {
+    match decl {
+        crate::ast::plpgsql::PlTypeDecl::VarrayOf { size, .. } => walk_expr(visitor, size),
+        _ => VisitorResult::Continue,
+    }
+}
+
 pub fn walk_pl_declaration(visitor: &mut dyn Visitor, decl: &crate::ast::plpgsql::PlDeclaration) -> VisitorResult {
     let result = visitor.visit_pl_declaration(decl);
     match result {
@@ -498,6 +505,11 @@ pub fn walk_statement(visitor: &mut dyn Visitor, stmt: &Statement) -> VisitorRes
                                 }
                             }
                         }
+                        crate::ast::PackageItem::Type(t) => {
+                            if walk_pl_type_decl(visitor, t) == VisitorResult::Stop {
+                                return VisitorResult::Stop;
+                            }
+                        }
                         crate::ast::PackageItem::Variable(_) => {}
                         crate::ast::PackageItem::Raw(_) => {}
                     }
@@ -519,6 +531,11 @@ pub fn walk_statement(visitor: &mut dyn Visitor, stmt: &Statement) -> VisitorRes
                                 if walk_pl_block(visitor, block) == VisitorResult::Stop {
                                     return VisitorResult::Stop;
                                 }
+                            }
+                        }
+                        crate::ast::PackageItem::Type(t) => {
+                            if walk_pl_type_decl(visitor, t) == VisitorResult::Stop {
+                                return VisitorResult::Stop;
                             }
                         }
                         crate::ast::PackageItem::Variable(_) => {}

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -6732,6 +6732,7 @@ impl SqlFormatter {
     }
 
     fn format_package_item(&self, item: &PackageItem, indent: usize) -> String {
+        use crate::ast::plpgsql::*;
         match item {
             PackageItem::Procedure(p) => self.format_package_procedure(p, indent),
             PackageItem::Function(f) => self.format_package_function(f, indent),
@@ -6742,6 +6743,32 @@ impl SqlFormatter {
                 }
                 s.push(';');
                 s
+            }
+            PackageItem::Type(t) => {
+                let inner = match t {
+                    PlTypeDecl::Record { name, fields } => {
+                        let fields_str = fields
+                            .iter()
+                            .map(|f| format!("{} {}", f.name, self.format_pl_data_type(&f.data_type)))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("{} {} {} ({})", self.kw("TYPE"), name, self.kw("IS RECORD"), fields_str)
+                    }
+                    PlTypeDecl::TableOf { name, elem_type, index_by } => {
+                        let mut s = format!("{} {} {} {} {}", self.kw("TYPE"), name, self.kw("IS TABLE OF"), self.format_pl_data_type(elem_type), "");
+                        if let Some(idx) = index_by {
+                            s = format!("{} {} {}", s.trim(), self.kw("INDEX BY"), self.format_pl_data_type(idx));
+                        }
+                        s.trim().to_string()
+                    }
+                    PlTypeDecl::VarrayOf { name, size, elem_type } => {
+                        format!("{} {} {} ({}) {} {}", self.kw("TYPE"), name, self.kw("IS VARRAY"), self.format_expr(size), self.kw("OF"), self.format_pl_data_type(elem_type))
+                    }
+                    PlTypeDecl::RefCursor { name } => {
+                        format!("{} {} {}", self.kw("TYPE"), name, self.kw("IS REF CURSOR"))
+                    }
+                };
+                format!("{};", inner)
             }
             PackageItem::Raw(s) => s.clone(),
         }

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -425,7 +425,7 @@ impl Parser {
         self.parse_pl_type_decl_body(name)
     }
 
-    fn parse_pl_type_decl_body(&mut self, name: String) -> Result<PlDeclaration, ParserError> {
+    pub(crate) fn parse_pl_type_decl_body(&mut self, name: String) -> Result<PlDeclaration, ParserError> {
         if self.match_ident_str("is") || self.match_ident_str("as") {
             self.advance();
         }
@@ -508,7 +508,7 @@ impl Parser {
 
 
 
-    fn skip_to_semicolon_or_keyword(&mut self) -> String {
+    pub(crate) fn skip_to_semicolon_or_keyword(&mut self) -> String {
         let mut collected = String::new();
         let mut depth = 0i32;
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2396,7 +2396,9 @@ end pkg_test;";
     match &infos[1].statement {
         Statement::CreatePackage(p) => {
             assert_eq!(p.name, vec!["pkg_test"]);
-            assert_eq!(p.items.len(), 1);
+            assert_eq!(p.items.len(), 2, "should have TYPE + PROCEDURE");
+            assert!(matches!(&p.items[0], PackageItem::Type(_)), "first item should be Type");
+            assert!(matches!(&p.items[1], PackageItem::Procedure(_)), "second item should be Procedure");
         }
         other => panic!("expected CreatePackage, got {:?}", other),
     }
@@ -2413,7 +2415,9 @@ end pkg_test;";
     match &infos[0].statement {
         Statement::CreatePackage(p) => {
             assert_eq!(p.name, vec!["pkg_test"]);
-            assert_eq!(p.items.len(), 1);
+            assert_eq!(p.items.len(), 2, "should have TYPE + PROCEDURE");
+            assert!(matches!(&p.items[0], PackageItem::Type(_)), "first item should be Type");
+            assert!(matches!(&p.items[1], PackageItem::Procedure(_)), "second item should be Procedure");
         }
         other => panic!("expected CreatePackage, got {:?}", other),
     }
@@ -13520,4 +13524,106 @@ fn test_comments_json_output() {
     assert_eq!(comments.len(), 1);
     assert_eq!(comments[0].get("type").unwrap().as_str().unwrap(), "line");
     assert_eq!(comments[0].get("line").unwrap().as_u64().unwrap(), 1);
+}
+
+// --- Issue #77: TYPE RECORD and VARRAY declarations in package spec ---
+
+#[test]
+fn test_package_spec_type_record() {
+    let sql = "CREATE OR REPLACE PACKAGE test_pkg AS\n\
+               TYPE t_coord IS RECORD (\n\
+                 ra NUMERIC(15,12),\n\
+                 dec NUMERIC(15,12),\n\
+                 epoch NUMERIC(10,2)\n\
+               );\n\
+               END test_pkg";
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackage(pkg) => {
+            assert_eq!(pkg.items.len(), 1);
+            match &pkg.items[0] {
+                PackageItem::Type(PlTypeDecl::Record { name, fields }) => {
+                    assert_eq!(name, "t_coord");
+                    assert_eq!(fields.len(), 3);
+                    assert_eq!(fields[0].name, "ra");
+                    assert_eq!(fields[1].name, "dec");
+                    assert_eq!(fields[2].name, "epoch");
+                }
+                other => panic!("expected Type(Record), got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackage, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_package_spec_type_varray() {
+    let sql = "CREATE OR REPLACE PACKAGE test_pkg AS\n\
+               TYPE t_arr IS VARRAY(4096) OF FLOAT8;\n\
+               END test_pkg";
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackage(pkg) => {
+            assert_eq!(pkg.items.len(), 1);
+            match &pkg.items[0] {
+                PackageItem::Type(PlTypeDecl::VarrayOf { name, size, elem_type }) => {
+                    assert_eq!(name, "t_arr");
+                    assert!(matches!(size.as_ref(), Expr::Literal(Literal::Integer(4096))));
+                    match elem_type {
+                        PlDataType::TypeName(t) => assert!(t.eq_ignore_ascii_case("float8")),
+                        other => panic!("expected TypeName, got {:?}", other),
+                    }
+                }
+                other => panic!("expected Type(VarrayOf), got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackage, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_package_spec_type_record_and_procedure() {
+    let sql = "CREATE OR REPLACE PACKAGE test_pkg AS\n\
+               TYPE t_rec IS RECORD (id INTEGER, name VARCHAR(100));\n\
+               TYPE t_arr IS VARRAY(10) OF INTEGER;\n\
+               PROCEDURE do_stuff(p1 IN t_rec);\n\
+               END test_pkg";
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackage(pkg) => {
+            assert_eq!(pkg.items.len(), 3);
+            assert!(matches!(&pkg.items[0], PackageItem::Type(PlTypeDecl::Record { .. })));
+            assert!(matches!(&pkg.items[1], PackageItem::Type(PlTypeDecl::VarrayOf { .. })));
+            assert!(matches!(&pkg.items[2], PackageItem::Procedure(_)));
+        }
+        other => panic!("expected CreatePackage, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_package_body_type_record() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY test_pkg AS\n\
+               TYPE t_rec IS RECORD (id INTEGER, name VARCHAR(100));\n\
+               PROCEDURE do_something IS\n\
+               BEGIN\n\
+                 NULL;\n\
+               END;\n\
+               END test_pkg";
+    let stmt = parse_one(sql);
+    match &stmt {
+        Statement::CreatePackageBody(pkg) => {
+            assert_eq!(pkg.items.len(), 2);
+            match &pkg.items[0] {
+                PackageItem::Type(PlTypeDecl::Record { name, fields }) => {
+                    assert_eq!(name, "t_rec");
+                    assert_eq!(fields.len(), 2);
+                    assert_eq!(fields[0].name, "id");
+                    assert_eq!(fields[1].name, "name");
+                }
+                other => panic!("expected Type(Record), got {:?}", other),
+            }
+            assert!(matches!(&pkg.items[1], PackageItem::Procedure(_)));
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
 }

--- a/src/parser/utility/functions.rs
+++ b/src/parser/utility/functions.rs
@@ -754,6 +754,24 @@ impl Parser {
                         }
                     }
                 }
+                Token::Keyword(Keyword::TYPE_P) => {
+                    self.advance();
+                    match self.parse_identifier() {
+                        Ok(type_name) => {
+                            match self.parse_pl_type_decl_body(type_name) {
+                                Ok(crate::ast::plpgsql::PlDeclaration::Type(type_decl)) => {
+                                    items.push(PackageItem::Type(type_decl));
+                                }
+                                _ => {
+                                    self.skip_to_semicolon_or_keyword();
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            self.skip_to_semicolon_or_keyword();
+                        }
+                    }
+                }
                 _ => {
                     if let Some(crate::ast::plpgsql::PlDeclaration::Variable(var)) =
                         self.try_parse_oracle_var_decl()


### PR DESCRIPTION
## Summary

- Fix TYPE ... IS RECORD(...) and TYPE ... IS VARRAY(n) OF ... declarations in package specs/bodies being silently skipped, causing fields to leak as individual Variable items
- Add PackageItem::Type(PlTypeDecl) variant to the AST
- Add Token::Keyword(Keyword::TYPE_P) handler in parse_package_body_items()
- Update formatter and visitor to handle the new variant
- Add 4 regression tests covering RECORD, VARRAY, mixed items, and package body

### Root cause

parse_package_body_items() had no explicit TYPE_P branch. The fallback path called try_parse_oracle_var_decl() which rejects name == "type" -> only the TYPE token was skipped -> remaining tokens (t_rec, IS, RECORD, field names...) were consumed one-by-one as garbage or misinterpreted as Variables.

### Files changed

| File | Change |
|------|--------|
| src/ast/mod.rs | Add PackageItem::Type(PlTypeDecl) variant |
| src/parser/utility/functions.rs | Add TYPE_P match arm in parse_package_body_items() |
| src/parser/plpgsql.rs | Make parse_pl_type_decl_body and skip_to_semicolon_or_keyword pub(crate) |
| src/formatter.rs | Add PackageItem::Type formatting |
| src/ast/visitor.rs | Add PackageItem::Type walking with walk_pl_type_decl helper |
| src/parser/tests.rs | Update 2 existing tests + add 4 new regression tests |

Closes #77