### PR TITLE
fix(#82,#81): parse aggregate FROM clause and implicit SELECT FROM

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1218,6 +1218,8 @@ pub enum Expr {
         default: Option<Box<Expr>>,
         conversion_format: Option<Box<Expr>>,
         #[serde(skip_serializing_if = "Option::is_none")]
+        agg_from: Option<Vec<TableRef>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         builtin: Option<BuiltinFuncMeta>,
     },
     Case {

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -827,7 +827,7 @@ fn walk_expr(visitor: &mut dyn Visitor, expr: &Expr) -> VisitorResult {
                 return VisitorResult::Stop;
             }
         }
-        Expr::FunctionCall { args, over, filter, within_group, separator, default, conversion_format, .. } => {
+        Expr::FunctionCall { args, over, filter, within_group, separator, default, conversion_format, agg_from, .. } => {
             for arg in args {
                 if walk_expr(visitor, arg) == VisitorResult::Stop {
                     return VisitorResult::Stop;
@@ -868,6 +868,13 @@ fn walk_expr(visitor: &mut dyn Visitor, expr: &Expr) -> VisitorResult {
             if let Some(conversion_format) = conversion_format {
                 if walk_expr(visitor, conversion_format) == VisitorResult::Stop {
                     return VisitorResult::Stop;
+                }
+            }
+            if let Some(from_items) = agg_from {
+                for table_ref in from_items {
+                    if walk_table_ref(visitor, table_ref) == VisitorResult::Stop {
+                        return VisitorResult::Stop;
+                    }
                 }
             }
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -867,6 +867,7 @@ impl SqlFormatter {
                 separator,
                 default,
                 conversion_format,
+                agg_from,
                 ..
             } => {
                 let parts: Vec<String> = name
@@ -896,6 +897,12 @@ impl SqlFormatter {
                 }
                 if let Some(fmt) = conversion_format {
                     result.push_str(&format!(", {}", self.format_expr(fmt)));
+                }
+                if let Some(from_items) = agg_from {
+                    result.push_str(" ");
+                    result.push_str(&self.kw("FROM"));
+                    result.push_str(" ");
+                    result.push_str(&self.format_table_refs(from_items));
                 }
                 result.push(')');
                 if let Some(f) = filter {

--- a/src/parser/ddl/create.rs
+++ b/src/parser/ddl/create.rs
@@ -375,6 +375,7 @@ impl Parser {
                     separator: None,
                     default: None,
                     conversion_format: None,
+                    agg_from: None,
                     builtin: None,
                 }),
             });

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    DataType, Expr, Literal, ObjectName, OrderByItem, SelectStatement, SequenceFunc, WhenClause,
-    WindowFrame, WindowFrameBound, WindowFrameDirection, WindowFrameMode, WindowSpec,
+    DataType, Expr, Literal, ObjectName, OrderByItem, SelectStatement, SelectTarget, SequenceFunc,
+    WhenClause, WindowFrame, WindowFrameBound, WindowFrameDirection, WindowFrameMode, WindowSpec,
     XmlAttribute, XmlAttributes, XmlContent, XmlOption,
 };
 use crate::parser::{Parser, ParserError};
@@ -548,6 +548,7 @@ impl Parser {
                             separator: None,
                             default: None,
                             conversion_format: None,
+                            agg_from: None,
                             builtin: None,
                         };
                     } else {
@@ -1332,6 +1333,7 @@ impl Parser {
                 separator: None,
                 default: None,
                 conversion_format: None,
+                agg_from: None,
                 builtin,
             });
         }
@@ -1353,6 +1355,7 @@ impl Parser {
                 separator: None,
                 default: None,
                 conversion_format: None,
+                agg_from: None,
                 builtin,
             });
         }
@@ -1387,6 +1390,51 @@ impl Parser {
             has_variadic = has_variadic || v;
             args.push(arg);
         }
+        let agg_from = if self.match_keyword(Keyword::FROM) {
+            self.advance();
+            let mut from_tables = vec![self.parse_table_ref()?];
+            while self.match_token(&Token::Comma) {
+                self.advance();
+                from_tables.push(self.parse_table_ref()?);
+            }
+            if let Some(Expr::FunctionCall { ref within_group, .. }) = args.last() {
+                if !within_group.is_empty() {
+                    let last_arg = args.pop().unwrap();
+                    let select = SelectStatement {
+                        hints: vec![],
+                        with: None,
+                        distinct: false,
+                        distinct_on: vec![],
+                        targets: vec![SelectTarget::Expr(last_arg, None)],
+                        into_targets: None,
+                        bulk_collect: false,
+                        into_table: None,
+                        from: from_tables,
+                        where_clause: None,
+                        connect_by: None,
+                        group_by: vec![],
+                        having: None,
+                        order_by: vec![],
+                        order_siblings: false,
+                        limit: None,
+                        offset: None,
+                        fetch: None,
+                        lock_clause: None,
+                        window_clause: vec![],
+                        set_operation: None,
+                        raw_body: None,
+                    };
+                    args.push(Expr::Subquery(Box::new(select)));
+                    None
+                } else {
+                    Some(from_tables)
+                }
+            } else {
+                Some(from_tables)
+            }
+        } else {
+            None
+        };
         if self.match_keyword(Keyword::PASSING) {
             self.advance();
             if self.match_keyword(Keyword::BY) {
@@ -1456,6 +1504,7 @@ impl Parser {
             separator: None,
             default,
             conversion_format,
+            agg_from,
             builtin,
         })
     }
@@ -1491,6 +1540,7 @@ impl Parser {
             separator: None,
             default: None,
             conversion_format: None,
+            agg_from: None,
             builtin,
         })
     }
@@ -1559,6 +1609,7 @@ impl Parser {
             separator,
             default: None,
             conversion_format: None,
+            agg_from: None,
             builtin,
         })
     }
@@ -1722,6 +1773,7 @@ impl Parser {
                     separator: None,
                     default: None,
                     conversion_format: None,
+                    agg_from: None,
                     builtin,
                 })
             }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5533,6 +5533,47 @@ fn test_filter_with_over() {
 }
 
 #[test]
+fn test_agg_from_clause() {
+    let stmt = parse_one("SELECT SUM(x * LN(x) FROM generate_series(1, 10) AS i) FROM t");
+    match stmt {
+        Statement::Select(s) => {
+            assert_eq!(s.targets.len(), 1);
+            match &s.targets[0] {
+                SelectTarget::Expr(expr, _) => match expr {
+                    Expr::FunctionCall { agg_from, .. } => {
+                        assert!(agg_from.is_some());
+                        let from_items = agg_from.as_ref().unwrap();
+                        assert_eq!(from_items.len(), 1);
+                    }
+                    _ => panic!("expected FunctionCall"),
+                },
+                _ => panic!("expected Expr target"),
+            }
+        }
+        _ => panic!("expected Select"),
+    }
+}
+
+#[test]
+fn test_bare_agg_from_implicit_select() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY test_pkg AS
+PROCEDURE test_proc IS
+  v_result JSONB;
+BEGIN
+  v_result := jsonb_build_object(
+    'mode', MODE() WITHIN GROUP (ORDER BY UNNEST) FROM UNNEST(ARRAY[1,2,3])
+  );
+END;
+END test_pkg";
+    let stmts = parse(sql);
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Statement::CreatePackageBody(_) => {}
+        _ => panic!("expected CreatePackageBody"),
+    }
+}
+
+#[test]
 fn test_create_table_interval_partition() {
     let stmt = parse_one(
         "CREATE TABLE t (id INT, created DATE) PARTITION BY RANGE (created) INTERVAL ('1 month') (PARTITION p0 VALUES LESS THAN ('2025-01-01'))",


### PR DESCRIPTION
## Summary

- Add `agg_from: Option<Vec<TableRef>>` field to `FunctionCall` AST node to support aggregate functions with FROM clause inside parentheses (e.g. `SUM(expr FROM generate_series(1, v_n) AS i)`)
- Handle `FROM` after aggregate expressions with `WITHIN GROUP` in non-aggregate function argument context by wrapping in implicit SELECT subquery (e.g. `MODE() WITHIN GROUP (...) FROM UNNEST(...)` as bare expression in PL/pgSQL)

Closes #82
Closes #81

## Changes

| File | Change |
|------|--------|
| `src/ast/mod.rs` | Add `agg_from` field to `FunctionCall` with serde skip |
| `src/parser/expr.rs` | Core FROM parsing logic after function arguments + `agg_from: None` at all construction sites |
| `src/formatter.rs` | Format `agg_from` as `FROM <table_refs>` inside function parens |
| `src/ast/visitor.rs` | Visit `agg_from` table refs |
| `src/parser/ddl/create.rs` | Add `agg_from: None` to DDL FunctionCall |
| `src/parser/tests.rs` | 2 new tests for both issues |

## Verification

- ✅ 1051 tests pass, 0 failed
- ✅ Issue #82 reproduction: `SUM(expr FROM generate_series(...))` → `VALID`
- ✅ Issue #81 reproduction: `MODE() WITHIN GROUP (...) FROM UNNEST(...)` in PL/pgSQL → `VALID`

## Implementation Detail

The fix handles two distinct patterns in `parse_function_call` after the argument comma loop:

1. **Aggregate FROM clause** (#82): `SUM(expr FROM source)` — stores the FROM clause in the new `agg_from` field
2. **Implicit SELECT** (#81): When `FROM` follows an argument that is a `FunctionCall` with `within_group` set, the argument is wrapped in `Expr::Subquery(SelectStatement { ... })` to represent the implicit SELECT