### PR TITLE
feat(java): cross-method JDBC param inference with String[] mapping and dynamic setters

### DIFF
--- a/docs/plans/2026-05-07-cross-method-jdbc-param-inference.md
+++ b/docs/plans/2026-05-07-cross-method-jdbc-param-inference.md
@@ -1,0 +1,492 @@
+# Cross-Method JDBC Parameter Inference
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Support JDBC `?` placeholder type/name inference across three patterns: `String[]` argument mapping (Pattern C), cross-method PS passing (Pattern B), and dynamic loop indexing.
+
+**Architecture:** Two-phase approach. Phase 1 (P1) handles `String[]` array argument resolution within a single method call — when `DbService.executeQuery(sql, new String[]{node})` is seen, map array elements to `?` in the referenced SQL constant. Phase 2 (P2) adds cross-method PS flow via a file-scoped method behavior index — each method records what it does with PS parameters, then call sites resolve and inject.
+
+**Tech Stack:** Rust, tree-sitter (Java CST), existing `ExtractContext` architecture.
+
+**Branch:** `feat/cross-method-jdbc-param-inference` (from `main`)
+
+---
+
+## Phase 1 (P1): String[] Argument Mapping
+
+Handle `DbService.executeQuery("ORACLEJDBC", SQL_CONSTANT, new String[] {node})` — parameters are in the same call expression as the SQL reference.
+
+### Task 1: Resolve tracked SQL variable in unambiguous method arguments
+
+Currently `find_first_string_arg` only matches `string_literal` / `binary_expression`. When the argument is an `identifier` that references a tracked SQL variable (e.g., `QUERY_MENU_SQL`), we need to recognize it and link to the existing extraction.
+
+**Files:**
+- Modify: `src/java/method_call.rs:55-94` (the `find_first_string_arg` / extraction push block)
+- Test: `src/java/tests.rs`
+
+**Step 1: Write the failing test**
+
+```rust
+#[test]
+fn test_sql_constant_referenced_in_method_call() {
+    let java = r#"
+        public class Dao {
+            private static final String SQL = "SELECT * FROM t WHERE id = ?";
+            public void query(String nodeId) {
+                List list = DbService.executeQuery("ORACLEJDBC", SQL, new String[] {nodeId});
+            }
+        }
+    "#;
+    let mut config = JavaExtractConfig::default();
+    config.extra_sql_methods = vec!["executeQuery".to_string()];
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    assert_eq!(result.extractions.len(), 1);
+    let ext = &result.extractions[0];
+    assert!(ext.sql.contains("__JAVA_VAR_String_nodeId__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test --features java test_sql_constant_referenced_in_method_call`
+Expected: FAIL — `__JAVA_VAR_JDBC_PARAM_1__` remains unresolved
+
+**Step 3: Implement SQL variable argument resolution**
+
+In `visit_method_invocation`, after the `find_first_string_arg` block (line 94), add a new block: when `pushed_extraction_idx` is `None` and an argument is an `identifier` found in `sql_vars`, resolve to that tracked variable's extraction index. Do NOT create a duplicate extraction — reuse the existing one.
+
+Then, scan remaining arguments for `array_creation_expression` patterns like `new String[] {var1, var2}` or `new Object[] {var1, var2}`. Extract element names from the array initializer. Map them positionally to `__JAVA_VAR_JDBC_PARAM_N__` in the linked extraction. Re-parse the modified SQL.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test --features java test_sql_constant_referenced_in_method_call`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/java/method_call.rs src/java/tests.rs
+git commit -m "feat(java): resolve SQL constant + String[] args in utility method calls"
+```
+
+### Task 2: Handle `new String[] {var}` array argument parsing
+
+Add a helper to extract variable names from `new String[] {a, b, c}` and `new Object[] {a, b, c}` array creation expressions.
+
+**Files:**
+- Modify: `src/java/method_call.rs`
+- Test: `src/java/tests.rs`
+
+**Step 1: Write failing tests for array arg variants**
+
+```rust
+#[test]
+fn test_array_args_multiple_params() {
+    let java = r#"
+        public class Dao {
+            private static final String SQL = "SELECT * FROM t WHERE a = ? AND b = ?";
+            public void query(String x, String y) {
+                DbService.executeQuery("DB", SQL, new String[] {x, y});
+            }
+        }
+    "#;
+    let mut config = JavaExtractConfig::default();
+    config.extra_sql_methods = vec!["executeQuery".to_string()];
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_x__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_y__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_array_args_object_array() {
+    let java = r#"
+        public class Dao {
+            private static final String SQL = "SELECT * FROM t WHERE id = ?";
+            public void query(int id) {
+                DbService.executeQuery("DB", SQL, new Object[] {id});
+            }
+        }
+    "#;
+    let mut config = JavaExtractConfig::default();
+    config.extra_sql_methods = vec!["executeQuery".to_string()];
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_int_id__"), "SQL: {}", ext.sql);
+}
+```
+
+**Step 2: Run tests — expect FAIL**
+
+**Step 3: Implement `extract_array_element_names` helper**
+
+Parse `array_creation_expression` nodes: walk into the `element_list` child, extract identifiers from each element. For elements that aren't simple identifiers (e.g., method calls, field access), use the existing `make_placeholder_for_node`.
+
+**Step 4: Run tests — expect PASS**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(java): parse String[]/Object[] array args for parameter inference"
+```
+
+### Task 3: Inline SQL + inline array args
+
+Handle the case where SQL is an inline string literal (not a constant) AND parameters are an inline array: `DbService.executeQuery("DB", "SELECT * FROM t WHERE id = ?", new String[]{x})`.
+
+**Files:**
+- Modify: `src/java/method_call.rs`
+- Test: `src/java/tests.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_inline_sql_with_inline_array_args() {
+    let java = r#"
+        public class Dao {
+            public void query(String nodeId) {
+                DbService.executeQuery("DB", "SELECT * FROM t WHERE id = ?", new String[] {nodeId});
+            }
+        }
+    "#;
+    let mut config = JavaExtractConfig::default();
+    config.extra_sql_methods = vec!["executeQuery".to_string()];
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    assert_eq!(result.extractions.len(), 1);
+    let ext = &result.extractions[0];
+    assert!(ext.sql.contains("__JAVA_VAR_String_nodeId__"), "SQL: {}", ext.sql);
+}
+```
+
+**Step 2: Run test — expect FAIL** (currently creates extraction with unresolved JDBC_PARAM)
+
+**Step 3: Extend the extraction push block**
+
+After creating a new extraction from an inline string arg, also scan remaining arguments for `array_creation_expression`. If found, immediately apply the array elements as backfill to the just-pushed extraction.
+
+**Step 4: Run test — expect PASS**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(java): backfill params from inline String[] in same call"
+```
+
+### Task 4: Verify Phase 1 with real-world pattern
+
+Test the exact user scenario: `static final` SQL constants + `DbService.executeQuery` + `String[]` args.
+
+**Files:**
+- Test: `src/java/tests.rs`
+
+**Step 1: Write integration test**
+
+```rust
+#[test]
+fn test_ebms_pattern_two_sql_constants() {
+    let java = r#"
+        public class EBMSHandler {
+            private static final String SWITCH_SQL = "SELECT KIND_ID FROM ebk_dic_all_kind t WHERE t.operation_kind = 'PI00168_SWITCH'";
+            private static final String QUERY_MENU_SQL = "SELECT t.node_id, t.node_name, t.edition FROM par_netuser_menu_tree t WHERE t.node_id = ?";
+
+            public int execute(String node) throws Exception {
+                List list1 = DbService.executeQuery("ORACLEJDBC", SWITCH_SQL);
+                List list2 = DbService.executeQuery("ORACLEJDBC", QUERY_MENU_SQL, new String[] {node});
+                return 0;
+            }
+        }
+    "#;
+    let mut config = JavaExtractConfig::default();
+    config.extra_sql_methods = vec!["executeQuery".to_string()];
+    let result = extract_sql_from_java(java, "EBMSHandler.java", &config);
+    assert_eq!(result.extractions.len(), 2);
+
+    let switch = result.extractions.iter().find(|e| e.sql.contains("SWITCH") || e.sql.contains("ebk_dic_all_kind")).unwrap();
+    assert!(!switch.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SWITCH_SQL has no params: {}", switch.sql);
+
+    let menu = result.extractions.iter().find(|e| e.sql.contains("par_netuser_menu_tree")).unwrap();
+    assert!(menu.sql.contains("__JAVA_VAR_String_node__"), "QUERY_MENU_SQL should resolve ?: {}", menu.sql);
+    assert!(!menu.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "QUERY_MENU_SQL should have no unresolved: {}", menu.sql);
+}
+```
+
+**Step 2: Run all tests**
+
+Run: `cargo test --features java`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git commit -m "test(java): integration test for DbService.executeQuery pattern"
+```
+
+---
+
+## Phase 2 (P2): Cross-Method PreparedStatement Flow
+
+Handle `ps = conn.prepareStatement(sql); submitData(ps, list);` where `submitData` calls `ps.setString` in another method.
+
+### Task 5: Add file-scoped method behavior index
+
+Introduce a `HashMap<String, MethodPsBehavior>` to `ExtractContext` that persists across method boundaries (not saved/restored in `visit_method_declaration`).
+
+**Files:**
+- Modify: `src/java/types.rs` — add `MethodPsBehavior`, `SetterPattern` types
+- Modify: `src/java/extract.rs` — add `method_behaviors` field to `ExtractContext`, NOT included in save/restore
+
+**Step 1: Define types**
+
+In `src/java/types.rs`:
+
+```rust
+/// Recorded behavior of a method on its PreparedStatement parameter.
+#[derive(Debug, Clone)]
+pub(super) struct MethodPsBehavior {
+    pub(super) ps_param_index: usize,
+    pub(super) ps_param_name: String,
+    pub(super) setter_patterns: Vec<SetterPattern>,
+}
+
+/// Pattern of a setXxx call on a PS parameter.
+#[derive(Debug, Clone)]
+pub(super) enum SetterPattern {
+    /// Literal index: ps.setString(1, name)
+    Literal {
+        index: usize,
+        java_type: String,
+        var_name: Option<String>,
+    },
+    /// Dynamic loop: ps.setString(i+1, arr[i])
+    DynamicLoop {
+        java_type: String,
+    },
+}
+```
+
+**Step 2: Add field to ExtractContext**
+
+In `src/java/extract.rs`, add:
+```rust
+pub(super) method_behaviors: HashMap<String, MethodPsBehavior>,
+```
+
+Initialize in `extract()` as `HashMap::new()`. Do NOT include in `visit_method_declaration`'s save/restore (`old_*` / restore) — this field is file-scoped.
+
+**Step 3: Compile check**
+
+Run: `cargo build --features java`
+Expected: compiles (field unused is OK)
+
+**Step 4: Commit**
+
+```bash
+git commit -m "feat(java): add MethodPsBehavior types and file-scoped method_behaviors index"
+```
+
+### Task 6: Record method behavior for PS-receiving methods
+
+When a method has a `PreparedStatement` parameter and makes `setXxx` calls on it, record the behavior in `method_behaviors`.
+
+**Files:**
+- Modify: `src/java/extract.rs` — at end of `visit_method_declaration`, after `backfill_jdbc_params()`
+- Modify: `src/java/method_call.rs` — extend `visit_setter_call` to also record into a per-method accumulator
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_cross_method_ps_passing_literal_setters() {
+    let java = r#"
+        public class Dao {
+            public void process(String name, String email) {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (name, email) VALUES (?, ?)");
+                insertData(ps, name, email);
+            }
+
+            public static void insertData(PreparedStatement ps, String name, String email) {
+                ps.setString(1, name);
+                ps.setString(2, email);
+                ps.execute();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO t")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_name__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_email__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+```
+
+**Step 2: Run test — expect FAIL**
+
+**Step 3: Implement behavior recording + call site injection**
+
+Part A — Recording: In `visit_method_declaration`, after backfill, scan `jdbc_param_map` for entries where the PS var name matches a method parameter of type `PreparedStatement`. Collect those into a `MethodPsBehavior` and insert into `method_behaviors`.
+
+Part B — Injection: In `visit_method_invocation`, when we encounter a method call `someMethod(ps, ...)` where:
+1. `ps` is in `ps_var_to_extraction` (tracked PS variable)
+2. The method name is found in `method_behaviors`
+3. The argument position matches the `ps_param_index`
+
+Then apply the behavior's `setter_patterns` to the extraction referenced by `ps_var_to_extraction[ps_var]`.
+
+**Step 4: Run test — expect PASS**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(java): cross-method PS parameter inference via method behavior index"
+```
+
+### Task 7: Handle dynamic loop setter pattern
+
+Record `ps.setString(i+1, s[i])` as `DynamicLoop { java_type: "String" }` instead of ignoring it.
+
+**Files:**
+- Modify: `src/java/method_call.rs` — extend `visit_setter_call` for dynamic index detection
+- Test: `src/java/tests.rs`
+
+**Step 1: Write failing test**
+
+```rust
+#[test]
+fn test_cross_method_dynamic_loop_setter() {
+    let java = r#"
+        public class Dao {
+            public void process(List list) {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (a,b,c) VALUES (?,?,?)");
+                submitData(ps, list);
+            }
+
+            public static void submitData(PreparedStatement ps, List list) throws Exception {
+                for (Iterator it = list.iterator(); it.hasNext();) {
+                    String[] s = (String[]) it.next();
+                    for (int i = 0; i < s.length; i++) {
+                        ps.setString(i + 1, s[i]);
+                    }
+                    ps.addBatch();
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO t")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_1__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_2__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_3__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+```
+
+**Step 2: Run test — expect FAIL**
+
+**Step 3: Implement dynamic index detection**
+
+In `visit_setter_call`, when `args[0].trim().parse::<usize>()` fails, check if the index argument is a `binary_expression` like `i + 1` or `i + 1)`. If so, record as `SetterPattern::DynamicLoop` in a per-method accumulator (separate from `jdbc_param_map` which requires a literal index).
+
+In the behavior recording step (Task 6 Part A), include `DynamicLoop` entries.
+
+In the injection step (Task 6 Part B), when applying `DynamicLoop`, generate `__JAVA_VAR_{java_type}_DYNAMIC_N__` for each `?` in the SQL that wasn't already covered by a `Literal` pattern.
+
+**Step 4: Run test — expect PASS**
+
+**Step 5: Commit**
+
+```bash
+git commit -m "feat(java): dynamic loop setter pattern inference across methods"
+```
+
+### Task 8: Real-world integration test — full user scenario
+
+Test the exact `submitData` + `process` scenario from the user's code.
+
+**Files:**
+- Test: `src/java/tests.rs`
+
+**Step 1: Write test**
+
+```rust
+#[test]
+fn test_user_scenario_submit_data_cross_method() {
+    let java = r#"
+        public class DataProcessor {
+            public static void submitData(PreparedStatement ps, List list) throws Exception {
+                try {
+                    for (Iterator it = list.iterator(); it.hasNext();) {
+                        String[] s = (String[]) it.next();
+                        for (int i = 0; i < s.length; i++) {
+                            ps.setString(i + 1, s[i]);
+                        }
+                        ps.addBatch();
+                    }
+                    ps.executeBatch();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            public void process(List list, String accno) throws Exception {
+                ps = conn.prepareStatement("insert into dat_clnt_fv_tran " +
+                        "(ACCNO,BUSIDATE,SERIALNO,TRXCODE,DRCRF,SUMMARY,AMOUNT,BALANCE,RECIPACC,RECIPNAM,NOTES)" +
+                        "VALUES(lpad(" + accno + ",19,0),?,?,?,?,?,?,?,?,?,?)");
+                if(list.size()>0){
+                    submitData(ps, list);
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "DataProcessor.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let ext = &result.extractions[0];
+    assert!(ext.sql.contains("__JAVA_VAR_String_accno__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_1__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_10__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+```
+
+**Step 2: Run all tests**
+
+Run: `cargo test --features java`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git commit -m "test(java): integration test for cross-method submitData scenario"
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 ──► Task 2 ──► Task 3 ──► Task 4   (Phase 1: String[] args)
+                                           │
+                                           ▼
+                    Task 5 ──► Task 6 ──► Task 7 ──► Task 8   (Phase 2: cross-method)
+```
+
+Phase 1 and Phase 2 are independent — Phase 2 does not depend on Phase 1. But they should land on the same branch.
+
+## Files Changed (Summary)
+
+| File | Tasks | Purpose |
+|---|---|---|
+| `src/java/method_call.rs` | 1,2,3,6,7 | Core logic: array arg parsing, SQL var resolution, cross-method injection |
+| `src/java/extract.rs` | 5,6 | ExtractContext extension, method behavior recording |
+| `src/java/types.rs` | 5 | New types: MethodPsBehavior, SetterPattern |
+| `src/java/tests.rs` | 1-8 | All tests |
+
+## Estimated Size
+
+| Phase | New/Modified LOC | Complexity |
+|---|---|---|
+| Phase 1 (Tasks 1-4) | ~120-150 lines | Low — single call expression scope |
+| Phase 2 (Tasks 5-8) | ~250-350 lines | Medium — file-scoped index, two-pass data flow |
+| **Total** | ~370-500 lines | |

--- a/src/java/extract.rs
+++ b/src/java/extract.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 
 use tree_sitter::Node;
 
-use super::types::{JavaExtractConfig, JdbcParamInfo};
+use super::types::{JavaExtractConfig, JdbcParamInfo, MethodPsBehavior};
 use crate::java::error::JavaError;
+use crate::java::method_call::PendingInjection;
 use crate::java::types::*;
 
 
@@ -14,6 +15,7 @@ pub(super) struct TrackedVar {
     pub(super) sql: String,
     pub(super) extraction_index: usize,
     pub(super) is_string_builder: bool,
+    pub(super) is_field_level: bool,
 }
 
 pub fn extract(
@@ -34,6 +36,10 @@ pub fn extract(
         jdbc_param_map: HashMap::new(),
         ps_var_to_extraction: HashMap::new(),
         extra_sql_methods: &config.extra_sql_methods,
+        method_behaviors: HashMap::new(),
+        pending_injections: Vec::new(),
+        class_ps_to_extraction: HashMap::new(),
+        dynamic_setters: Vec::new(),
     };
     ctx.visit(root);
     let extractions: Vec<ExtractedSql> = ctx
@@ -62,6 +68,10 @@ pub(super) struct ExtractContext<'a> {
     /// Maps PreparedStatement variable name → extraction index for backfill.
     pub(super) ps_var_to_extraction: HashMap<String, usize>,
     pub(super) extra_sql_methods: &'a [String],
+    pub(super) method_behaviors: HashMap<String, MethodPsBehavior>,
+    pub(super) pending_injections: Vec<PendingInjection>,
+    pub(super) class_ps_to_extraction: HashMap<String, usize>,
+    pub(super) dynamic_setters: Vec<(String, String)>,
 }
 
 impl<'a> ExtractContext<'a> {
@@ -106,15 +116,31 @@ impl<'a> ExtractContext<'a> {
         for child in node.children(&mut cursor) {
             self.visit(child);
         }
+        self.apply_pending_injections();
         self.class_name = old_class;
     }
 
     pub(super) fn visit_method_declaration(&mut self, node: Node) {
         let old_method = self.method_name.clone();
+        let field_sql_vars: HashMap<String, TrackedVar> = self
+            .sql_vars
+            .iter()
+            .filter(|(_, v)| v.is_field_level)
+            .map(|(k, v)| (k.clone(), TrackedVar {
+                sql: v.sql.clone(),
+                extraction_index: v.extraction_index,
+                is_string_builder: v.is_string_builder,
+                is_field_level: true,
+            }))
+            .collect();
         let old_sql_vars = std::mem::take(&mut self.sql_vars);
+        for (k, v) in field_sql_vars {
+            self.sql_vars.insert(k, v);
+        }
         let old_var_types = std::mem::take(&mut self.var_types);
         let old_jdbc_param_map = std::mem::take(&mut self.jdbc_param_map);
         let old_ps_var_to_extraction = std::mem::take(&mut self.ps_var_to_extraction);
+        let old_dynamic_setters = std::mem::take(&mut self.dynamic_setters);
         if let Some(name_node) = node.child_by_field_name("name") {
             self.method_name = Some(self.node_text(name_node));
         }
@@ -172,11 +198,18 @@ impl<'a> ExtractContext<'a> {
         // Backfill JDBC parameter type/name inference from setXxx() calls
         self.backfill_jdbc_params();
 
+        self.record_method_behavior(node);
+
+        for (var, idx) in &self.ps_var_to_extraction {
+            self.class_ps_to_extraction.insert(var.clone(), *idx);
+        }
+
         self.method_name = old_method;
         self.sql_vars = old_sql_vars;
         self.var_types = old_var_types;
         self.jdbc_param_map = old_jdbc_param_map;
         self.ps_var_to_extraction = old_ps_var_to_extraction;
+        self.dynamic_setters = old_dynamic_setters;
     }
 
     pub(super) fn recurse(&mut self, node: Node) {
@@ -324,9 +357,40 @@ impl<'a> ExtractContext<'a> {
             Some(t) => format!("__JAVA_VAR_{}_{}__", t, sanitized),
             None => match self.var_types.get(&var_name) {
                 Some(t) => format!("__JAVA_VAR_{}_{}__", t, sanitized),
-                None => format!("__JAVA_VAR_{}__", sanitized),
+                None => {
+                    let default_type = self
+                        .infer_type_from_concat_context(node)
+                        .unwrap_or_else(|| sanitized.clone());
+                    if default_type != sanitized {
+                        format!("__JAVA_VAR_{}_{}__", default_type, sanitized)
+                    } else {
+                        format!("__JAVA_VAR_{}__", sanitized)
+                    }
+                }
             },
         }
+    }
+
+    /// Check if an identifier is used in a string concatenation context (parent `+` binary
+    /// expression where the other operand is a string literal or String-typed expression).
+    fn infer_type_from_concat_context(&self, node: Node) -> Option<String> {
+        let parent = node.parent()?;
+        if parent.kind() != "binary_expression" {
+            return None;
+        }
+        let op = parent.child_by_field_name("operator").map(|n| self.node_text(n));
+        if op.as_deref() != Some("+") {
+            return None;
+        }
+        // Check if the OTHER operand of this + is a String
+        let left = parent.child_by_field_name("left")?;
+        let right = parent.child_by_field_name("right")?;
+        let other = if left.id() == node.id() { right } else { left };
+        let other_type = self.infer_expression_type(other);
+        if other_type.as_deref() == Some("String") {
+            return Some("String".to_string());
+        }
+        None
     }
 
     /// If this method_invocation is the RHS of a variable declaration or assignment,
@@ -488,6 +552,94 @@ impl<'a> ExtractContext<'a> {
                 ext.parse_result = parse_result;
             }
         }
+    }
+
+    fn record_method_behavior(&mut self, node: Node) {
+        let method_name_str = match &self.method_name {
+            Some(n) => n.clone(),
+            None => return,
+        };
+
+        let mut ps_param_name: Option<String> = None;
+        let mut ps_param_index: Option<usize> = None;
+
+        if let Some(params_node) = node.child_by_field_name("parameters") {
+            let mut cursor = params_node.walk();
+            let mut param_idx = 0usize;
+            for child in params_node.children(&mut cursor) {
+                if child.kind() == "formal_parameter" {
+                    let mut pc = child.walk();
+                    let mut type_name: Option<String> = None;
+                    let mut var_name: Option<String> = None;
+                    for p in child.children(&mut pc) {
+                        match p.kind() {
+                            "type_identifier" | "generic_type" => {
+                                type_name = self.extract_type_name(p);
+                            }
+                            "identifier" => {
+                                var_name = Some(self.node_text(p));
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let (Some(t), Some(v)) = (&type_name, &var_name) {
+                        if t == "PreparedStatement" {
+                            ps_param_name = Some(v.clone());
+                            ps_param_index = Some(param_idx);
+                        }
+                    }
+                    param_idx += 1;
+                }
+            }
+        }
+
+        let ps_var = match ps_param_name {
+            Some(v) => v,
+            None => return,
+        };
+        let ps_idx = match ps_param_index {
+            Some(i) => i,
+            None => return,
+        };
+
+        let mut setter_patterns: Vec<crate::java::types::SetterPattern> = Vec::new();
+        for ((var_name, _), info) in &self.jdbc_param_map {
+            if var_name == &ps_var {
+                setter_patterns.push(crate::java::types::SetterPattern::Literal {
+                    index: info.index,
+                    java_type: info.java_type.clone(),
+                    var_name: info.var_name.clone(),
+                });
+            }
+        }
+
+        let mut seen_dynamic_types: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (var_name, java_type) in &self.dynamic_setters {
+            if var_name == &ps_var && !seen_dynamic_types.contains(java_type) {
+                seen_dynamic_types.insert(java_type.clone());
+                setter_patterns.push(crate::java::types::SetterPattern::DynamicLoop {
+                    java_type: java_type.clone(),
+                });
+            }
+        }
+
+        if setter_patterns.is_empty() {
+            return;
+        }
+
+        setter_patterns.sort_by_key(|p| match p {
+            crate::java::types::SetterPattern::Literal { index, .. } => *index,
+            crate::java::types::SetterPattern::DynamicLoop { .. } => usize::MAX,
+        });
+
+        self.method_behaviors.insert(
+            method_name_str,
+            crate::java::types::MethodPsBehavior {
+                ps_param_index: ps_idx,
+                ps_param_name: ps_var,
+                setter_patterns,
+            },
+        );
     }
 
     pub(super) fn node_text(&self, node: Node) -> String {

--- a/src/java/method_call.rs
+++ b/src/java/method_call.rs
@@ -5,8 +5,13 @@ use tree_sitter::Node;
 use super::constant::{JDBC_SETTER_TYPES, SQL_METHOD_AMBIGUOUS, SQL_METHOD_UNAMBIGUOUS};
 use super::extract::ExtractContext;
 use super::heuristics::{detect_parameter_style, looks_like_sql};
-use super::types::JdbcParamInfo;
+use super::types::{JdbcParamInfo, MethodPsBehavior};
 use crate::java::types::*;
+
+pub(super) struct PendingInjection {
+    pub(super) ps_var: String,
+    pub(super) method_name: String,
+}
 
 impl<'a> ExtractContext<'a> {
     pub(super) fn visit_method_invocation(&mut self, node: Node) {
@@ -32,7 +37,9 @@ impl<'a> ExtractContext<'a> {
             let next_char = method_name.chars().nth(3).unwrap();
             if next_char.is_ascii_uppercase() {
                 if let Some(root_var) = self.find_method_chain_root(node) {
-                    if self.ps_var_to_extraction.contains_key(&root_var) {
+                    let is_ps = self.ps_var_to_extraction.contains_key(&root_var)
+                        || self.var_types.get(&root_var).map_or(false, |t| t == "PreparedStatement");
+                    if is_ps {
                         self.visit_setter_call(node, &method_name);
                         return;
                     }
@@ -43,6 +50,30 @@ impl<'a> ExtractContext<'a> {
         let is_unambiguous = SQL_METHOD_UNAMBIGUOUS.contains(&method_name.as_str())
             || self.extra_sql_methods.iter().any(|m| m == &method_name);
         let is_ambiguous = SQL_METHOD_AMBIGUOUS.contains(&method_name.as_str());
+
+        if let Some(args_node) = node.child_by_field_name("arguments") {
+            if args_node.kind() == "argument_list" {
+                let mut cursor = args_node.walk();
+                let mut found_ps_var: Option<String> = None;
+                for child in args_node.children(&mut cursor) {
+                    if child.kind() == "," || child.kind() == "(" || child.kind() == ")" {
+                        continue;
+                    }
+                    if child.kind() == "identifier" {
+                        let arg_name = self.node_text(child);
+                        if self.ps_var_to_extraction.contains_key(&arg_name) {
+                            found_ps_var = Some(arg_name);
+                        }
+                    }
+                }
+                if let Some(ps_var) = found_ps_var {
+                    self.pending_injections.push(PendingInjection {
+                        ps_var,
+                        method_name: method_name.clone(),
+                    });
+                }
+            }
+        }
 
         if !is_unambiguous && !is_ambiguous {
             let mut cursor = node.walk();
@@ -57,40 +88,68 @@ impl<'a> ExtractContext<'a> {
             _ => return,
         };
 
+        let tracked_sql_idx = {
+            let mut cursor = args_node.walk();
+            let mut found = None;
+            for child in args_node.children(&mut cursor) {
+                if child.kind() == "identifier" {
+                    let arg_name = self.node_text(child);
+                    if let Some(tracked) = self.sql_vars.get(&arg_name) {
+                        found = Some(tracked.extraction_index);
+                        break;
+                    }
+                }
+            }
+            found
+        };
+
         let mut pushed_extraction_idx: Option<usize> = None;
 
-        if let Some((sql_text, is_text_block)) = self.find_first_string_arg(&args_node) {
-            if !is_unambiguous && !looks_like_sql(&sql_text) {
-                return;
+        if let Some((sql_text, is_text_block)) = self.find_sql_arg(&args_node) {
+            let is_sql = looks_like_sql(&sql_text);
+
+            if !is_sql && tracked_sql_idx.is_some() {
+            } else {
+                if !is_unambiguous && !is_sql {
+                    return;
+                }
+
+                let sql_kind = match method_name.as_str() {
+                    "createQuery" => SqlKind::Jpql,
+                    _ => SqlKind::NativeSql,
+                };
+                let param_style = detect_parameter_style(&sql_text);
+                let sql_converted = self.convert_placeholders(&sql_text);
+                let parse_result = self.try_parse_sql(&sql_converted, sql_kind);
+
+                self.extractions.push(ExtractedSql {
+                    sql: sql_converted,
+                    origin: SqlOrigin {
+                        method: ExtractionMethod::MethodCall,
+                        class_name: self.class_name.clone(),
+                        method_name: self.method_name.clone(),
+                        annotation_name: None,
+                        api_method_name: Some(method_name.clone()),
+                        variable_name: None,
+                        line: node.start_position().row + 1,
+                        column: node.start_position().column,
+                    },
+                    sql_kind,
+                    parameter_style: param_style,
+                    is_concatenated: false,
+                    is_text_block,
+                    parse_result,
+                });
+                pushed_extraction_idx = Some(self.extractions.len() - 1);
             }
+        }
 
-            let sql_kind = match method_name.as_str() {
-                "createQuery" => SqlKind::Jpql,
-                _ => SqlKind::NativeSql,
-            };
-            let param_style = detect_parameter_style(&sql_text);
-            let sql_converted = self.convert_placeholders(&sql_text);
-            let parse_result = self.try_parse_sql(&sql_converted, sql_kind);
+        let backfill_target = pushed_extraction_idx.or(tracked_sql_idx);
 
-            self.extractions.push(ExtractedSql {
-                sql: sql_converted,
-                origin: SqlOrigin {
-                    method: ExtractionMethod::MethodCall,
-                    class_name: self.class_name.clone(),
-                    method_name: self.method_name.clone(),
-                    annotation_name: None,
-                    api_method_name: Some(method_name.clone()),
-                    variable_name: None,
-                    line: node.start_position().row + 1,
-                    column: node.start_position().column,
-                },
-                sql_kind,
-                parameter_style: param_style,
-                is_concatenated: false,
-                is_text_block,
-                parse_result,
-            });
-            pushed_extraction_idx = Some(self.extractions.len() - 1);
+        if let Some(array_elements) = self.find_array_creation_arg(&args_node) {
+            if let Some(ext_idx) = backfill_target {
+                self.backfill_array_params(ext_idx, &array_elements);
+            }
         }
 
         // Track PreparedStatement variable → extraction mapping
@@ -142,6 +201,27 @@ impl<'a> ExtractContext<'a> {
         None
     }
 
+    fn find_sql_arg(&self, args_node: &Node) -> Option<(String, bool)> {
+        let mut first_string: Option<(String, bool)> = None;
+        let mut cursor = args_node.walk();
+        for child in args_node.children(&mut cursor) {
+            match child.kind() {
+                "string_literal" | "binary_expression" => {
+                    if let Some((text, is_tb)) = self.extract_string_value(child) {
+                        if looks_like_sql(&text) {
+                            return Some((text, is_tb));
+                        }
+                        if first_string.is_none() {
+                            first_string = Some((text, is_tb));
+                        }
+                    }
+                }
+                _ => continue,
+            }
+        }
+        first_string
+    }
+
     /// Handle `ps.setXxx(index, value)` calls to infer `?` placeholder types.
     pub(super) fn visit_setter_call(&mut self, node: Node, method_name: &str) {
         // Determine Java type from setter method name
@@ -176,27 +256,26 @@ impl<'a> ExtractContext<'a> {
             return;
         }
 
-        // Parse parameter index
         let idx_text = self.node_text(args[0]);
         let param_index: usize = match idx_text.trim().parse() {
             Ok(n) => n,
-            Err(_) => return,
+            Err(_) => {
+                let ps_var = match self.find_method_chain_root(node) {
+                    Some(v) => v,
+                    None => return,
+                };
+                self.dynamic_setters.push((ps_var, java_type));
+                return;
+            }
         };
 
-        // Extract variable name from value argument
         let value_node = args[1];
         let var_name = self.extract_setter_value_name(value_node);
 
-        // Find the PreparedStatement variable name
         let ps_var = match self.find_method_chain_root(node) {
             Some(v) => v,
             None => return,
         };
-
-        // Only track if this PS variable is known
-        if !self.ps_var_to_extraction.contains_key(&ps_var) {
-            return;
-        }
 
         self.jdbc_param_map.insert(
             (ps_var, param_index),
@@ -221,6 +300,243 @@ impl<'a> ExtractContext<'a> {
                 node.child_by_field_name("name").map(|n| self.node_text(n))
             }
             _ => None,
+        }
+    }
+
+    fn find_array_creation_arg(&self, args_node: &Node) -> Option<Vec<(String, Option<String>)>> {
+        let mut cursor = args_node.walk();
+        for child in args_node.children(&mut cursor) {
+            if child.kind() == "array_creation_expression" {
+                return Some(self.extract_array_element_names(child));
+            }
+        }
+        None
+    }
+
+    fn extract_array_element_names(&self, node: Node) -> Vec<(String, Option<String>)> {
+        let mut elements = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "dimensions" || child.kind() == "type_identifier" || child.kind() == "integral_type" || child.kind() == "primitive_type" || child.kind() == "floating_point_type" || child.kind() == "boolean_type" || child.kind() == "generic_type" || child.kind() == "array_type" {
+                continue;
+            }
+            if child.kind() == "dimensions" {
+                continue;
+            }
+            if child.kind() == "element_list" || child.kind() == "array_initializer" {
+                let mut el_cursor = child.walk();
+                for el in child.children(&mut el_cursor) {
+                    if el.kind() == "," || el.kind() == "{" || el.kind() == "}" {
+                        continue;
+                    }
+                    match el.kind() {
+                        "identifier" => {
+                            let name = self.node_text(el);
+                            let inferred = self.var_types.get(&name).cloned();
+                            elements.push((name, inferred));
+                        }
+                        _ => {
+                            let placeholder = self.make_placeholder_for_node(el);
+                            elements.push((placeholder, None));
+                        }
+                    }
+                }
+            }
+        }
+        elements
+    }
+
+    fn backfill_array_params(&mut self, ext_idx: usize, elements: &[(String, Option<String>)]) {
+        let mut modified = false;
+        if let Some(ext) = self.extractions.get_mut(ext_idx) {
+            for (i, (var_name, inferred_type)) in elements.iter().enumerate() {
+                let param_num = i + 1;
+                let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", param_num);
+                let java_type = inferred_type.as_deref()
+                    .or_else(|| self.var_types.get(var_name).map(|s| s.as_str()))
+                    .unwrap_or("Object");
+                let sanitized = var_name
+                    .chars()
+                    .map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' })
+                    .collect::<String>();
+                let new = format!("__JAVA_VAR_{}_{}__", java_type, sanitized);
+                let before = ext.sql.len();
+                ext.sql = ext.sql.replace(&old, &new);
+                modified |= ext.sql.len() != before;
+            }
+        }
+        if modified {
+            if let Some(ext) = self.extractions.get(ext_idx) {
+                let sql = ext.sql.clone();
+                let sql_kind = ext.sql_kind;
+                let parse_result = self.try_parse_sql(&sql, sql_kind);
+                if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                    ext.parse_result = parse_result;
+                }
+            }
+        }
+    }
+
+    fn resolve_ps_arg_extraction(
+        &self,
+        args_node: &Node,
+        behavior: &super::types::MethodPsBehavior,
+    ) -> Option<usize> {
+        let mut cursor = args_node.walk();
+        let mut arg_idx = 0usize;
+        for child in args_node.children(&mut cursor) {
+            if child.kind() == "," || child.kind() == "(" || child.kind() == ")" {
+                continue;
+            }
+            if arg_idx == behavior.ps_param_index {
+                if child.kind() == "identifier" {
+                    let ps_var = self.node_text(child);
+                    return self.ps_var_to_extraction.get(&ps_var).copied();
+                }
+                return None;
+            }
+            arg_idx += 1;
+        }
+        None
+    }
+
+    fn apply_fallback_dynamic(&mut self, ext_idx: usize) {
+        let max_param = {
+            let ext = match self.extractions.get(ext_idx) {
+                Some(e) => e,
+                None => return,
+            };
+            let mut count = 0usize;
+            let mut pos = 0;
+            while let Some(i) = ext.sql[pos..].find("__JAVA_VAR_JDBC_PARAM_") {
+                let abs_pos = pos + i;
+                let rest = match ext.sql.get(abs_pos + 22..) {
+                    Some(r) => r,
+                    None => break,
+                };
+                if let Some(end_off) = rest.find("__") {
+                    if let Ok(param_num) = rest[..end_off].parse::<usize>() {
+                        count = count.max(param_num);
+                    }
+                }
+                pos = abs_pos + 22;
+            }
+            count
+        };
+        if max_param == 0 {
+            return;
+        }
+        let mut modified = false;
+        for n in 1..=max_param {
+            let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", n);
+            let new = format!("__JAVA_VAR_String_DYNAMIC_{}__", n);
+            if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                let before = ext.sql.len();
+                ext.sql = ext.sql.replace(&old, &new);
+                modified |= ext.sql.len() != before;
+            }
+        }
+        if modified {
+            if let Some(ext) = self.extractions.get(ext_idx) {
+                let sql = ext.sql.clone();
+                let sql_kind = ext.sql_kind;
+                let parse_result = self.try_parse_sql(&sql, sql_kind);
+                if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                    ext.parse_result = parse_result;
+                }
+            }
+        }
+    }
+
+    pub(super) fn apply_pending_injections(&mut self) {
+        let injections = std::mem::take(&mut self.pending_injections);
+        for injection in injections {
+            let ext_idx = match self.class_ps_to_extraction.get(&injection.ps_var) {
+                Some(&idx) => idx,
+                None => continue,
+            };
+            let behavior = match self.method_behaviors.get(&injection.method_name) {
+                Some(b) => b.clone(),
+                None => {
+                    self.apply_fallback_dynamic(ext_idx);
+                    continue;
+                }
+            };
+
+            let mut modified = false;
+            for pattern in &behavior.setter_patterns {
+                match pattern {
+                    super::types::SetterPattern::Literal {
+                        index,
+                        java_type,
+                        var_name,
+                    } => {
+                        let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", index);
+                        let new = match var_name {
+                            Some(name) => {
+                                let sanitized = name
+                                    .chars()
+                                    .map(|c| {
+                                        if c.is_ascii_alphanumeric() || c == '_' {
+                                            c
+                                        } else {
+                                            '_'
+                                        }
+                                    })
+                                    .collect::<String>();
+                                format!("__JAVA_VAR_{}_{}__", java_type, sanitized)
+                            }
+                            None => format!("__JAVA_VAR_{}_JDBC_PARAM_{}__", java_type, index),
+                        };
+                        if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                            let before = ext.sql.len();
+                            ext.sql = ext.sql.replace(&old, &new);
+                            modified |= ext.sql.len() != before;
+                        }
+                    }
+                    super::types::SetterPattern::DynamicLoop { java_type } => {
+                        let max_param = {
+                            let ext = match self.extractions.get(ext_idx) {
+                                Some(e) => e,
+                                None => continue,
+                            };
+                            let mut count = 0usize;
+                            let mut pos = 0;
+                            while let Some(i) = ext.sql[pos..].find("__JAVA_VAR_JDBC_PARAM_") {
+                                let abs_pos = pos + i;
+                                let rest = &ext.sql[abs_pos + 22..];
+                                if let Some(end_off) = rest.find("__") {
+                                    if let Ok(param_num) = rest[..end_off].parse::<usize>() {
+                                        count = count.max(param_num);
+                                    }
+                                }
+                                pos = abs_pos + 22;
+                            }
+                            count
+                        };
+                        for n in 1..=max_param {
+                            let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", n);
+                            let new = format!("__JAVA_VAR_{}_DYNAMIC_{}__", java_type, n);
+                            if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                                let before = ext.sql.len();
+                                ext.sql = ext.sql.replace(&old, &new);
+                                modified |= ext.sql.len() != before;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if modified {
+                if let Some(ext) = self.extractions.get(ext_idx) {
+                    let sql = ext.sql.clone();
+                    let sql_kind = ext.sql_kind;
+                    let parse_result = self.try_parse_sql(&sql, sql_kind);
+                    if let Some(ext) = self.extractions.get_mut(ext_idx) {
+                        ext.parse_result = parse_result;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/java/tests.rs
+++ b/src/java/tests.rs
@@ -1470,3 +1470,279 @@ fn test_jdbc_reused_ps_variable_three_rounds() {
     let t3 = result.extractions.iter().find(|e| e.sql.contains("t3")).unwrap();
     assert!(t3.sql.contains("__JAVA_VAR_String_z__"), "t3: {}", t3.sql);
 }
+
+// ── String[] Argument Mapping Tests (Phase 1) ──
+
+#[test]
+fn test_string_array_arg_sql_constant_single_param() {
+    let java = r#"
+        public class Dao {
+            private static final String SQL = "SELECT * FROM t WHERE id = ?";
+            public void query(String nodeId) {
+                DbService.executeQuery("ORACLEJDBC", SQL, new String[] {nodeId});
+            }
+        }
+    "#;
+    let config = JavaExtractConfig {
+        extra_sql_methods: vec!["executeQuery".to_string()],
+    };
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_nodeId__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_string_array_arg_multiple_params() {
+    let java = r#"
+        public class Dao {
+            private static final String SQL = "SELECT * FROM t WHERE a = ? AND b = ?";
+            public void query(String x, String y) {
+                DbService.executeQuery("DB", SQL, new String[] {x, y});
+            }
+        }
+    "#;
+    let config = JavaExtractConfig {
+        extra_sql_methods: vec!["executeQuery".to_string()],
+    };
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_x__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_y__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_object_array_arg_typed_params() {
+    let java = r#"
+        public class Dao {
+            private static final String SQL = "SELECT * FROM t WHERE id = ?";
+            public void query(int id) {
+                DbService.executeQuery("DB", SQL, new Object[] {id});
+            }
+        }
+    "#;
+    let config = JavaExtractConfig {
+        extra_sql_methods: vec!["executeQuery".to_string()],
+    };
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_int_id__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_inline_sql_with_inline_string_array() {
+    let java = r#"
+        public class Dao {
+            public void query(String nodeId) {
+                DbService.executeQuery("DB", "SELECT * FROM t WHERE id = ?", new String[] {nodeId});
+            }
+        }
+    "#;
+    let config = JavaExtractConfig {
+        extra_sql_methods: vec!["executeQuery".to_string()],
+    };
+    let result = extract_sql_from_java(java, "Dao.java", &config);
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("SELECT")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_nodeId__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_real_world_integration_ebms_handler() {
+    let java = r#"
+        public class EBMSHandler {
+            private static final String SWITCH_SQL = "SELECT KIND_ID FROM ebk_dic_all_kind t WHERE t.operation_kind = 'PI00168_SWITCH'";
+            private static final String QUERY_MENU_SQL = "SELECT t.node_id, t.node_name, t.edition FROM par_netuser_menu_tree t WHERE t.node_id = ?";
+            public int execute(String node) throws Exception {
+                List list1 = DbService.executeQuery("ORACLEJDBC", SWITCH_SQL);
+                List list2 = DbService.executeQuery("ORACLEJDBC", QUERY_MENU_SQL, new String[] {node});
+                return 0;
+            }
+        }
+    "#;
+    let config = JavaExtractConfig {
+        extra_sql_methods: vec!["executeQuery".to_string()],
+    };
+    let result = extract_sql_from_java(java, "EBMSHandler.java", &config);
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+
+    let switch_ext = result
+        .extractions
+        .iter()
+        .find(|e| e.sql.contains("SWITCH"))
+        .unwrap();
+    assert!(
+        !switch_ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"),
+        "SWITCH_SQL should have no unresolved params, got: {}",
+        switch_ext.sql
+    );
+
+    let menu_ext = result
+        .extractions
+        .iter()
+        .find(|e| e.sql.contains("node_id"))
+        .unwrap();
+    assert!(
+        menu_ext.sql.contains("__JAVA_VAR_String_node__"),
+        "QUERY_MENU_SQL should have backfilled node param, got: {}",
+        menu_ext.sql
+    );
+    assert!(
+        !menu_ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"),
+        "QUERY_MENU_SQL should have no unresolved placeholders, got: {}",
+        menu_ext.sql
+    );
+}
+
+// ── Cross-Method PreparedStatement Flow Tests (Phase 2) ──
+
+#[test]
+fn test_cross_method_ps_passing_literal_setters() {
+    let java = r#"
+        public class Dao {
+            public void process(String name, String email) {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (name, email) VALUES (?, ?)");
+                insertData(ps, name, email);
+            }
+
+            public static void insertData(PreparedStatement ps, String name, String email) {
+                ps.setString(1, name);
+                ps.setString(2, email);
+                ps.execute();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO t")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_name__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_email__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_cross_method_dynamic_loop_setter() {
+    let java = r#"
+        public class Dao {
+            public void process(List list) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (a,b,c) VALUES (?,?,?)");
+                submitData(ps, list);
+            }
+
+            public static void submitData(PreparedStatement ps, List list) throws Exception {
+                for (Iterator it = list.iterator(); it.hasNext();) {
+                    String[] s = (String[]) it.next();
+                    for (int i = 0; i < s.length; i++) {
+                        ps.setString(i + 1, s[i]);
+                    }
+                    ps.addBatch();
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    let ext = result.extractions.iter().find(|e| e.sql.contains("INSERT INTO t")).unwrap();
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_1__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_2__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_3__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_user_scenario_submit_data_cross_method() {
+    let java = r#"
+        public class DataProcessor {
+            public static void submitData(PreparedStatement ps, List list) throws Exception {
+                try {
+                    for (Iterator it = list.iterator(); it.hasNext();) {
+                        String[] s = (String[]) it.next();
+                        for (int i = 0; i < s.length; i++) {
+                            ps.setString(i + 1, s[i]);
+                        }
+                        ps.addBatch();
+                    }
+                    ps.executeBatch();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            public void process(List list, String accno) throws Exception {
+                ps = conn.prepareStatement("insert into dat_clnt_fv_tran " +
+                        "(ACCNO,BUSIDATE,SERIALNO,TRXCODE,DRCRF,SUMMARY,AMOUNT,BALANCE,RECIPACC,RECIPNAM,NOTES)" +
+                        "VALUES(lpad(" + accno + ",19,0),?,?,?,?,?,?,?,?,?,?)");
+                if(list.size()>0){
+                    submitData(ps, list);
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "DataProcessor.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let ext = &result.extractions[0];
+    assert!(ext.sql.contains("__JAVA_VAR_String_accno__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_1__"), "SQL: {}", ext.sql);
+    assert!(ext.sql.contains("__JAVA_VAR_String_DYNAMIC_10__"), "SQL: {}", ext.sql);
+    assert!(!ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_undeclared_var_in_string_concat_gets_string_type() {
+    let java = r#"
+        public class Foo {
+            public void bar(Connection conn) throws Exception {
+                PreparedStatement ps = conn.prepareStatement(
+                    "SELECT * FROM t WHERE id = " + someVar + " AND name = ?");
+                ps.setString(1, "x");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Foo.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let ext = &result.extractions[0];
+    assert!(ext.sql.contains("__JAVA_VAR_String_someVar__"), "SQL: {}", ext.sql);
+}
+
+#[test]
+fn test_cross_method_fallback_when_method_unparsed() {
+    let java = r#"
+        public class MailService {
+            public void saveAttachment(Connection conn) throws Exception {
+                List list = new ArrayList();
+                PreparedStatement ps = conn.prepareStatement(
+                    "insert into t (a,b,c) VALUES (?,?,?)");
+                submitData(ps, list);
+            }
+            public static void submitData(PreparedStatement ps, List list) throws Exception {
+                for (int i = 0; i < 3; i++) {
+                    ps.setString(i + 1, "x");
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "MailService.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let ext = &result.extractions[0];
+    assert!(
+        ext.sql.contains("__JAVA_VAR_String_DYNAMIC_1__"),
+        "Expected DYNAMIC fallback, got: {}",
+        ext.sql
+    );
+    assert!(
+        ext.sql.contains("__JAVA_VAR_String_DYNAMIC_3__"),
+        "Expected DYNAMIC_3, got: {}",
+        ext.sql
+    );
+    assert!(
+        !ext.sql.contains("__JAVA_VAR_JDBC_PARAM_"),
+        "Should not have JDBC_PARAM, got: {}",
+        ext.sql
+    );
+}

--- a/src/java/types.rs
+++ b/src/java/types.rs
@@ -76,3 +76,22 @@ pub(super) struct JdbcParamInfo {
     pub(super) java_type: String,
     pub(super) var_name: Option<String>,
 }
+
+#[derive(Debug, Clone)]
+pub(super) struct MethodPsBehavior {
+    pub(super) ps_param_index: usize,
+    pub(super) ps_param_name: String,
+    pub(super) setter_patterns: Vec<SetterPattern>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum SetterPattern {
+    Literal {
+        index: usize,
+        java_type: String,
+        var_name: Option<String>,
+    },
+    DynamicLoop {
+        java_type: String,
+    },
+}

--- a/src/java/variable.rs
+++ b/src/java/variable.rs
@@ -9,7 +9,7 @@ use crate::java::types::*;
 
 impl<'a> ExtractContext<'a> {
     pub(super) fn visit_field_declaration(&mut self, node: Node) {
-        self.check_string_declaration(node);
+        self.check_string_declaration(node, true);
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             self.visit(child);
@@ -25,7 +25,7 @@ impl<'a> ExtractContext<'a> {
         if is_sb {
             self.check_string_builder_declaration(node);
         } else {
-            self.check_string_declaration(node);
+            self.check_string_declaration(node, false);
         }
 
         if let Some(t) = type_name {
@@ -150,20 +150,21 @@ impl<'a> ExtractContext<'a> {
                 sql: sql_converted,
                 extraction_index: self.extractions.len() - 1,
                 is_string_builder: true,
+                is_field_level: false,
             },
         );
     }
 
-    pub(super) fn check_string_declaration(&mut self, node: Node) {
+    pub(super) fn check_string_declaration(&mut self, node: Node, is_field_level: bool) {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             if child.kind() == "variable_declarator" {
-                self.check_declarator(child);
+                self.check_declarator(child, is_field_level);
             }
         }
     }
 
-    pub(super) fn check_declarator(&mut self, declarator: Node) {
+    pub(super) fn check_declarator(&mut self, declarator: Node, is_field_level: bool) {
         let name_node = match declarator.child_by_field_name("name") {
             Some(n) => n,
             None => return,
@@ -229,6 +230,7 @@ impl<'a> ExtractContext<'a> {
                 sql: sql_converted,
                 extraction_index: self.extractions.len() - 1,
                 is_string_builder: false,
+                is_field_level,
             },
         );
     }
@@ -600,6 +602,7 @@ impl<'a> ExtractContext<'a> {
                 sql: sql_converted,
                 extraction_index: self.extractions.len() - 1,
                 is_string_builder: was_sb,
+                is_field_level: false,
             },
         );
     }


### PR DESCRIPTION
## Summary
- **String[]/Object[] array parameter mapping**: Automatically maps `new String[]{x, y}` elements to `JDBC_PARAM_N` placeholders, then backfills to typed `JAVA_VAR_{type}_{name}` via `backfill_array_params`
- **Cross-method PreparedStatement injection**: Records per-method PS setter patterns (literal index + dynamic loop), defers method call resolution to type_declaration end, and applies pending injections across method boundaries
- **Edge case handling**: Infers `String` type for undeclared variables in concatenation context (`"..." + someVar + "..."`); falls back to `DYNAMIC` placeholders when method behavior is unavailable (e.g., source syntax errors preventing method parsing)
- **Field-level SQL constants**: Persists across method boundaries via `is_field_level` flag on `TrackedVar`

## Test plan
- [x] 10 new tests covering: String[] mapping (5), cross-method literal/dynamic injection (3), edge cases (2)
- [x] All 1193 tests pass (1183 existing + 10 new)
- [x] Verified against real-world `error_java1.java` with 4 extraction scenarios

## Commits
- `c19995f` feat(java): cross-method JDBC param inference with String[] mapping and dynamic setter support
- `995882c` test(java): add 10 tests for cross-method JDBC param inference