### PR TITLE
feat(ibatis): resolve DTO fields from Mapper method parameter types

### DIFF
--- a/src/ibatis/java_resolve.rs
+++ b/src/ibatis/java_resolve.rs
@@ -82,6 +82,27 @@ impl JavaSourceResolver {
             .map(|root| root.join(&relative))
             .find(|path| path.is_file())
     }
+
+    pub fn resolve_by_class_name(&self, class_name: &str) -> Option<PathBuf> {
+        let target = format!("{}.java", class_name);
+        for root in &self.roots {
+            let found = walkdir::WalkDir::new(root)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .find(|e| {
+                    e.file_name().to_str().map(|n| n == target).unwrap_or(false)
+                });
+            if let Some(entry) = found {
+                return Some(entry.into_path());
+            }
+        }
+        None
+    }
+
+    pub fn read_source_by_class_name(&self, class_name: &str) -> Option<String> {
+        let path = self.resolve_by_class_name(class_name)?;
+        std::fs::read_to_string(&path).ok()
+    }
 }
 
 pub fn java_type_to_jdbc(java_type: &str) -> Option<crate::ibatis::types::JdbcType> {

--- a/src/ibatis/mod.rs
+++ b/src/ibatis/mod.rs
@@ -156,12 +156,27 @@ fn infer_param_types(
         .and_then(|info| info.methods.get(&stmt.id))
         .map(|m| &m.params);
 
-    // Parse DTO (if parameterType is a FQN, not "map")
-    let dto_fields = stmt.parameter_type.as_ref()
+    // Parse DTO from XML parameterType or from method parameter type
+    let mut dto_fields: std::collections::HashMap<String, String> = stmt.parameter_type.as_ref()
         .filter(|pt| pt.contains('.') && !pt.eq_ignore_ascii_case("map"))
         .and_then(|pt| resolver.read_source(pt))
         .map(|src| crate::java::parse_dto_fields(&src))
         .unwrap_or_default();
+
+    if dto_fields.is_empty() {
+        if let Some(ref info) = interface_info {
+            if let Some(method) = info.methods.get(&stmt.id) {
+                for param in &method.params {
+                    if java_type_to_jdbc(&param.java_type).is_none() {
+                        if let Some(src) = resolver.read_source_by_class_name(&param.java_type) {
+                            let fields = crate::java::parse_dto_fields(&src);
+                            dto_fields.extend(fields);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     collected_params.iter().map(|(name, inline_java_type, raw)| {
         // Priority 1: XML inline annotation


### PR DESCRIPTION
- When method param is non-primitive (e.g. User), resolve class by name and extract its fields as type source for SQL parameters
- Add resolve_by_class_name to JavaSourceResolver using walkdir search
- Enables type inference for insert/update with DTO params without needing parameterType in XML

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)