### PR TITLE
fix(parser): skip compound keyword after END in statement boundary detection

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -355,15 +355,18 @@ impl Parser {
             self.has_begin_after_declare(self.pos)
         });
 
+        let mut skip_next = false;
+
         for i in self.pos..self.tokens.len() {
+            if skip_next {
+                skip_next = false;
+                continue;
+            }
             match &self.tokens[i].token {
                 Token::Eof => return if i > 0 { i - 1 } else { 0 },
                 Token::LParen => depth += 1,
                 Token::RParen => depth = (depth - 1).max(0),
                 Token::DollarString { .. } => {
-                    // Dollar-quoted body contains its own BEGIN/END internally
-                    // (not as separate tokens), so clear in_routine_decl to
-                    // prevent subsequent semicolons from being swallowed.
                     if in_routine_decl && begin_depth == 0 {
                         in_routine_decl = false;
                     }
@@ -391,6 +394,7 @@ impl Parser {
                         {
                             case_depth -= 1;
                         }
+                        skip_next = true;
                     } else if case_depth > 0 {
                         case_depth -= 1;
                     } else if begin_depth > 0 {


### PR DESCRIPTION
## Summary

- Fix `find_statement_end_pos` depth tracking bug where compound END tokens (`END CASE`, `END LOOP`, `END IF`) caused the trailing keyword to re-increment depth counters, preventing `seen_outer_end` from being set
- Add `skip_next` flag to skip the token immediately after a compound END, preventing the trailing keyword from being processed as a new construct start

## Problem

When a SQL file contained `END CASE;` inside a PL/pgSQL package body, the statement boundary scanner would:

1. See `END` → correctly decrement `case_depth`
2. See `CASE` (next token) → **incorrectly increment** `case_depth` back to 1

This `case_depth` leak caused subsequent `END;` (function/procedure endings) to be consumed by the `case_depth > 0` branch instead of the `begin_depth > 0` branch, leaving `begin_depth` unable to reach zero. As a result, `seen_outer_end` was never set, the package body `/` terminator was treated as an internal token, and **all statements after the package body were silently dropped** from `parse -j` output.

## Fix

Added a `skip_next` flag that is set when a compound END is detected. The next iteration skips the trailing keyword token entirely.

## Testing

- `astro_functions_pkg.sql`: 2 statements → **5 statements** (correctly outputs CreatePackage + CreatePackageBody + CreateTable + Insert + Do)
- 1097 unit tests: all passing
- All existing test cases: no regression

Addresses #87 (方案 B)