### PR TITLE
feat(ibatis): improve parameter type inference with parameterClass and typeAlias

### DIFF
--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -4,6 +4,7 @@
 //! - #{param} → __XML_PARAM_param__
 //! - #{param,javaType=double} → __XML_PARAM_DOUBLE_param__
 //! - ${expr} → __XML_RAW_expr__
+//! - ${expr,javaType=string} → __XML_RAW_STRING_expr__
 
 use crate::ibatis::types::SqlNode;
 use crate::ibatis::util::{find_closing_brace, parse_param_type};
@@ -36,9 +37,18 @@ pub fn flatten_sql(node: &SqlNode) -> String {
                 None => format!("{}{}{}", PARAM_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
             }
         }
-        SqlNode::RawExpr { expr } => {
+        SqlNode::RawExpr { expr, java_type } => {
             let sanitized = sanitize_param_name(expr);
-            format!("{}{}{}", RAW_PREFIX, sanitized, PLACEHOLDER_SUFFIX)
+            match java_type {
+                Some(t) => format!(
+                    "{}{}_{}{}",
+                    RAW_PREFIX,
+                    t.to_uppercase(),
+                    sanitized,
+                    PLACEHOLDER_SUFFIX
+                ),
+                None => format!("{}{}{}", RAW_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
+            }
         }
         // 动态元素: "最完整"策略，取所有内容
         SqlNode::If { children, prepend, .. } => apply_prepend(prepend, &flatten_children(children)),
@@ -166,6 +176,13 @@ fn collect_params_recursive(
             };
             params.push((name.clone(), java_type.clone(), raw));
         }
+        SqlNode::RawExpr { expr, java_type } => {
+            let raw = match java_type {
+                Some(t) => format!("${{{},{}}}", expr, format!("javaType={}", t)),
+                None => format!("${{{}}}", expr),
+            };
+            params.push((expr.clone(), java_type.clone(), raw));
+        }
         SqlNode::If { children, .. }
         | SqlNode::Where { children, .. }
         | SqlNode::Set { children, .. }
@@ -179,7 +196,7 @@ fn collect_params_recursive(
                 for c in ch { collect_params_recursive(c, params); }
             }
         }
-        SqlNode::Text { .. } | SqlNode::RawExpr { .. } | SqlNode::Bind { .. } | SqlNode::Include { .. } => {}
+        SqlNode::Text { .. } | SqlNode::Bind { .. } | SqlNode::Include { .. } => {}
     }
 }
 
@@ -264,6 +281,7 @@ fn apply_trim(
 /// - `#{param}` → `__XML_PARAM_param__`
 /// - `#{name,javaType=double}` → `__XML_PARAM_DOUBLE_name__`
 /// - `${expr}` → `__XML_RAW_expr__`
+/// - `${expr,javaType=string}` → `__XML_RAW_STRING_expr__`
 /// - `'...'` 内的 `#{}` 和 `${}` 不替换
 fn replace_params(sql: &str) -> String {
     let mut result = String::with_capacity(sql.len());
@@ -327,10 +345,23 @@ fn replace_params(sql: &str) -> String {
         // 处理 ${
         if c == '$' && i + 1 < len && chars[i + 1] == '{' {
             if let Some(end) = find_closing_brace(&chars, i + 2) {
-                let expr: String = chars[i + 2..end].iter().collect();
-                result.push_str(RAW_PREFIX);
-                result.push_str(&sanitize_param_name(&expr));
-                result.push_str(PLACEHOLDER_SUFFIX);
+                let raw: String = chars[i + 2..end].iter().collect();
+                let (name, java_type) = parse_param_type(&raw);
+                let sanitized = sanitize_param_name(&name);
+                match java_type {
+                    Some(t) => {
+                        result.push_str(RAW_PREFIX);
+                        result.push_str(&t.to_uppercase());
+                        result.push('_');
+                        result.push_str(&sanitized);
+                        result.push_str(PLACEHOLDER_SUFFIX);
+                    }
+                    None => {
+                        result.push_str(RAW_PREFIX);
+                        result.push_str(&sanitized);
+                        result.push_str(PLACEHOLDER_SUFFIX);
+                    }
+                }
                 i = end + 1;
                 continue;
             }
@@ -362,11 +393,24 @@ fn replace_params(sql: &str) -> String {
                 end += 1;
             }
             if end < len && end > start {
-                let param: String = chars[start..end].iter().collect();
-                if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
-                    result.push_str(RAW_PREFIX);
-                    result.push_str(&sanitize_param_name(&param));
-                    result.push_str(PLACEHOLDER_SUFFIX);
+                let raw: String = chars[start..end].iter().collect();
+                if !raw.contains(' ') && !raw.contains('\n') && !raw.contains('\r') {
+                    let (name, java_type) = parse_param_type(&raw);
+                    let sanitized = sanitize_param_name(&name);
+                    match java_type {
+                        Some(t) => {
+                            result.push_str(RAW_PREFIX);
+                            result.push_str(&t.to_uppercase());
+                            result.push('_');
+                            result.push_str(&sanitized);
+                            result.push_str(PLACEHOLDER_SUFFIX);
+                        }
+                        None => {
+                            result.push_str(RAW_PREFIX);
+                            result.push_str(&sanitized);
+                            result.push_str(PLACEHOLDER_SUFFIX);
+                        }
+                    }
                     i = end + 1;
                     continue;
                 }
@@ -457,5 +501,21 @@ mod param_tests {
     #[test]
     fn test_param_no_type() {
         assert_eq!(replace_params("#{simple}"), "__XML_PARAM_simple__");
+    }
+
+    #[test]
+    fn test_dollar_param_with_java_type() {
+        assert_eq!(
+            replace_params("ORDER BY ${col,javaType=string}"),
+            "ORDER BY __XML_RAW_STRING_col__"
+        );
+    }
+
+    #[test]
+    fn test_dollar_param_with_jdbc_type() {
+        assert_eq!(
+            replace_params("${table,jdbcType=VARCHAR}"),
+            "__XML_RAW_VARCHAR_table__"
+        );
     }
 }

--- a/src/ibatis/mod.rs
+++ b/src/ibatis/mod.rs
@@ -107,9 +107,12 @@ fn parse_mapper_bytes_internal(
 
         for param in &parameters {
             if let Some(jdbc) = &param.jdbc_type {
-                let untyped = format!("{}{}{}", "__XML_PARAM_", param.name, "__");
-                let typed = format!("{}{}_{}{}", "__XML_PARAM_", format!("{:?}", jdbc).to_uppercase(), param.name, "__");
-                flat_sql = flat_sql.replace(&untyped, &typed);
+                let jdbc_str = format!("{:?}", jdbc).to_uppercase();
+                for prefix in ["__XML_PARAM_", "__XML_RAW_"] {
+                    let untyped = format!("{}{}{}", prefix, param.name, "__");
+                    let typed = format!("{}{}_{}{}", prefix, jdbc_str, param.name, "__");
+                    flat_sql = flat_sql.replace(&untyped, &typed);
+                }
             }
         }
 

--- a/src/ibatis/mod.rs
+++ b/src/ibatis/mod.rs
@@ -92,7 +92,7 @@ fn parse_mapper_bytes_internal(
         #[cfg(feature = "java")]
         let parameters = {
             let resolver = java_resolve::JavaSourceResolver::new(java_source_roots.clone());
-            infer_param_types(&mapper_file.namespace, stmt, &collected, &resolver)
+            infer_param_types(&mapper_file.namespace, stmt, &collected, &resolver, &mapper_file.type_aliases)
         };
         #[cfg(not(feature = "java"))]
         let parameters: Vec<types::ParamMeta> = collected.iter().map(|(name, java_type, raw)| {
@@ -154,9 +154,26 @@ fn infer_param_types(
     stmt: &types::MapperStatement,
     collected_params: &[(String, Option<String>, String)],
     resolver: &java_resolve::JavaSourceResolver,
+    type_aliases: &[(String, String)],
 ) -> Vec<types::ParamMeta> {
     use crate::ibatis::types::{InferenceSource, ParamMeta};
     use crate::ibatis::java_resolve::{java_type_to_jdbc, jdbc_type_from_str};
+
+    let resolved_param_type: Option<String> = stmt.parameter_type.as_ref().map(|pt| {
+        type_aliases.iter()
+            .find(|(alias, _)| alias.eq_ignore_ascii_case(pt))
+            .map(|(_, fqn)| fqn.clone())
+            .unwrap_or_else(|| pt.clone())
+    });
+
+    // P0-A: parameterClass is a simple type (e.g. "java.lang.Integer", "int") -> all params inherit it
+    let simple_param_jdbc = resolved_param_type.as_ref()
+        .and_then(|pt| {
+            let jdbc = java_type_to_jdbc(pt);
+            if jdbc.is_some() { return jdbc; }
+            // FQN last segment: "java.lang.Integer" -> "Integer"
+            pt.rsplit('.').next().and_then(|short| java_type_to_jdbc(short))
+        });
 
     // Parse Mapper interface (if available)
     let interface_info = resolver.read_source(namespace)
@@ -167,12 +184,24 @@ fn infer_param_types(
         .and_then(|info| info.methods.get(&stmt.id))
         .map(|m| &m.params);
 
-    // Parse DTO from XML parameterType or from method parameter type
-    let mut dto_fields: std::collections::HashMap<String, String> = stmt.parameter_type.as_ref()
+    // P0-B: short names resolved via typeAlias, then by class name search
+    let mut dto_fields: std::collections::HashMap<String, String> = resolved_param_type.as_ref()
         .filter(|pt| pt.contains('.') && !pt.eq_ignore_ascii_case("map"))
         .and_then(|pt| resolver.read_source(pt))
         .map(|src| crate::java::parse_dto_fields(&src))
         .unwrap_or_default();
+
+    // P0-B: Try resolve_by_class_name for short names (e.g. "account" -> testdomain.Account)
+    if dto_fields.is_empty() {
+        if let Some(ref pt) = resolved_param_type {
+            if !pt.contains('.') && !pt.eq_ignore_ascii_case("map") {
+                if let Some(src) = resolver.read_source_by_class_name(pt) {
+                    let fields = crate::java::parse_dto_fields(&src);
+                    dto_fields.extend(fields);
+                }
+            }
+        }
+    }
 
     if dto_fields.is_empty() {
         if let Some(ref info) = interface_info {
@@ -212,7 +241,18 @@ fn infer_param_types(
             }
         }
 
-        // Priority 2: Mapper interface method signature
+        // Priority 2: parameterClass is a simple type -> all params inherit that type
+        if let Some(jdbc) = simple_param_jdbc {
+            return ParamMeta {
+                name: name.clone(),
+                jdbc_type: Some(jdbc),
+                source: Some(InferenceSource::ParameterClass),
+                position: 0,
+                raw: raw.clone(),
+            };
+        }
+
+        // Priority 3: Mapper interface method signature
         if let Some(params) = method_params {
             if let Some(param) = params.iter().find(|p| p.name == *name) {
                 if let Some(jdbc) = java_type_to_jdbc(&param.java_type) {
@@ -232,7 +272,7 @@ fn infer_param_types(
             }
         }
 
-        // Priority 3: DTO fields
+        // Priority 4: DTO fields
         if let Some(java_t) = dto_fields.get(name) {
             if let Some(jdbc) = java_type_to_jdbc(java_t) {
                 return ParamMeta {

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -238,8 +238,9 @@ fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                         content: std::mem::take(&mut current_text),
                     });
                 }
-                let expr: String = chars[i + 2..end].iter().collect();
-                nodes.push(SqlNode::RawExpr { expr });
+                let raw: String = chars[i + 2..end].iter().collect();
+                let (expr, java_type) = parse_param_type(&raw);
+                nodes.push(SqlNode::RawExpr { expr, java_type });
                 i = end + 1;
                 continue;
             }
@@ -283,7 +284,9 @@ fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                             content: std::mem::take(&mut current_text),
                         });
                     }
-                    nodes.push(SqlNode::RawExpr { expr: param });
+                    let raw: String = chars[start..end].iter().collect();
+                    let (expr, java_type) = parse_param_type(&raw);
+                    nodes.push(SqlNode::RawExpr { expr, java_type });
                     i = end + 1;
                     continue;
                 }
@@ -424,7 +427,10 @@ fn simple_node_to_text(node: &SqlNode) -> String {
             Some(t) => format!("#{{{},{}}}", name, format!("javaType={}", t)),
             None => format!("#{{{}}}", name),
         },
-        SqlNode::RawExpr { expr } => format!("${{{}}}", expr),
+        SqlNode::RawExpr { expr, java_type } => match java_type {
+            Some(t) => format!("${{{},{}}}", expr, format!("javaType={}", t)),
+            None => format!("${{{}}}", expr),
+        },
         _ => String::new(),
     }
 }

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -21,6 +21,7 @@ pub fn parse_xml(xml: &[u8]) -> Result<MapperFile, IbatisError> {
     let mut fragments: Vec<SqlFragment> = Vec::new();
     let mut parameter_maps: Vec<ParameterMapDef> = Vec::new();
     let mut statements: Vec<MapperStatement> = Vec::new();
+    let mut type_aliases: Vec<(String, String)> = Vec::new();
 
     loop {
         buf.clear();
@@ -75,6 +76,10 @@ pub fn parse_xml(xml: &[u8]) -> Result<MapperFile, IbatisError> {
                             content: String::new(),
                         },
                     });
+                } else if tag.as_ref().eq_ignore_ascii_case(b"typeAlias") {
+                    if let (Some(alias), Some(type_attr)) = (get_attr(&e, "alias"), get_attr(&e, "type")) {
+                        type_aliases.push((alias, type_attr));
+                    }
                 }
             }
             Ok(Event::Eof) => break,
@@ -92,6 +97,7 @@ pub fn parse_xml(xml: &[u8]) -> Result<MapperFile, IbatisError> {
         namespace,
         fragments,
         parameter_maps,
+        type_aliases,
         statements,
     })
 }

--- a/src/ibatis/resolver.rs
+++ b/src/ibatis/resolver.rs
@@ -31,6 +31,7 @@ pub fn resolve_includes(mapper: &MapperFile) -> Result<MapperFile, IbatisError> 
         namespace: mapper.namespace.clone(),
         fragments: resolved_fragments,
         parameter_maps: mapper.parameter_maps.clone(),
+        type_aliases: mapper.type_aliases.clone(),
         statements: resolved_statements,
     })
 }

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -163,7 +163,10 @@ fn node_text(node: &SqlNode) -> String {
             Some(t) => format!("#{{{},{}}}", name, format!("javaType={}", t)),
             None => format!("#{{{}}}", name),
         },
-        SqlNode::RawExpr { expr } => format!("${{{}}}", expr),
+        SqlNode::RawExpr { expr, java_type } => match java_type {
+            Some(t) => format!("${{{},{}}}", expr, format!("javaType={}", t)),
+            None => format!("${{{}}}", expr),
+        },
         SqlNode::If { children, .. } => children.iter().map(node_text).collect(),
         SqlNode::Choose { branches } => branches
             .iter()
@@ -366,6 +369,34 @@ fn test_e2e_dollar_param_placeholder() {
     let result = super::parse_mapper_bytes(xml);
     let stmt = &result.statements[0];
     assert!(stmt.flat_sql.contains("__XML_RAW_column__"));
+}
+
+#[test]
+fn test_e2e_dollar_param_with_java_type() {
+    let xml = br#"<mapper namespace="test">
+        <select id="dynamicOrder">SELECT * FROM users ORDER BY ${column,javaType=string}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    let stmt = &result.statements[0];
+    assert!(
+        stmt.flat_sql.contains("__XML_RAW_STRING_column__"),
+        "got: {}",
+        stmt.flat_sql
+    );
+}
+
+#[test]
+fn test_e2e_dollar_param_with_jdbc_type() {
+    let xml = br#"<mapper namespace="test">
+        <select id="dynamicCol">SELECT ${col,jdbcType=VARCHAR} FROM users</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    let stmt = &result.statements[0];
+    assert!(
+        stmt.flat_sql.contains("__XML_RAW_VARCHAR_col__"),
+        "got: {}",
+        stmt.flat_sql
+    );
 }
 
 #[test]

--- a/src/ibatis/types.rs
+++ b/src/ibatis/types.rs
@@ -9,6 +9,8 @@ pub struct MapperFile {
     pub fragments: Vec<SqlFragment>,
     /// iBatis 2.x parameterMap 定义 (<parameterMap id="...">)
     pub parameter_maps: Vec<ParameterMapDef>,
+    /// typeAlias 映射 (<typeAlias alias="account" type="testdomain.Account" />)
+    pub type_aliases: Vec<(String, String)>,
     /// SQL 语句 (<select>/<insert>/<update>/<delete>)
     pub statements: Vec<MapperStatement>,
 }
@@ -186,6 +188,7 @@ pub enum JdbcType {
 pub enum InferenceSource {
     InlineJavaType,
     InlineJdbcType,
+    ParameterClass,
     JavaMethodSignature,
     JavaParamAnnotation,
     JavaDtoField,

--- a/src/ibatis/types.rs
+++ b/src/ibatis/types.rs
@@ -69,6 +69,7 @@ pub enum SqlNode {
     },
     RawExpr {
         expr: String,
+        java_type: Option<String>,
     },
     Include {
         refid: String,


### PR DESCRIPTION
## Summary

- **P0-A**: When `parameterClass` is a simple Java type (e.g. `java.lang.Integer`, `int`, `string`), all `#{value}` / `${value}` parameters now inherit that type automatically
- **P0-B**: Resolve `<typeAlias alias="account" type="testdomain.Account" />` so DTO field types are looked up correctly; short class names also resolved via file search

## Before → After

| Scenario | Before | After |
|---|---|---|
| `parameterClass="java.lang.Integer"` | `__XML_PARAM_value__` | `__XML_PARAM_INTEGER_value__` |
| `parameterClass="int"` | `__XML_PARAM_value__` | `__XML_PARAM_INTEGER_value__` |
| `parameterClass="account"` (typeAlias) | no DTO lookup | resolves to `testdomain.Account` → fields typed |
| `parameterClass="account"` + `${id}` | `__XML_RAW_id__` | `__XML_RAW_INTEGER_id__` |

Inference coverage on iBatis Account.xml: **15/19 untyped params → typed** (38 statements, 34 now with full type info)

## Changes

- `types.rs`: Add `type_aliases` field to `MapperFile`, add `ParameterClass` inference source
- `parser.rs`: Collect `<typeAlias>` elements during XML parsing
- `resolver.rs`: Propagate `type_aliases` through include resolution
- `mod.rs`: New inference priority — `parameterClass` simple type detection + typeAlias expansion + short-name resolve-by-class-name

## Test plan

- [x] `cargo test --features full` — 1227 passed
- [x] Verified against `lib/ibatis-2/src/test/resources/com/ibatis/sqlmap/maps/Account.xml` with `--java-src`
- [x] 4 remaining untyped statements have no type info source (no `parameterClass`) — expected