### PR TITLE
feat: add MCP server support with 7 tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,10 +155,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -181,6 +208,20 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -243,6 +284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,12 +407,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -367,6 +436,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -380,8 +483,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -490,6 +598,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +681,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -617,6 +761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "ogsql-parser"
 version = "0.1.0"
 dependencies = [
@@ -627,6 +780,8 @@ dependencies = [
  "phf",
  "quick-xml",
  "ratatui",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -678,6 +833,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "percent-encoding"
@@ -806,6 +967,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +1014,41 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
 
 [[package]]
 name = "rustix"
@@ -869,6 +1085,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1140,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1088,6 +1341,7 @@ version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -1105,6 +1359,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1157,7 +1424,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1279,6 +1558,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,10 +1634,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ quick-xml = { version = "0.39", optional = true }
 tree-sitter = { version = "0.24", optional = true }
 tree-sitter-java = { version = "0.23", optional = true }
 walkdir = { version = "2", optional = true }
+rmcp = { version = "1.5", features = ["server", "macros", "transport-io", "schemars"], optional = true }
+schemars = { version = "1", optional = true }
 
 [dev-dependencies]
 
@@ -45,12 +47,18 @@ ibatis = ["dep:quick-xml", "dep:walkdir"]
 java = ["dep:tree-sitter", "dep:tree-sitter-java", "dep:walkdir"]
 serve = ["cli", "dep:axum", "dep:tokio", "dep:tower-http", "dep:utoipa"]
 tui = ["cli", "dep:ratatui", "dep:crossterm"]
-full = ["cli", "ibatis", "java", "serve", "tui"]
+mcp = ["dep:rmcp", "dep:schemars", "dep:tokio", "ibatis", "java"]
+full = ["cli", "ibatis", "java", "mcp", "serve", "tui"]
 
 [[bin]]
 name = "ogsql"
 path = "src/bin/ogsql.rs"
 required-features = ["cli"]
+
+[[bin]]
+name = "ogsql-mcp"
+path = "src/bin/ogsql-mcp.rs"
+required-features = ["mcp"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ cargo build --release --features serve
 # With TUI playground
 cargo build --release --features tui
 
+# With MCP server
+cargo build --release --features mcp
+
 # All features
 cargo build --release --features full
 ```
@@ -214,6 +217,44 @@ When built with `--features serve`, the following endpoints are available:
 | POST | `/api/format` | Format SQL (body: `{"sql": "..."}`) |
 | POST | `/api/tokenize` | Tokenize SQL (body: `{"sql": "..."}`) |
 | POST | `/api/validate` | Validate SQL (body: `{"sql": "..."}`) |
+
+#### MCP Server / MCP 服务器
+
+When built with `--features mcp`, an MCP (Model Context Protocol) server binary is available:
+
+```bash
+# Build MCP server
+cargo build --release --features mcp
+
+# Run (stdio transport — for Claude Desktop, Cursor, etc.)
+ogsql-mcp
+```
+
+##### MCP Tools / MCP 工具
+
+| Tool | Description |
+|------|-------------|
+| `parse` | Parse SQL → AST JSON (with fingerprints, comments, errors) |
+| `tokenize` | SQL → Token list with types, values, positions |
+| `format` | Format SQL with standardized casing |
+| `validate` | Validate SQL syntax, report errors/warnings |
+| `json2sql` | Convert AST JSON back to SQL |
+| `parse_xml` | Parse iBatis/MyBatis XML mapper → extracted SQL |
+| `parse_java` | Extract SQL from Java source files |
+
+##### Claude Desktop Configuration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ogsql": {
+      "command": "/path/to/ogsql-mcp"
+    }
+  }
+}
+```
 
 ### Use as Library / 作为库使用
 

--- a/docs/plans/2026-05-02-mcp-server.md
+++ b/docs/plans/2026-05-02-mcp-server.md
@@ -1,0 +1,587 @@
+# MCP Server Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Expose ogsql-parser's parsing capabilities (parse, tokenize, format, validate, json2sql, parse-xml, parse-java) as MCP tools via the `rmcp` crate, using stdio transport.
+
+**Architecture:** Add a new `mcp` feature gate to Cargo.toml. Create `src/mcp/mod.rs` with an `OgsqlServer` struct using `rmcp`'s `#[tool_router(server_handler)]` macro to define all tools. Create `src/bin/ogsql-mcp.rs` as the binary entry point that starts the server with stdio transport. The MCP module depends on the parser core only — no axum/HTTP dependency.
+
+**Tech Stack:** Rust, `rmcp` v1.5 (official MCP Rust SDK), `schemars` for JSON Schema generation, `tokio` for async runtime.
+
+**Worktree:** `/Users/c2j/Projects/Desktop_Projects/DB/ogsql-parser/.worktrees/feat/mcp-server`
+**Branch:** `feat/mcp-server`
+
+---
+
+## Reference Files (READ FIRST before starting)
+
+- `Cargo.toml` — Current feature gates and dependencies pattern
+- `src/lib.rs` — Module exports pattern
+- `src/bin/ogsql.rs` — Existing CLI binary, shows how parser is called
+- `src/ibatis/mod.rs` — `parse_mapper_bytes_with_path()` API
+- `src/java/mod.rs` — `extract_sql_from_java()` API
+
+## Key rmcp API Patterns
+
+```rust
+// Server struct — must derive Clone
+#[derive(Debug, Clone)]
+struct OgsqlServer;
+
+// Tool router + auto ServerHandler impl
+#[tool_router(server_handler)]
+impl OgsqlServer {
+    // Each tool: #[tool(description = "...")] + Parameters<T> -> return type
+    #[tool(description = "Parse SQL into AST JSON")]
+    fn parse(
+        &self,
+        Parameters(params): Parameters<ParseParams>,
+    ) -> String {
+        // ... return JSON string
+    }
+}
+
+// Binary entry: stdio transport
+// let service = OgsqlServer.serve(stdio()).await?;
+// service.waiting().await?;
+```
+
+**Return types:** Tools return `String` (plain text) or `Json<T>` (structured). For our case, returning JSON strings is simplest since our parser already produces serde_json output.
+
+---
+
+### Task 1: Add rmcp dependencies + mcp feature to Cargo.toml
+
+**Files:**
+- Modify: `Cargo.toml`
+
+**Step 1: Add new optional dependencies**
+
+Add after the existing optional deps block (after `walkdir` line):
+
+```toml
+rmcp = { version = "1.5", features = ["server", "macros", "transport-io"], optional = true }
+schemars = { version = "0.8", optional = true }
+```
+
+**Step 2: Add `mcp` feature**
+
+Add to the `[features]` section after the `tui` feature:
+
+```toml
+mcp = ["dep:rmcp", "dep:schemars", "dep:tokio"]
+```
+
+Also add `mcp` to the `full` feature:
+
+```toml
+full = ["cli", "ibatis", "java", "mcp", "serve", "tui"]
+```
+
+**Step 3: Add new binary target**
+
+Add after the existing `[[bin]]` block:
+
+```toml
+[[bin]]
+name = "ogsql-mcp"
+path = "src/bin/ogsql-mcp.rs"
+required-features = ["mcp"]
+```
+
+**Step 4: Verify Cargo.toml parses correctly**
+
+Run: `cargo check --features mcp 2>&1 | head -20`
+Expected: May show missing module errors (that's OK — we haven't created the files yet). Should NOT show dependency resolution errors.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml
+git commit -m "feat(mcp): add rmcp dependency and mcp feature gate"
+```
+
+---
+
+### Task 2: Create src/mcp/mod.rs with all tool definitions
+
+**Files:**
+- Create: `src/mcp/mod.rs`
+
+This is the core file. It defines the `OgsqlServer` struct and all 7 MCP tools.
+
+**Step 1: Create the file with the complete implementation**
+
+```rust
+//! MCP (Model Context Protocol) server support.
+//!
+//! Exposes ogsql-parser capabilities as MCP tools via the `rmcp` crate.
+
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::model::{ServerInfo, ServerTool};
+use rmcp::{tool, tool_router, ServiceExt};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct OgsqlServer;
+
+// ── Parameter types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParseParams {
+    /// SQL text to parse
+    pub sql: String,
+    /// Whether to preserve comments in output
+    #[serde(default)]
+    pub preserve_comments: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TokenizeParams {
+    /// SQL text to tokenize
+    pub sql: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FormatParams {
+    /// SQL text to format
+    pub sql: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ValidateParams {
+    /// SQL text to validate
+    pub sql: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct Json2SqlParams {
+    /// JSON string (output from parse tool) containing statements
+    pub json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParseXmlParams {
+    /// XML content of an iBatis/MyBatis mapper file
+    pub xml: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParseJavaParams {
+    /// Java source file content
+    pub source: String,
+    /// Extra method names to treat as SQL-bearing (e.g. ["executeQuery", "nativeQuery"])
+    #[serde(default)]
+    pub extra_sql_methods: Vec<String>,
+}
+
+// ── Tool implementations ─────────────────────────────────────────────────────
+
+#[tool_router(server_handler)]
+impl OgsqlServer {
+    #[tool(description = "Parse SQL into structured AST JSON with error reports and query fingerprints")]
+    fn parse(
+        &self,
+        Parameters(ParseParams { sql, preserve_comments }): Parameters<ParseParams>,
+    ) -> String {
+        let options = ogsql_parser::ParseOptions { preserve_comments };
+        let output = ogsql_parser::Parser::parse_sql_with_options(&sql, options);
+
+        let all_stmts: Vec<_> = output.statements.iter().map(|si| si.statement.clone()).collect();
+        let fingerprints = ogsql_parser::compute_query_fingerprints(&all_stmts);
+
+        let mut out = serde_json::json!({
+            "statements": output.statements,
+            "errors": output.errors,
+        });
+        if !fingerprints.is_empty() {
+            out.as_object_mut().unwrap().insert(
+                "query_fingerprints".to_string(),
+                serde_json::json!(fingerprints),
+            );
+        }
+        if !output.comments.is_empty() {
+            out.as_object_mut().unwrap().insert(
+                "comments".to_string(),
+                serde_json::json!(output.comments),
+            );
+        }
+        serde_json::to_string_pretty(&out).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Tokenize SQL into a list of typed tokens with line/column positions")]
+    fn tokenize(
+        &self,
+        Parameters(TokenizeParams { sql }): Parameters<TokenizeParams>,
+    ) -> String {
+        match ogsql_parser::Tokenizer::new(&sql).tokenize() {
+            Ok(tokens) => {
+                let list: Vec<serde_json::Value> = tokens
+                    .iter()
+                    .map(|t| {
+                        let (token_type, value) = token_display(t);
+                        serde_json::json!({
+                            "type": token_type,
+                            "value": value,
+                            "line": t.location.line,
+                            "column": t.location.column,
+                        })
+                    })
+                    .collect();
+                serde_json::to_string_pretty(&serde_json::json!({"tokens": list}))
+                    .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+            }
+            Err(e) => format!("{{\"error\": \"{}\"}}", e),
+        }
+    }
+
+    #[tool(description = "Format SQL with standardized keyword casing and indentation")]
+    fn format(
+        &self,
+        Parameters(FormatParams { sql }): Parameters<FormatParams>,
+    ) -> String {
+        let output = ogsql_parser::Parser::parse_sql_with_options(
+            &sql,
+            ogsql_parser::ParseOptions { preserve_comments: false },
+        );
+        let formatter = ogsql_parser::SqlFormatter::new();
+        let formatted: Vec<String> = output
+            .statements
+            .iter()
+            .map(|si| formatter.format_statement(&si.statement))
+            .collect();
+        serde_json::to_string_pretty(&serde_json::json!({
+            "formatted": formatted.join(";\n"),
+            "statement_count": formatted.len(),
+            "error_count": output.errors.len(),
+            "errors": output.errors,
+        }))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Validate SQL syntax and report errors and warnings")]
+    fn validate(
+        &self,
+        Parameters(ValidateParams { sql }): Parameters<ValidateParams>,
+    ) -> String {
+        let output = ogsql_parser::Parser::parse_sql_with_options(
+            &sql,
+            ogsql_parser::ParseOptions { preserve_comments: false },
+        );
+        let errors = output.errors;
+        let has_real_errors = errors.iter().any(|e| !is_warning(e));
+        serde_json::to_string_pretty(&serde_json::json!({
+            "valid": !has_real_errors,
+            "error_count": errors.iter().filter(|e| !is_warning(e)).count(),
+            "warning_count": errors.iter().filter(|e| is_warning(e)).count(),
+            "errors": errors,
+        }))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Convert JSON AST (from parse tool output) back to SQL text")]
+    fn json2sql(
+        &self,
+        Parameters(Json2SqlParams { json }): Parameters<Json2SqlParams>,
+    ) -> String {
+        let json_value: serde_json::Value = match serde_json::from_str(&json) {
+            Ok(v) => v,
+            Err(e) => return format!("{{\"error\": \"Invalid JSON: {}\"}}", e),
+        };
+
+        let statements: Vec<ogsql_parser::Statement> = if let Some(arr) = json_value.get("statements") {
+            match serde_json::from_value(arr.clone()) {
+                Ok(s) => s,
+                Err(e) => return format!("{{\"error\": \"Failed to deserialize statements: {}\"}}", e),
+            }
+        } else {
+            match serde_json::from_value(json_value) {
+                Ok(s) => s,
+                Err(e) => return format!("{{\"error\": \"Failed to deserialize: {}\"}}", e),
+            }
+        };
+
+        let formatter = ogsql_parser::SqlFormatter::new();
+        let formatted: Vec<String> = statements
+            .iter()
+            .map(|s| formatter.format_statement(s))
+            .collect();
+
+        serde_json::to_string_pretty(&serde_json::json!({
+            "statements": formatted,
+            "count": formatted.len(),
+        }))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Parse iBatis/MyBatis XML mapper content and extract SQL statements")]
+    fn parse_xml(
+        &self,
+        Parameters(ParseXmlParams { xml }): Parameters<ParseXmlParams>,
+    ) -> String {
+        let result = ogsql_parser::ibatis::parse_mapper_bytes_with_path(xml.as_bytes(), None);
+        serde_json::to_string_pretty(&result)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Extract embedded SQL from Java source files (string literals, annotations, method calls)")]
+    fn parse_java(
+        &self,
+        Parameters(ParseJavaParams { source, extra_sql_methods }): Parameters<ParseJavaParams>,
+    ) -> String {
+        let config = ogsql_parser::java::JavaExtractConfig { extra_sql_methods };
+        let result = ogsql_parser::java::extract_sql_from_java(&source, "<mcp-input>", &config);
+        serde_json::to_string_pretty(&result)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn token_display(t: &ogsql_parser::TokenWithSpan) -> (String, String) {
+    use ogsql_parser::Token;
+    match &t.token {
+        Token::Keyword(k) => ("Keyword".into(), format!("{:?}", k)),
+        Token::Ident(s) => ("Ident".into(), s.clone()),
+        Token::Integer(n) => ("Integer".into(), n.to_string()),
+        Token::StringLiteral(s) => ("String".into(), s.clone()),
+        Token::Float(s) => ("Float".into(), s.clone()),
+        Token::Op(s) => ("Op".into(), s.clone()),
+        Token::OpLe => ("Op".into(), "<=".into()),
+        Token::OpNe => ("Op".into(), "<>".into()),
+        Token::OpGe => ("Op".into(), ">=".into()),
+        Token::OpShiftL => ("Op".into(), "<<".into()),
+        Token::OpShiftR => ("Op".into(), ">>".into()),
+        Token::OpArrow => ("Op".into(), "->".into()),
+        Token::OpJsonArrow => ("Op".into(), "->>".into()),
+        Token::OpNe2 => ("Op".into(), "!=".into()),
+        Token::OpDblBang => ("Op".into(), "!!".into()),
+        Token::OpConcat => ("Op".into(), "||".into()),
+        Token::Comment(s) => ("Comment".into(), s.clone()),
+        other => ("Other".into(), format!("{:?}", other)),
+    }
+}
+
+fn is_warning(e: &ogsql_parser::ParserError) -> bool {
+    matches!(
+        e,
+        ogsql_parser::ParserError::Warning { .. }
+            | ogsql_parser::ParserError::ReservedKeywordAsIdentifier { .. }
+    )
+}
+```
+
+**IMPORTANT:** The `parse_xml` and `parse_java` tools MUST be defined unconditionally in this file. The feature gates for `ibatis` and `java` are handled at the `Cargo.toml` level — the `mcp` feature should require `ibatis` and `java` as well. Update the feature definition:
+
+```toml
+mcp = ["dep:rmcp", "dep:schemars", "dep:tokio", "ibatis", "java"]
+```
+
+This way, when `mcp` is enabled, `ibatis` and `java` are automatically pulled in.
+
+**Step 2: Verify it compiles (expect errors for missing module registration — we fix that in Task 3)**
+
+Run: `cargo check --features mcp 2>&1 | head -30`
+
+**Step 3: Commit**
+
+```bash
+git add src/mcp/mod.rs
+git commit -m "feat(mcp): add OgsqlServer with all 7 tool definitions"
+```
+
+---
+
+### Task 3: Update lib.rs to expose mcp module
+
+**Files:**
+- Modify: `src/lib.rs`
+
+**Step 1: Add mcp module export**
+
+Add at the end of `src/lib.rs` (after the `#[cfg(feature = "java")]` block):
+
+```rust
+#[cfg(feature = "mcp")]
+pub mod mcp;
+```
+
+**Step 2: Verify compilation**
+
+Run: `cargo check --features mcp 2>&1 | tail -10`
+Expected: Should compile successfully (or only show warnings).
+
+**Step 3: Commit**
+
+```bash
+git add src/lib.rs
+git commit -m "feat(mcp): expose mcp module from lib.rs"
+```
+
+---
+
+### Task 4: Create binary entry src/bin/ogsql-mcp.rs
+
+**Files:**
+- Create: `src/bin/ogsql-mcp.rs`
+
+**Step 1: Create the file**
+
+```rust
+//! MCP server binary for ogsql-parser.
+//!
+//! Starts an MCP server over stdio transport, exposing all parser tools.
+//!
+//! Usage with Claude Desktop (add to claude_desktop_config.json):
+//! ```json
+//! {
+//!   "mcpServers": {
+//!     "ogsql": {
+//!       "command": "ogsql-mcp",
+//!       "args": []
+//!     }
+//!   }
+//! }
+//! ```
+
+use ogsql_parser::mcp::OgsqlServer;
+use rmcp::ServiceExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // IMPORTANT: Use stderr for logging in stdio mode — stdout is reserved for MCP protocol
+    eprintln!("ogsql-mcp: starting MCP server on stdio");
+
+    let service = OgsqlServer
+        .serve(rmcp::transport::stdio())
+        .await
+        .map_err(|e| {
+            eprintln!("ogsql-mcp: server initialization failed: {:?}", e);
+            e
+        })?;
+
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+**Step 2: Verify the binary compiles**
+
+Run: `cargo check --features mcp --bin ogsql-mcp 2>&1 | tail -10`
+Expected: Compiles successfully.
+
+**Step 3: Commit**
+
+```bash
+git add src/bin/ogsql-mcp.rs
+git commit -m "feat(mcp): add ogsql-mcp binary with stdio transport"
+```
+
+---
+
+### Task 5: Build verification and smoke test
+
+**Step 1: Full build with mcp feature**
+
+Run: `cargo build --features mcp 2>&1 | tail -10`
+Expected: Build succeeds.
+
+**Step 2: Build with full features**
+
+Run: `cargo build --features full 2>&1 | tail -10`
+Expected: Build succeeds.
+
+**Step 3: Existing tests still pass**
+
+Run: `cargo test 2>&1 | tail -10`
+Expected: All existing tests pass (same as baseline).
+
+**Step 4: Manual smoke test — verify server starts**
+
+Run the binary in background briefly to check it starts without panicking:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}' | timeout 3 ./target/debug/ogsql-mcp 2>/dev/null || true
+```
+
+Expected: JSON-RPC response with server info (not a panic/crash).
+
+**Step 5: Commit any fixes**
+
+If any fixes were needed, commit them.
+
+---
+
+### Task 6: Update README with MCP documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add MCP section after the HTTP API section**
+
+Add a new section:
+
+```markdown
+### MCP Server / MCP 服务器
+
+When built with `--features mcp`, an MCP server binary is available:
+
+```bash
+# Build MCP server
+cargo build --release --features mcp
+
+# Run (stdio transport)
+ogsql-mcp
+```
+
+#### MCP Tools / MCP 工具
+
+| Tool | Description |
+|------|-------------|
+| `parse` | Parse SQL → AST JSON (with fingerprints, comments, errors) |
+| `tokenize` | SQL → Token list with types, values, positions |
+| `format` | Format SQL with standardized casing |
+| `validate` | Validate SQL syntax, report errors/warnings |
+| `json2sql` | Convert AST JSON back to SQL |
+| `parse_xml` | Parse iBatis/MyBatis XML mapper → extracted SQL |
+| `parse_java` | Extract SQL from Java source files |
+
+#### Claude Desktop Configuration
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ogsql": {
+      "command": "/path/to/ogsql-mcp"
+    }
+  }
+}
+```
+```
+
+**Step 2: Update CLI Commands section**
+
+Add `mcp` to the feature build examples and note the binary.
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add MCP server documentation to README"
+```
+
+---
+
+## Summary of File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `Cargo.toml` | Modify | Add rmcp, schemars deps; add mcp feature; add ogsql-mcp binary |
+| `src/mcp/mod.rs` | Create | OgsqlServer struct with 7 tools |
+| `src/lib.rs` | Modify | Add `#[cfg(feature = "mcp")] pub mod mcp;` |
+| `src/bin/ogsql-mcp.rs` | Create | Binary entry with stdio transport |
+| `README.md` | Modify | MCP documentation section |

--- a/src/bin/ogsql-mcp.rs
+++ b/src/bin/ogsql-mcp.rs
@@ -1,0 +1,16 @@
+use ogsql_parser::mcp::OgsqlServer;
+use rmcp::ServiceExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    eprintln!("ogsql-mcp: starting MCP server on stdio");
+    let service = OgsqlServer
+        .serve(rmcp::transport::stdio())
+        .await
+        .map_err(|e| {
+            eprintln!("ogsql-mcp: server init failed: {:?}", e);
+            e
+        })?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,6 @@ pub mod ibatis;
 
 #[cfg(feature = "java")]
 pub mod java;
+
+#[cfg(feature = "mcp")]
+pub mod mcp;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,279 @@
+//! MCP (Model Context Protocol) server support.
+//!
+//! Exposes ogsql-parser capabilities as MCP tools via the `rmcp` crate.
+//! Supports stdio transport for integration with Claude Desktop, Cursor, etc.
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::schemars::JsonSchema;
+use rmcp::tool;
+use rmcp::tool_router;
+use serde::Deserialize;
+
+// ── Parameter types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParseParams {
+    /// SQL text to parse
+    pub sql: String,
+    /// Whether to preserve comments in output
+    #[serde(default)]
+    pub preserve_comments: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TokenizeParams {
+    /// SQL text to tokenize
+    pub sql: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FormatParams {
+    /// SQL text to format
+    pub sql: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ValidateParams {
+    /// SQL text to validate
+    pub sql: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct Json2SqlParams {
+    /// JSON string (output from parse tool) containing statements
+    pub json: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParseXmlParams {
+    /// XML content of an iBatis/MyBatis mapper file
+    pub xml: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ParseJavaParams {
+    /// Java source file content
+    pub source: String,
+    /// Extra method names to treat as SQL-bearing (e.g. ["executeQuery", "nativeQuery"])
+    #[serde(default)]
+    pub extra_sql_methods: Vec<String>,
+}
+
+// ── Server struct ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct OgsqlServer;
+
+// ── Tool implementations ─────────────────────────────────────────────────────
+
+#[tool_router(server_handler)]
+impl OgsqlServer {
+    #[tool(description = "Parse SQL into structured AST JSON with error reports and query fingerprints")]
+    fn parse(
+        &self,
+        Parameters(ParseParams { sql, preserve_comments }): Parameters<ParseParams>,
+    ) -> String {
+        let options = crate::ParseOptions { preserve_comments };
+        let output = crate::Parser::parse_sql_with_options(&sql, options);
+
+        let all_stmts: Vec<_> = output
+            .statements
+            .iter()
+            .map(|si| si.statement.clone())
+            .collect();
+        let fingerprints = crate::compute_query_fingerprints(&all_stmts);
+
+        let mut out = serde_json::json!({
+            "statements": output.statements,
+            "errors": output.errors,
+        });
+        if !fingerprints.is_empty() {
+            out.as_object_mut().unwrap().insert(
+                "query_fingerprints".to_string(),
+                serde_json::json!(fingerprints),
+            );
+        }
+        if !output.comments.is_empty() {
+            out.as_object_mut().unwrap().insert(
+                "comments".to_string(),
+                serde_json::json!(output.comments),
+            );
+        }
+        serde_json::to_string_pretty(&out).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Tokenize SQL into a list of typed tokens with line/column positions")]
+    fn tokenize(
+        &self,
+        Parameters(TokenizeParams { sql }): Parameters<TokenizeParams>,
+    ) -> String {
+        match crate::Tokenizer::new(&sql).tokenize() {
+            Ok(tokens) => {
+                let list: Vec<serde_json::Value> = tokens
+                    .iter()
+                    .map(|t| {
+                        let (token_type, value) = token_display(t);
+                        serde_json::json!({
+                            "type": token_type,
+                            "value": value,
+                            "line": t.location.line,
+                            "column": t.location.column,
+                        })
+                    })
+                    .collect();
+                serde_json::to_string_pretty(&serde_json::json!({"tokens": list}))
+                    .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+            }
+            Err(e) => format!("{{\"error\": \"{}\"}}", e),
+        }
+    }
+
+    #[tool(description = "Format SQL with standardized keyword casing and indentation")]
+    fn format(
+        &self,
+        Parameters(FormatParams { sql }): Parameters<FormatParams>,
+    ) -> String {
+        let output = crate::Parser::parse_sql_with_options(
+            &sql,
+            crate::ParseOptions {
+                preserve_comments: false,
+            },
+        );
+        let formatter = crate::SqlFormatter::new();
+        let formatted: Vec<String> = output
+            .statements
+            .iter()
+            .map(|si| formatter.format_statement(&si.statement))
+            .collect();
+        serde_json::to_string_pretty(&serde_json::json!({
+            "formatted": formatted.join(";\n"),
+            "statement_count": formatted.len(),
+            "error_count": output.errors.len(),
+            "errors": output.errors,
+        }))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Validate SQL syntax and report errors and warnings")]
+    fn validate(
+        &self,
+        Parameters(ValidateParams { sql }): Parameters<ValidateParams>,
+    ) -> String {
+        let output = crate::Parser::parse_sql_with_options(
+            &sql,
+            crate::ParseOptions {
+                preserve_comments: false,
+            },
+        );
+        let errors = output.errors;
+        let has_real_errors = errors.iter().any(|e| !is_warning(e));
+        serde_json::to_string_pretty(&serde_json::json!({
+            "valid": !has_real_errors,
+            "error_count": errors.iter().filter(|e| !is_warning(e)).count(),
+            "warning_count": errors.iter().filter(|e| is_warning(e)).count(),
+            "errors": errors,
+        }))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Convert JSON AST (from parse tool output) back to SQL text")]
+    fn json2sql(
+        &self,
+        Parameters(Json2SqlParams { json }): Parameters<Json2SqlParams>,
+    ) -> String {
+        let json_value: serde_json::Value = match serde_json::from_str(&json) {
+            Ok(v) => v,
+            Err(e) => return format!("{{\"error\": \"Invalid JSON: {}\"}}", e),
+        };
+
+        let statements: Vec<crate::Statement> = if let Some(arr) =
+            json_value.get("statements")
+        {
+            match serde_json::from_value(arr.clone()) {
+                Ok(s) => s,
+                Err(e) => {
+                    return format!(
+                        "{{\"error\": \"Failed to deserialize statements: {}\"}}",
+                        e
+                    )
+                }
+            }
+        } else {
+            match serde_json::from_value(json_value) {
+                Ok(s) => s,
+                Err(e) => return format!("{{\"error\": \"Failed to deserialize: {}\"}}", e),
+            }
+        };
+
+        let formatter = crate::SqlFormatter::new();
+        let formatted: Vec<String> = statements
+            .iter()
+            .map(|s| formatter.format_statement(s))
+            .collect();
+
+        serde_json::to_string_pretty(&serde_json::json!({
+            "statements": formatted,
+            "count": formatted.len(),
+        }))
+        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Parse iBatis/MyBatis XML mapper content and extract SQL statements")]
+    fn parse_xml(
+        &self,
+        Parameters(ParseXmlParams { xml }): Parameters<ParseXmlParams>,
+    ) -> String {
+        let result =
+            crate::ibatis::parse_mapper_bytes_with_path(xml.as_bytes(), None);
+        serde_json::to_string_pretty(&result)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+
+    #[tool(description = "Extract embedded SQL from Java source files (string literals, annotations, method calls)")]
+    fn parse_java(
+        &self,
+        Parameters(ParseJavaParams { source, extra_sql_methods }): Parameters<ParseJavaParams>,
+    ) -> String {
+        let config = crate::java::JavaExtractConfig {
+            extra_sql_methods,
+        };
+        let result =
+            crate::java::extract_sql_from_java(&source, "<mcp-input>", &config);
+        serde_json::to_string_pretty(&result)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn token_display(t: &crate::TokenWithSpan) -> (String, String) {
+    use crate::Token;
+    match &t.token {
+        Token::Keyword(k) => ("Keyword".into(), format!("{:?}", k)),
+        Token::Ident(s) => ("Ident".into(), s.clone()),
+        Token::Integer(n) => ("Integer".into(), n.to_string()),
+        Token::StringLiteral(s) => ("String".into(), s.clone()),
+        Token::Float(s) => ("Float".into(), s.clone()),
+        Token::Op(s) => ("Op".into(), s.clone()),
+        Token::OpLe => ("Op".into(), "<=".into()),
+        Token::OpNe => ("Op".into(), "<>".into()),
+        Token::OpGe => ("Op".into(), ">=".into()),
+        Token::OpShiftL => ("Op".into(), "<<".into()),
+        Token::OpShiftR => ("Op".into(), ">>".into()),
+        Token::OpArrow => ("Op".into(), "->".into()),
+        Token::OpJsonArrow => ("Op".into(), "->>".into()),
+        Token::OpNe2 => ("Op".into(), "!=".into()),
+        Token::OpDblBang => ("Op".into(), "!!".into()),
+        Token::OpConcat => ("Op".into(), "||".into()),
+        Token::Comment(s) => ("Comment".into(), s.clone()),
+        other => ("Other".into(), format!("{:?}", other)),
+    }
+}
+
+fn is_warning(e: &crate::ParserError) -> bool {
+    matches!(
+        e,
+        crate::ParserError::Warning { .. }
+            | crate::ParserError::ReservedKeywordAsIdentifier { .. }
+    )
+}


### PR DESCRIPTION
## Summary

- Add MCP (Model Context Protocol) server support via the official `rmcp` Rust SDK
- Expose all ogsql-parser capabilities as MCP tools over stdio transport
- Compatible with Claude Desktop, Cursor, and other MCP clients

## MCP Tools Added

| Tool | Description |
|------|-------------|
| `parse` | Parse SQL → AST JSON (with fingerprints, comments, errors) |
| `tokenize` | SQL → Token list with types, values, positions |
| `format` | Format SQL with standardized casing |
| `validate` | Validate SQL syntax, report errors/warnings |
| `json2sql` | Convert AST JSON back to SQL |
| `parse_xml` | Parse iBatis/MyBatis XML mapper → extracted SQL |
| `parse_java` | Extract SQL from Java source files |

## Usage

```bash
cargo build --release --features mcp
ogsql-mcp  # starts MCP server on stdio
```

Claude Desktop config:
```json
{
  "mcpServers": {
    "ogsql": { "command": "/path/to/ogsql-mcp" }
  }
}
```

## Changes

- `Cargo.toml`: Add `rmcp` v1.6, `schemars` v1 deps; `mcp` feature gate (auto-includes ibatis + java); `ogsql-mcp` binary target
- `src/mcp/mod.rs`: `OgsqlServer` with `#[tool_router(server_handler)]` — 7 tools wrapping parser core
- `src/bin/ogsql-mcp.rs`: Binary entry with stdio transport
- `src/lib.rs`: Expose `mcp` module behind feature gate
- `README.md`: MCP server documentation section