### PR TITLE
feat(ibatis): support iBatis 2.x #param# and $param$ placeholder syntax

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/ruoyi-springboot3-pro"]
 	path = lib/ruoyi-springboot3-pro
 	url = https://github.com/undsky/RuoYi-SpringBoot3-Pro.git
+[submodule "lib/ibatis-2"]
+	path = lib/ibatis-2
+	url = https://github.com/mybatis/ibatis-2.git

--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -276,6 +276,44 @@ fn replace_params(sql: &str) -> String {
             }
         }
 
+        // 处理 iBatis 2.x #param# 格式
+        if c == '#' && (i + 1 >= len || chars[i + 1] != '{') {
+            let start = i + 1;
+            let mut end = start;
+            while end < len && chars[end] != '#' {
+                end += 1;
+            }
+            if end < len && end > start {
+                let param: String = chars[start..end].iter().collect();
+                if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
+                    result.push_str(PARAM_PREFIX);
+                    result.push_str(&param);
+                    result.push_str(PLACEHOLDER_SUFFIX);
+                    i = end + 1;
+                    continue;
+                }
+            }
+        }
+
+        // 处理 iBatis 2.x $param$ 格式
+        if c == '$' && (i + 1 >= len || chars[i + 1] != '{') {
+            let start = i + 1;
+            let mut end = start;
+            while end < len && chars[end] != '$' {
+                end += 1;
+            }
+            if end < len && end > start {
+                let param: String = chars[start..end].iter().collect();
+                if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
+                    result.push_str(RAW_PREFIX);
+                    result.push_str(&param);
+                    result.push_str(PLACEHOLDER_SUFFIX);
+                    i = end + 1;
+                    continue;
+                }
+            }
+        }
+
         result.push(c);
         i += 1;
     }

--- a/src/ibatis/mod.rs
+++ b/src/ibatis/mod.rs
@@ -87,7 +87,7 @@ fn parse_mapper_bytes_internal(
             infer_param_types(&mapper_file.namespace, stmt, &collected, &resolver)
         };
         #[cfg(not(feature = "java"))]
-        let parameters = collected.iter().map(|(name, java_type, raw)| {
+        let parameters: Vec<types::ParamMeta> = collected.iter().map(|(name, java_type, raw)| {
             types::ParamMeta {
                 name: name.clone(),
                 jdbc_type: None,

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -230,6 +230,51 @@ fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                 continue;
             }
         }
+
+        // iBatis 2.x #param# format
+        if chars[i] == '#' && (i + 1 >= len || chars[i + 1] != '{') {
+            let start = i + 1;
+            let mut end = start;
+            while end < len && chars[end] != '#' {
+                end += 1;
+            }
+            if end < len && end > start {
+                let param: String = chars[start..end].iter().collect();
+                if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
+                    if !current_text.is_empty() {
+                        nodes.push(SqlNode::Text {
+                            content: std::mem::take(&mut current_text),
+                        });
+                    }
+                    let (name, java_type) = parse_param_type(&param);
+                    nodes.push(SqlNode::Parameter { name, java_type });
+                    i = end + 1;
+                    continue;
+                }
+            }
+        }
+
+        // iBatis 2.x $param$ format
+        if chars[i] == '$' && (i + 1 >= len || chars[i + 1] != '{') {
+            let start = i + 1;
+            let mut end = start;
+            while end < len && chars[end] != '$' {
+                end += 1;
+            }
+            if end < len && end > start {
+                let param: String = chars[start..end].iter().collect();
+                if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
+                    if !current_text.is_empty() {
+                        nodes.push(SqlNode::Text {
+                            content: std::mem::take(&mut current_text),
+                        });
+                    }
+                    nodes.push(SqlNode::RawExpr { expr: param });
+                    i = end + 1;
+                    continue;
+                }
+            }
+        }
         current_text.push(chars[i]);
         i += 1;
     }


### PR DESCRIPTION
- Parse #param# as SqlNode::Parameter (same as #{param})
- Parse $param$ as SqlNode::RawExpr (same as ${expr})
- Handle in both parser (node tree) and flatten (text replacement)
- Fixes #value# and #id# not being recognized in iBatis 2.0 sqlmap files

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)