### PR TITLE
fix(java): backfill JDBC params incrementally when PS variable is reused

### DIFF
--- a/src/java/extract.rs
+++ b/src/java/extract.rs
@@ -398,6 +398,61 @@ impl<'a> ExtractContext<'a> {
         }
     }
 
+    /// Backfill a single PS variable's old binding before its mapping is overwritten.
+    pub(super) fn backfill_for_ps_var(&mut self, ps_var: &str, ext_idx: usize) {
+        let keys: Vec<(String, usize)> = self
+            .jdbc_param_map
+            .keys()
+            .filter(|(v, _)| v == ps_var)
+            .cloned()
+            .collect();
+
+        if keys.is_empty() {
+            return;
+        }
+
+        let mut modified = false;
+        for key in &keys {
+            let info = match self.jdbc_param_map.get(key) {
+                Some(i) => i,
+                None => continue,
+            };
+            let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", info.index);
+            let new = match &info.var_name {
+                Some(name) => format!(
+                    "__JAVA_VAR_{}_{}__",
+                    info.java_type,
+                    sanitize_var_name(name)
+                ),
+                None => format!(
+                    "__JAVA_VAR_{}_JDBC_PARAM_{}__",
+                    info.java_type,
+                    info.index
+                ),
+            };
+            if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                let before = ext.sql.len();
+                ext.sql = ext.sql.replace(&old, &new);
+                modified |= ext.sql.len() != before;
+            }
+        }
+
+        for key in keys {
+            self.jdbc_param_map.remove(&key);
+        }
+
+        if modified {
+            if let Some(ext) = self.extractions.get(ext_idx) {
+                let sql = ext.sql.clone();
+                let sql_kind = ext.sql_kind;
+                let parse_result = self.try_parse_sql(&sql, sql_kind);
+                if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                    ext.parse_result = parse_result;
+                }
+            }
+        }
+    }
+
     /// After collecting setXxx() info, replace __JAVA_VAR_JDBC_PARAM_N__
     /// with __JAVA_VAR_{Type}_{name}__ in the extracted SQL.
     pub(super) fn backfill_jdbc_params(&mut self) {

--- a/src/java/method_call.rs
+++ b/src/java/method_call.rs
@@ -115,6 +115,9 @@ impl<'a> ExtractContext<'a> {
                     }
                 };
                 if let Some(idx) = extraction_idx {
+                    if let Some(&old_idx) = self.ps_var_to_extraction.get(&target_var) {
+                        self.backfill_for_ps_var(&target_var, old_idx);
+                    }
                     self.ps_var_to_extraction.insert(target_var, idx);
                 }
             }

--- a/src/java/tests.rs
+++ b/src/java/tests.rs
@@ -1383,3 +1383,90 @@ fn test_jdbc_ambiguous_method_sql_not_affected() {
     assert_eq!(result.extractions.len(), 1);
     assert!(result.extractions[0].sql.contains("__JAVA_VAR_JDBC_PARAM_1__"));
 }
+
+#[test]
+fn test_jdbc_reused_ps_variable_both_backfilled() {
+    let java = r#"
+        public class Dao {
+            public void batch(String seqId, String zipName, String status) {
+                String sql1 = "INSERT INTO dat_mail_aas_attachment (SEQ_ID,FILE_NAME,FILE_CONTENT) VALUES (?,?, empty_blob())";
+                PreparedStatement st = conn.prepareStatement(sql1);
+                st.setString(1, seqId);
+                st.setString(2, zipName);
+                st.execute();
+
+                String sql2 = "UPDATE dat_mail_aas_attachment SET FILE_NAME = ? WHERE SEQ_ID = ?";
+                st = conn.prepareStatement(sql2);
+                st.setString(1, zipName);
+                st.setString(2, seqId);
+                st.executeUpdate();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let insert_ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO")).unwrap();
+    assert!(
+        insert_ext.sql.contains("__JAVA_VAR_String_seqId__"),
+        "INSERT should have backfilled param 1, got: {}",
+        insert_ext.sql
+    );
+    assert!(
+        insert_ext.sql.contains("__JAVA_VAR_String_zipName__"),
+        "INSERT should have backfilled param 2, got: {}",
+        insert_ext.sql
+    );
+    assert!(
+        !insert_ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"),
+        "INSERT should have no unresolved placeholders, got: {}",
+        insert_ext.sql
+    );
+
+    let update_ext = result.extractions.iter().find(|e| e.sql.contains("UPDATE")).unwrap();
+    assert!(
+        update_ext.sql.contains("__JAVA_VAR_String_zipName__"),
+        "UPDATE should have backfilled param 1, got: {}",
+        update_ext.sql
+    );
+    assert!(
+        update_ext.sql.contains("__JAVA_VAR_String_seqId__"),
+        "UPDATE should have backfilled param 2, got: {}",
+        update_ext.sql
+    );
+}
+
+#[test]
+fn test_jdbc_reused_ps_variable_three_rounds() {
+    let java = r#"
+        public class Dao {
+            public void multi(String x, String y, String z) {
+                String sql1 = "INSERT INTO t1 (v) VALUES (?)";
+                PreparedStatement ps = conn.prepareStatement(sql1);
+                ps.setString(1, x);
+                ps.execute();
+
+                String sql2 = "INSERT INTO t2 (v) VALUES (?)";
+                ps = conn.prepareStatement(sql2);
+                ps.setString(1, y);
+                ps.execute();
+
+                String sql3 = "INSERT INTO t3 (v) VALUES (?)";
+                ps = conn.prepareStatement(sql3);
+                ps.setString(1, z);
+                ps.execute();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    assert_eq!(result.extractions.len(), 3);
+
+    let t1 = result.extractions.iter().find(|e| e.sql.contains("t1")).unwrap();
+    assert!(t1.sql.contains("__JAVA_VAR_String_x__"), "t1: {}", t1.sql);
+
+    let t2 = result.extractions.iter().find(|e| e.sql.contains("t2")).unwrap();
+    assert!(t2.sql.contains("__JAVA_VAR_String_y__"), "t2: {}", t2.sql);
+
+    let t3 = result.extractions.iter().find(|e| e.sql.contains("t3")).unwrap();
+    assert!(t3.sql.contains("__JAVA_VAR_String_z__"), "t3: {}", t3.sql);
+}


### PR DESCRIPTION
## Summary
- Fix JDBC parameter type backfill lost when the same PreparedStatement variable is reused across multiple prepareStatement() calls
- Add incremental backfill at collision detection point instead of relying solely on method-end batch processing

## Problem
When Java code reuses a PS variable name (e.g. st) for multiple prepareStatement() calls, both ps_var_to_extraction and jdbc_param_map are HashMaps whose insert overwrites previous entries. The first SQL placeholders remain unresolved as __JAVA_VAR_JDBC_PARAM_N__.

## Fix
In method_call.rs, when prepareStatement/prepareCall detects the target PS variable already has a mapping:
1. Immediately backfill the old extraction using collected setXxx() info
2. Drain consumed jdbc_param_map entries for that PS variable
3. Then insert the new mapping

The existing method-end backfill_jdbc_params() remains as safety net for the last PS binding.

## Test plan
- [x] New test: test_jdbc_reused_ps_variable_both_backfilled - 2 rounds of PS reuse, both backfilled
- [x] New test: test_jdbc_reused_ps_variable_three_rounds - 3 rounds, all backfilled
- [x] All 1183 existing tests pass with 0 regressions
- [x] End-to-end CLI verified: same-var, different-var, single-statement, three-round scenarios