### PR TITLE
feat(java): infer JDBC ? placeholder types and names from setXxx() calls

### DIFF
--- a/src/java/constant.rs
+++ b/src/java/constant.rs
@@ -32,6 +32,29 @@ pub(super) const SQL_METHOD_UNAMBIGUOUS: &[&str] = &[
 
 pub(super) const SQL_METHOD_AMBIGUOUS: &[&str] = &["query", "update", "execute"];
 
+pub(super) const JDBC_SETTER_TYPES: &[(&str, &str)] = &[
+    ("setString", "String"),
+    ("setInt", "int"),
+    ("setLong", "long"),
+    ("setDouble", "double"),
+    ("setFloat", "float"),
+    ("setShort", "short"),
+    ("setByte", "byte"),
+    ("setBoolean", "boolean"),
+    ("setDate", "Date"),
+    ("setTime", "Time"),
+    ("setTimestamp", "Timestamp"),
+    ("setBigDecimal", "BigDecimal"),
+    ("setBytes", "byte[]"),
+    ("setBlob", "Blob"),
+    ("setClob", "Clob"),
+    ("setNClob", "NClob"),
+    ("setBinaryStream", "InputStream"),
+    ("setCharacterStream", "Reader"),
+    ("setAsciiStream", "InputStream"),
+    ("setURL", "URL"),
+];
+
 pub(super) const SQL_KEYWORDS: &[&str] = &[
     "SELECT ",
     "INSERT ",

--- a/src/java/extract.rs
+++ b/src/java/extract.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use tree_sitter::Node;
 
-use super::types::JavaExtractConfig;
+use super::types::{JavaExtractConfig, JdbcParamInfo};
 use crate::java::error::JavaError;
 use crate::java::types::*;
 
@@ -31,6 +31,8 @@ pub fn extract(
         method_name: None,
         sql_vars: HashMap::new(),
         var_types: HashMap::new(),
+        jdbc_param_map: HashMap::new(),
+        ps_var_to_extraction: HashMap::new(),
         extra_sql_methods: &config.extra_sql_methods,
     };
     ctx.visit(root);
@@ -55,6 +57,10 @@ pub(super) struct ExtractContext<'a> {
     pub(super) method_name: Option<String>,
     pub(super) sql_vars: HashMap<String, TrackedVar>,
     pub(super) var_types: HashMap<String, String>,
+    /// Tracks setXxx calls: (ps_var_name, param_index) → inferred info.
+    pub(super) jdbc_param_map: HashMap<(String, usize), JdbcParamInfo>,
+    /// Maps PreparedStatement variable name → extraction index for backfill.
+    pub(super) ps_var_to_extraction: HashMap<String, usize>,
     pub(super) extra_sql_methods: &'a [String],
 }
 
@@ -107,6 +113,8 @@ impl<'a> ExtractContext<'a> {
         let old_method = self.method_name.clone();
         let old_sql_vars = std::mem::take(&mut self.sql_vars);
         let old_var_types = std::mem::take(&mut self.var_types);
+        let old_jdbc_param_map = std::mem::take(&mut self.jdbc_param_map);
+        let old_ps_var_to_extraction = std::mem::take(&mut self.ps_var_to_extraction);
         if let Some(name_node) = node.child_by_field_name("name") {
             self.method_name = Some(self.node_text(name_node));
         }
@@ -161,9 +169,14 @@ impl<'a> ExtractContext<'a> {
             }
         }
 
+        // Backfill JDBC parameter type/name inference from setXxx() calls
+        self.backfill_jdbc_params();
+
         self.method_name = old_method;
         self.sql_vars = old_sql_vars;
         self.var_types = old_var_types;
+        self.jdbc_param_map = old_jdbc_param_map;
+        self.ps_var_to_extraction = old_ps_var_to_extraction;
     }
 
     pub(super) fn recurse(&mut self, node: Node) {
@@ -316,6 +329,34 @@ impl<'a> ExtractContext<'a> {
         }
     }
 
+    /// If this method_invocation is the RHS of a variable declaration or assignment,
+    /// return the LHS variable name by walking up the CST.
+    pub(super) fn find_assignment_target(&self, node: Node) -> Option<String> {
+        let mut current = node;
+        loop {
+            let parent = current.parent()?;
+            match parent.kind() {
+                "variable_declarator" => {
+                    if let Some(name_node) = parent.child_by_field_name("name") {
+                        return Some(self.node_text(name_node));
+                    }
+                    return None;
+                }
+                "assignment_expression" => {
+                    let left = parent.child_by_field_name("left")?;
+                    if left.kind() == "identifier" {
+                        return Some(self.node_text(left));
+                    }
+                    return None;
+                }
+                "argument_list" | "field_access" | "method_invocation" => {
+                    current = parent;
+                }
+                _ => return None,
+            }
+        }
+    }
+
     fn infer_expression_type(&self, node: Node) -> Option<String> {
         match node.kind() {
             "identifier" => self.var_types.get(&self.node_text(node)).cloned(),
@@ -354,6 +395,43 @@ impl<'a> ExtractContext<'a> {
             }
             "string_literal" => Some("String".to_string()),
             _ => None,
+        }
+    }
+
+    /// After collecting setXxx() info, replace __JAVA_VAR_JDBC_PARAM_N__
+    /// with __JAVA_VAR_{Type}_{name}__ in the extracted SQL.
+    pub(super) fn backfill_jdbc_params(&mut self) {
+        let mut to_reparse: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+        for ((ps_var, _param_idx), info) in &self.jdbc_param_map {
+            let ext_idx = match self.ps_var_to_extraction.get(ps_var) {
+                Some(&idx) => idx,
+                None => continue,
+            };
+            let ext = match self.extractions.get_mut(ext_idx) {
+                Some(e) => e,
+                None => continue,
+            };
+
+            let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", info.index);
+            let new = match &info.var_name {
+                Some(name) => format!("__JAVA_VAR_{}_{}__", info.java_type, sanitize_var_name(name)),
+                None => format!("__JAVA_VAR_{}_JDBC_PARAM_{}__", info.java_type, info.index),
+            };
+            ext.sql = ext.sql.replace(&old, &new);
+            to_reparse.insert(ext_idx);
+        }
+
+        // Re-parse modified extractions
+        for idx in to_reparse {
+            let (sql, sql_kind) = {
+                let ext = &self.extractions[idx];
+                (ext.sql.clone(), ext.sql_kind)
+            };
+            let parse_result = self.try_parse_sql(&sql, sql_kind);
+            if let Some(ext) = self.extractions.get_mut(idx) {
+                ext.parse_result = parse_result;
+            }
         }
     }
 

--- a/src/java/method_call.rs
+++ b/src/java/method_call.rs
@@ -2,9 +2,10 @@
 
 use tree_sitter::Node;
 
-use super::constant::{SQL_METHOD_AMBIGUOUS, SQL_METHOD_UNAMBIGUOUS};
+use super::constant::{JDBC_SETTER_TYPES, SQL_METHOD_AMBIGUOUS, SQL_METHOD_UNAMBIGUOUS};
 use super::extract::ExtractContext;
 use super::heuristics::{detect_parameter_style, looks_like_sql};
+use super::types::JdbcParamInfo;
 use crate::java::types::*;
 
 impl<'a> ExtractContext<'a> {
@@ -26,6 +27,19 @@ impl<'a> ExtractContext<'a> {
             }
         }
 
+        // Intercept JDBC setter calls (setString, setInt, etc.)
+        if method_name.starts_with("set") && method_name.len() > 3 {
+            let next_char = method_name.chars().nth(3).unwrap();
+            if next_char.is_ascii_uppercase() {
+                if let Some(root_var) = self.find_method_chain_root(node) {
+                    if self.ps_var_to_extraction.contains_key(&root_var) {
+                        self.visit_setter_call(node, &method_name);
+                        return;
+                    }
+                }
+            }
+        }
+
         let is_unambiguous = SQL_METHOD_UNAMBIGUOUS.contains(&method_name.as_str())
             || self.extra_sql_methods.iter().any(|m| m == &method_name);
         let is_ambiguous = SQL_METHOD_AMBIGUOUS.contains(&method_name.as_str());
@@ -42,6 +56,8 @@ impl<'a> ExtractContext<'a> {
             Some(n) if n.kind() == "argument_list" => n,
             _ => return,
         };
+
+        let mut pushed_extraction_idx: Option<usize> = None;
 
         if let Some((sql_text, is_text_block)) = self.find_first_string_arg(&args_node) {
             if !is_unambiguous && !looks_like_sql(&sql_text) {
@@ -63,7 +79,7 @@ impl<'a> ExtractContext<'a> {
                     class_name: self.class_name.clone(),
                     method_name: self.method_name.clone(),
                     annotation_name: None,
-                    api_method_name: Some(method_name),
+                    api_method_name: Some(method_name.clone()),
                     variable_name: None,
                     line: node.start_position().row + 1,
                     column: node.start_position().column,
@@ -74,6 +90,34 @@ impl<'a> ExtractContext<'a> {
                 is_text_block,
                 parse_result,
             });
+            pushed_extraction_idx = Some(self.extractions.len() - 1);
+        }
+
+        // Track PreparedStatement variable → extraction mapping
+        if method_name == "prepareStatement" || method_name == "prepareCall" {
+            if let Some(target_var) = self.find_assignment_target(node) {
+                let extraction_idx = match pushed_extraction_idx {
+                    Some(idx) => Some(idx),
+                    None => {
+                        // First arg may be a tracked SQL variable; resolve its extraction index
+                        let mut cursor = args_node.walk();
+                        let mut found = None;
+                        for child in args_node.children(&mut cursor) {
+                            if child.kind() == "identifier" {
+                                let arg_name = self.node_text(child);
+                                if let Some(tracked) = self.sql_vars.get(&arg_name) {
+                                    found = Some(tracked.extraction_index);
+                                    break;
+                                }
+                            }
+                        }
+                        found
+                    }
+                };
+                if let Some(idx) = extraction_idx {
+                    self.ps_var_to_extraction.insert(target_var, idx);
+                }
+            }
         }
 
         let mut cursor = node.walk();
@@ -93,5 +137,87 @@ impl<'a> ExtractContext<'a> {
             }
         }
         None
+    }
+
+    /// Handle `ps.setXxx(index, value)` calls to infer `?` placeholder types.
+    pub(super) fn visit_setter_call(&mut self, node: Node, method_name: &str) {
+        // Determine Java type from setter method name
+        let java_type = match JDBC_SETTER_TYPES.iter().find(|(m, _)| *m == method_name) {
+            Some((_, t)) => t.to_string(),
+            None => {
+                if method_name == "setObject" {
+                    "Object".to_string()
+                } else {
+                    return;
+                }
+            }
+        };
+
+        let args_node = match node.child_by_field_name("arguments") {
+            Some(n) if n.kind() == "argument_list" => n,
+            _ => return,
+        };
+
+        // Extract arguments: first is index (int literal), second is value
+        let mut args = Vec::new();
+        {
+            let mut cursor = args_node.walk();
+            for child in args_node.children(&mut cursor) {
+                if child.kind() != "," && child.kind() != "(" && child.kind() != ")" {
+                    args.push(child);
+                }
+            }
+        }
+
+        if args.len() < 2 {
+            return;
+        }
+
+        // Parse parameter index
+        let idx_text = self.node_text(args[0]);
+        let param_index: usize = match idx_text.trim().parse() {
+            Ok(n) => n,
+            Err(_) => return,
+        };
+
+        // Extract variable name from value argument
+        let value_node = args[1];
+        let var_name = self.extract_setter_value_name(value_node);
+
+        // Find the PreparedStatement variable name
+        let ps_var = match self.find_method_chain_root(node) {
+            Some(v) => v,
+            None => return,
+        };
+
+        // Only track if this PS variable is known
+        if !self.ps_var_to_extraction.contains_key(&ps_var) {
+            return;
+        }
+
+        self.jdbc_param_map.insert(
+            (ps_var, param_index),
+            JdbcParamInfo {
+                index: param_index,
+                java_type,
+                var_name,
+            },
+        );
+    }
+
+    /// Extract a variable name from the setter value argument.
+    fn extract_setter_value_name(&self, node: Node) -> Option<String> {
+        match node.kind() {
+            "identifier" => Some(self.node_text(node)),
+            "field_access" => {
+                let text = self.node_text(node);
+                let parts: Vec<&str> = text.rsplitn(2, '.').collect();
+                Some(parts[0].to_string())
+            }
+            "method_invocation" => {
+                node.child_by_field_name("name").map(|n| self.node_text(n))
+            }
+            _ => None,
+        }
     }
 }

--- a/src/java/tests.rs
+++ b/src/java/tests.rs
@@ -312,7 +312,7 @@ fn test_prepare_statement() {
     assert_eq!(result.extractions.len(), 1);
     let ext = &result.extractions[0];
     assert!(ext.sql.contains("DELETE FROM users"));
-    assert!(ext.sql.contains("__JAVA_VAR_JDBC_PARAM_1__"));
+    assert!(ext.sql.contains("__JAVA_VAR_String_id__"), "SQL: {}", ext.sql);
     assert_eq!(
         ext.origin.api_method_name.as_deref(),
         Some("prepareStatement")
@@ -1185,4 +1185,201 @@ public class User {
     assert_eq!(fields.get("salary").unwrap(), "BigDecimal");
     assert_eq!(fields.get("createTime").unwrap(), "Date");
     assert_eq!(fields.get("active").unwrap(), "boolean");
+}
+
+// ── JDBC Parameter Type Inference Tests ──
+
+#[test]
+fn test_jdbc_setString_inference() {
+    let java = r#"
+        public class UserDao {
+            public void insert(String seqId, String zipName) {
+                String sqlSub = "INSERT INTO dat_mail_aas_attachment (SEQ_ID,FILE_NAME,FILE_CONTENT) VALUES (?,?, empty_blob())";
+                PreparedStatement st = conn.prepareStatement(sqlSub);
+                st.setString(1, seqId);
+                st.setString(2, zipName);
+                st.execute();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "UserDao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_seqId__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_zipName__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_setInt_inference() {
+    let java = r#"
+        public class Dao {
+            public void query(int id, String name) {
+                PreparedStatement ps = conn.prepareStatement("SELECT * FROM t WHERE id = ? AND name = ?");
+                ps.setInt(1, id);
+                ps.setString(2, name);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_int_id__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_name__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_multiple_types() {
+    let java = r#"
+        public class Dao {
+            public void insert(String name, int age, BigDecimal salary) {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO emp (name, age, salary) VALUES (?, ?, ?)");
+                ps.setString(1, name);
+                ps.setInt(2, age);
+                ps.setBigDecimal(3, salary);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_name__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_int_age__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_BigDecimal_salary__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_no_setter_falls_back_to_param_n() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                PreparedStatement ps = conn.prepareStatement("SELECT * FROM t WHERE id = ?");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_JDBC_PARAM_1__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_String_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_partial_setter_inference() {
+    let java = r#"
+        public class Dao {
+            public void query(String name, int age) {
+                PreparedStatement ps = conn.prepareStatement("SELECT * FROM t WHERE name = ? AND age = ?");
+                ps.setString(1, name);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_name__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_JDBC_PARAM_2__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_setter_out_of_order() {
+    let java = r#"
+        public class Dao {
+            public void query(String name, int id) {
+                PreparedStatement ps = conn.prepareStatement("SELECT * FROM t WHERE id = ? AND name = ?");
+                ps.setString(2, name);
+                ps.setInt(1, id);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("id = __JAVA_VAR_int_id__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("name = __JAVA_VAR_String_name__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_two_prepared_statements_same_method() {
+    let java = r#"
+        public class Dao {
+            public void batch(String a, String b) {
+                PreparedStatement ps1 = conn.prepareStatement("INSERT INTO t1 (v) VALUES (?)");
+                ps1.setString(1, a);
+                PreparedStatement ps2 = conn.prepareStatement("INSERT INTO t2 (v) VALUES (?)");
+                ps2.setString(1, b);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let insert_t1 = result.extractions.iter().find(|e| e.sql.contains("t1")).unwrap();
+    let insert_t2 = result.extractions.iter().find(|e| e.sql.contains("t2")).unwrap();
+    assert!(insert_t1.sql.contains("__JAVA_VAR_String_a__"), "SQL: {}", insert_t1.sql);
+    assert!(insert_t2.sql.contains("__JAVA_VAR_String_b__"), "SQL: {}", insert_t2.sql);
+}
+
+#[test]
+fn test_jdbc_exact_user_example() {
+    let java = r#"
+        public class AutoSendReport {
+            public void run(String seqId, String zipName) {
+                String sqlSub="INSERT INTO dat_mail_aas_attachment (SEQ_ID,FILE_NAME,FILE_CONTENT) VALUES (?,?, empty_blob())";
+                PreparedStatement st = conn.prepareStatement(sqlSub);
+                st.setString(1, seqId);
+                st.setString(2, zipName);
+                st.execute();
+                conn.commit();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "AutoSendReport.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO dat_mail_aas_attachment")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_seqId__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_zipName__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_setter_with_literal_value() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                PreparedStatement ps = conn.prepareStatement("SELECT * FROM t WHERE status = ?");
+                ps.setString(1, "active");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_JDBC_PARAM_1__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_sql_constant_with_prepare_statement() {
+    let java = r#"
+        public class Dao {
+            public void query(int id) {
+                String sql = "SELECT * FROM t WHERE id = ?";
+                PreparedStatement ps = conn.prepareStatement(sql);
+                ps.setInt(1, id);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_int_id__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_jdbc_ambiguous_method_sql_not_affected() {
+    let java = r#"
+        public class Dao {
+            public void run() {
+                jdbc.query("SELECT * FROM users WHERE id = ?");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_JDBC_PARAM_1__"));
 }

--- a/src/java/types.rs
+++ b/src/java/types.rs
@@ -68,3 +68,11 @@ pub struct JavaExtractConfig {
     /// Additional method names to treat as unambiguous SQL carriers.
     pub extra_sql_methods: Vec<String>,
 }
+
+/// Inferred type/name info for a JDBC `?` parameter, derived from `setXxx()` calls.
+#[derive(Debug, Clone)]
+pub(super) struct JdbcParamInfo {
+    pub(super) index: usize,
+    pub(super) java_type: String,
+    pub(super) var_name: Option<String>,
+}


### PR DESCRIPTION
## Summary

- Infer Java type and variable name for JDBC `?` placeholders by analyzing `setXxx(index, value)` calls that follow `prepareStatement()`
- Replace `__JAVA_VAR_JDBC_PARAM_N__` with `__JAVA_VAR_{Type}_{name}__` (e.g., `setString(1, seqId)` → `__JAVA_VAR_String_seqId__`)
- Handles: direct string args, SQL variable references, out-of-order setters, multiple PreparedStatements per method, 19 setter types
- Falls back gracefully to `JDBC_PARAM_N` when no setter call is found

## Example

**Before:**
```
INSERT INTO dat_mail_aas_attachment (SEQ_ID,FILE_NAME,FILE_CONTENT) VALUES (__JAVA_VAR_JDBC_PARAM_1__,__JAVA_VAR_JDBC_PARAM_2__, empty_blob())
```

**After** (with `st.setString(1, seqId); st.setString(2, zipName);`):
```
INSERT INTO dat_mail_aas_attachment (SEQ_ID,FILE_NAME,FILE_CONTENT) VALUES (__JAVA_VAR_String_seqId__,__JAVA_VAR_String_zipName__, empty_blob())
```

## Test Plan
- [x] 11 new tests: mixed setter types, partial inference, out-of-order setters, multiple PS vars, literal values, variable references
- [x] All 1181 tests pass (0 regressions)
- [x] `cargo test --features java` green