### PR TITLE
fix(#90): parse PL/pgSQL CALL statements into structured ProcedureCall AST nodes

### DIFF
--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -603,6 +603,8 @@ impl Parser {
             self.parse_pl_execute()
         } else if self.match_ident_str("perform") {
             self.parse_pl_perform()
+        } else if self.match_ident_str("call") {
+            self.parse_pl_call()
         } else if self.match_ident_str("open") {
             self.parse_pl_open()
         } else if self.match_ident_str("fetch") {
@@ -1782,6 +1784,61 @@ impl Parser {
             parsed_query,
             parsed_expr,
         })
+    }
+
+    fn parse_pl_call(&mut self) -> Result<PlStatement, ParserError> {
+        let save_pos = self.pos;
+
+        self.advance();
+
+        let name = match self.parse_object_name() {
+            Ok(n) => n,
+            Err(_) => {
+                self.pos = save_pos;
+                let sql = self.skip_to_semicolon_or_keyword();
+                return Ok(PlStatement::Sql(sql));
+            }
+        };
+
+        if let Err(_) = self.expect_token(&Token::LParen) {
+            self.pos = save_pos;
+            let sql = self.skip_to_semicolon_or_keyword();
+            return Ok(PlStatement::Sql(sql));
+        }
+
+        let mut arguments = Vec::new();
+        if !self.match_token(&Token::RParen) {
+            loop {
+                match self.parse_expr() {
+                    Ok(arg) => arguments.push(arg),
+                    Err(_) => {
+                        self.pos = save_pos;
+                        let sql = self.skip_to_semicolon_or_keyword();
+                        return Ok(PlStatement::Sql(sql));
+                    }
+                }
+                if self.match_token(&Token::Comma) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        if let Err(_) = self.expect_token(&Token::RParen) {
+            self.pos = save_pos;
+            let sql = self.skip_to_semicolon_or_keyword();
+            return Ok(PlStatement::Sql(sql));
+        }
+
+        arguments.retain(|a| !matches!(a, Expr::Default));
+
+        self.try_consume_semicolon();
+
+        Ok(PlStatement::ProcedureCall(Spanned::new(PlProcedureCall {
+            name,
+            arguments,
+        }, None)))
     }
 
     fn parse_pl_open(&mut self) -> Result<PlStatement, ParserError> {

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -516,3 +516,101 @@ fn test_set_transaction_serializable_deferrable() {
         other => panic!("expected SetTransaction, got {:?}", other),
     }
 }
+
+#[test]
+fn test_pl_call_with_qualified_name() {
+    let sql = "CREATE OR REPLACE PROCEDURE prc_test IS
+               BEGIN
+                 CALL pkg_inventory.check_stock(p_product_id, p_qty);
+               END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::ProcedureCall(call) => {
+                    assert_eq!(call.name, vec!["pkg_inventory", "check_stock"]);
+                    assert_eq!(call.arguments.len(), 2);
+                }
+                other => panic!("expected ProcedureCall, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_pl_call_with_simple_name_no_args() {
+    let sql = "CREATE OR REPLACE PROCEDURE prc_test IS
+               BEGIN
+                 CALL my_procedure();
+               END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::ProcedureCall(call) => {
+                    assert_eq!(call.name, vec!["my_procedure"]);
+                    assert_eq!(call.arguments.len(), 0);
+                }
+                other => panic!("expected ProcedureCall, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_pl_call_with_literal_arguments() {
+    let sql = "CREATE OR REPLACE PROCEDURE prc_test IS
+               BEGIN
+                 CALL pkg_order.create_order(p_user_id, 0, 1);
+               END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref().expect("procedure should have a body");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::ProcedureCall(call) => {
+                    assert_eq!(call.name, vec!["pkg_order", "create_order"]);
+                    assert_eq!(call.arguments.len(), 3);
+                }
+                other => panic!("expected ProcedureCall, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateProcedure, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_pl_call_inside_package_body() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY my_pkg IS
+               PROCEDURE proc1 IS
+               BEGIN
+                 CALL pkg_order.create_order(1, 2, 3);
+               END proc1;
+               END my_pkg;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            let proc = p.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::ProcedureCall(call) => {
+                    assert_eq!(call.name, vec!["pkg_order", "create_order"]);
+                    assert_eq!(call.arguments.len(), 3);
+                }
+                other => panic!("expected ProcedureCall, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

- Add `parse_pl_call()` to handle `CALL package.procedure(args)` inside PL/pgSQL blocks (procedure/function/package bodies)
- Previously these fell through to raw `sql_text` fallback because the `parse_pl_statement()` dispatcher had no `call` branch
- Now produces `PlStatement::ProcedureCall { name, arguments }` — same structured node as bare procedure calls

Closes #90

## Root Cause

`parse_pl_statement()` in `plpgsql.rs` dispatched ~30 PL keywords but had no `match_ident_str("call")` arm. When `CALL` was encountered inside a PL block, it fell through to `parse_pl_sql_or_assignment()` where the keyword token could not be matched as an identifier, ultimately producing `PlStatement::Sql("CALL ...")`.

## Changes

**`src/parser/plpgsql.rs`** (+57 lines)
- Add `call` branch in `parse_pl_statement()` dispatcher (after `perform`)
- New `parse_pl_call()` method: advances past CALL keyword, parses `object_name(args)`, returns `PlStatement::ProcedureCall` with graceful fallback to `PlStatement::Sql` on parse errors

**`src/parser/tests_plsql_fixes.rs`** (+98 lines)
- `test_pl_call_with_qualified_name` — `CALL pkg_inventory.check_stock(p_product_id, p_qty)`
- `test_pl_call_with_simple_name_no_args` — `CALL my_procedure()`
- `test_pl_call_with_literal_arguments` — `CALL pkg_order.create_order(p_user_id, 0, 1)`
- `test_pl_call_inside_package_body` — CALL inside `CREATE PACKAGE BODY`

## Test Plan

- [x] 1101 tests pass (1097 baseline + 4 new)
- [x] No regression in main workspace
- [x] LSP diagnostics clean on changed files