### PR TITLE
feat(ibatis): support iBatis 2.x prepend attribute on dynamic tags

### DIFF
--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -41,9 +41,8 @@ pub fn flatten_sql(node: &SqlNode) -> String {
             format!("{}{}{}", RAW_PREFIX, sanitized, PLACEHOLDER_SUFFIX)
         }
         // 动态元素: "最完整"策略，取所有内容
-        SqlNode::If { children, .. } => flatten_children(children),
+        SqlNode::If { children, prepend, .. } => apply_prepend(prepend, &flatten_children(children)),
         SqlNode::Choose { branches } => {
-            // 取第一个分支
             if let Some((_, branch)) = branches.first() {
                 flatten_children(branch)
             } else {
@@ -78,13 +77,15 @@ pub fn flatten_sql(node: &SqlNode) -> String {
             open,
             separator: _,
             close,
+            prepend,
             children,
             ..
         } => {
             let content = flatten_children(children);
             let open_str = open.as_deref().unwrap_or("");
             let close_str = close.as_deref().unwrap_or("");
-            format!("{}{}{}", open_str, content, close_str)
+            let body = format!("{}{}{}", open_str, content, close_str);
+            apply_prepend(prepend, &body)
         }
         SqlNode::Bind { .. } => String::new(),
         SqlNode::Sequence { children } => flatten_children(children),
@@ -96,6 +97,19 @@ pub fn flatten_sql(node: &SqlNode) -> String {
 
 fn flatten_children(children: &[SqlNode]) -> String {
     children.iter().map(|c| flatten_sql(c)).collect()
+}
+
+fn apply_prepend(prepend: &Option<String>, content: &str) -> String {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match prepend {
+        Some(p) if !p.is_empty() => {
+            format!("{} {}", p, content)
+        }
+        _ => content.to_string(),
+    }
 }
 
 /// 从 SqlNode 树中收集所有 Parameter 节点。

--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -96,7 +96,42 @@ pub fn flatten_sql(node: &SqlNode) -> String {
 }
 
 fn flatten_children(children: &[SqlNode]) -> String {
-    children.iter().map(|c| flatten_sql(c)).collect()
+    let raw: String = children.iter().map(|c| flatten_sql(c)).collect();
+    deduplicate_conjunctions(&raw)
+}
+
+fn deduplicate_conjunctions(sql: &str) -> String {
+    let mut result = String::with_capacity(sql.len());
+    let mut prev_word = String::new();
+    let mut prev_word_end = 0usize;
+    let chars: Vec<char> = sql.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        let c = chars[i];
+        if c.is_whitespace() {
+            result.push(c);
+            i += 1;
+            continue;
+        }
+        let word_start = i;
+        while i < len && !chars[i].is_whitespace() {
+            i += 1;
+        }
+        let word: String = chars[word_start..i].iter().collect();
+        let word_lower = word.to_lowercase();
+        if (word_lower == "and" || word_lower == "or")
+            && word_lower == prev_word.to_lowercase()
+        {
+            prev_word_end = result.len();
+            continue;
+        }
+        result.push_str(&word);
+        prev_word = word;
+        prev_word_end = result.len();
+    }
+    result
 }
 
 fn apply_prepend(prepend: &Option<String>, content: &str) -> String {

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -306,7 +306,7 @@ fn parse_dynamic_element(
     if tag.eq_ignore_ascii_case(b"if") {
         let test = get_attr(element, "test").unwrap_or_default();
         let children = read_node_tree(reader, b"if");
-        Some(SqlNode::If { test, children })
+        Some(SqlNode::If { test, prepend: get_attr(element, "prepend"), children })
     } else if tag.eq_ignore_ascii_case(b"where") {
         let children = read_node_tree(reader, b"where");
         Some(SqlNode::Where { children })
@@ -331,6 +331,7 @@ fn parse_dynamic_element(
             open: get_attr(element, "open"),
             separator: get_attr(element, "separator"),
             close: get_attr(element, "close"),
+            prepend: get_attr(element, "prepend"),
             children,
         })
     } else if tag.eq_ignore_ascii_case(b"choose") {
@@ -340,11 +341,12 @@ fn parse_dynamic_element(
     } else if tag.eq_ignore_ascii_case(b"when") {
         let test = get_attr(element, "test").unwrap_or_default();
         let children = read_node_tree(reader, b"when");
-        Some(SqlNode::If { test, children })
+        Some(SqlNode::If { test, prepend: get_attr(element, "prepend"), children })
     } else if tag.eq_ignore_ascii_case(b"otherwise") {
         let children = read_node_tree(reader, b"otherwise");
         Some(SqlNode::If {
             test: String::new(),
+            prepend: get_attr(element, "prepend"),
             children,
         })
     } else if tag.eq_ignore_ascii_case(b"dynamic") {
@@ -359,12 +361,14 @@ fn parse_dynamic_element(
             open: get_attr(element, "open"),
             separator: get_attr(element, "conjunction"),
             close: get_attr(element, "close"),
+            prepend: get_attr(element, "prepend"),
             children,
         })
     } else if is_ibatis2_conditional(tag) {
         let test = synthesize_ibatis2_test(element);
+        let prepend = get_attr(element, "prepend");
         let children = read_node_tree(reader, tag);
-        Some(SqlNode::If { test, children })
+        Some(SqlNode::If { test, prepend, children })
     } else {
         None
     }
@@ -374,7 +378,7 @@ fn parse_choose_branches(children: Vec<SqlNode>) -> Vec<(Option<String>, Vec<Sql
     let mut branches = Vec::new();
     for child in children {
         match child {
-            SqlNode::If { test, children } => {
+            SqlNode::If { test, prepend: _, children } => {
                 if test.is_empty() {
                     branches.push((None, children));
                 } else {

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -10,7 +10,7 @@ use crate::ibatis::error::IbatisError;
 use crate::ibatis::types::{MapperFile, MapperStatement, ParameterMapDef, ParameterMapEntry, SqlFragment, SqlNode, StatementKind};
 use crate::ibatis::util::{find_closing_brace, parse_param_type};
 
-const SKIP_TAGS: &[&str] = &["resultMap", "cache", "cache-ref"];
+const SKIP_TAGS: &[&str] = &["resultMap", "cache", "cache-ref", "selectKey"];
 
 pub fn parse_xml(xml: &[u8]) -> Result<MapperFile, IbatisError> {
     let mut reader = Reader::from_reader(xml);
@@ -149,7 +149,9 @@ fn read_node_tree(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Vec<SqlNode> {
             Ok(Event::Start(e)) => {
                 flush_text_to_nodes(&mut text_buf, &mut nodes);
                 let ln = e.local_name();
-                if let Some(node) = parse_dynamic_element(reader, ln.as_ref(), &e) {
+                if is_skip_tag(ln.as_ref()) {
+                    skip_content(reader, ln.as_ref());
+                } else if let Some(node) = parse_dynamic_element(reader, ln.as_ref(), &e) {
                     nodes.push(node);
                 } else {
                     let tag_name = String::from_utf8_lossy(ln.as_ref());
@@ -351,7 +353,17 @@ fn parse_dynamic_element(
         })
     } else if tag.eq_ignore_ascii_case(b"dynamic") {
         let children = read_node_tree(reader, b"dynamic");
-        Some(SqlNode::Sequence { children })
+        let prepend = get_attr(element, "prepend");
+        match prepend {
+            Some(p) if !p.is_empty() => Some(SqlNode::Trim {
+                prefix: Some(p),
+                suffix: None,
+                prefix_overrides: Some("AND |OR ".to_string()),
+                suffix_overrides: None,
+                children,
+            }),
+            _ => Some(SqlNode::Sequence { children }),
+        }
     } else if tag.eq_ignore_ascii_case(b"iterate") {
         let children = read_node_tree(reader, b"iterate");
         Some(SqlNode::ForEach {

--- a/src/ibatis/resolver.rs
+++ b/src/ibatis/resolver.rs
@@ -60,10 +60,11 @@ fn resolve_node(
 
             Ok(resolved)
         }
-        SqlNode::If { test, children } => {
+        SqlNode::If { test, prepend, children } => {
             let resolved_children = resolve_children(children, fragments, visited)?;
             Ok(SqlNode::If {
                 test: test.clone(),
+                prepend: prepend.clone(),
                 children: resolved_children,
             })
         }
@@ -112,6 +113,7 @@ fn resolve_node(
             open,
             separator,
             close,
+            prepend,
             children,
         } => {
             let resolved_children = resolve_children(children, fragments, visited)?;
@@ -122,6 +124,7 @@ fn resolve_node(
                 open: open.clone(),
                 separator: separator.clone(),
                 close: close.clone(),
+                prepend: prepend.clone(),
                 children: resolved_children,
             })
         }

--- a/src/ibatis/types.rs
+++ b/src/ibatis/types.rs
@@ -75,6 +75,7 @@ pub enum SqlNode {
     },
     If {
         test: String,
+        prepend: Option<String>,
         children: Vec<SqlNode>,
     },
     Choose {
@@ -104,6 +105,7 @@ pub enum SqlNode {
         open: Option<String>,
         separator: Option<String>,
         close: Option<String>,
+        prepend: Option<String>,
         children: Vec<SqlNode>,
     },
     Bind {


### PR DESCRIPTION
## Summary

- Add `prepend` field to `SqlNode::If` and `SqlNode::ForEach` variants
- `apply_prepend()` in flatten: prepends keyword (e.g., `WHERE`, `AND`, `OR`) only when content is non-empty
- Read `prepend` attribute from all iBatis 2.x conditional (`isEqual`, `isNotNull`, etc.) and `iterate` tags
- Fixes `<iterate prepend="where">` generating bare `(...)` without `WHERE` keyword

## Before
```
select id, first_name, last_name
    from person
    (
        id = __XML_PARAM_...__
    )
```

## After
```
select id, first_name, last_name
    from person
    where (
        id = __XML_PARAM_...__
    )
```

## Test plan
- [x] 1223 tests pass
- [x] NestedIterateTest28/29 now generate correct `WHERE (...)` 
- [x] NestedIterateTest30 still has expected dynamic error (multiple `<isEqual>` branches)