### PR TITLE
feat: preserve standalone labels via Block-wrapping in attach_label

### DIFF
--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -2434,26 +2434,42 @@ fn is_pl_terminator(p: &Parser) -> bool {
     terminators.iter().any(|t| p.match_ident_str(t))
 }
 
-fn attach_label(mut stmt: PlStatement, label: Option<String>) -> PlStatement {
-    match &mut stmt {
-        PlStatement::Loop(s) => {
-            s.node.label = label.clone();
+fn attach_label(stmt: PlStatement, label: Option<String>) -> PlStatement {
+    let label = match label {
+        Some(l) => l,
+        None => return stmt,
+    };
+    match stmt {
+        PlStatement::Loop(mut s) => {
+            s.node.label = Some(label);
+            PlStatement::Loop(s)
         }
-        PlStatement::While(s) => {
-            s.node.label = label.clone();
+        PlStatement::While(mut s) => {
+            s.node.label = Some(label);
+            PlStatement::While(s)
         }
-        PlStatement::For(s) => {
-            s.node.label = label.clone();
+        PlStatement::For(mut s) => {
+            s.node.label = Some(label);
+            PlStatement::For(s)
         }
-        PlStatement::ForEach(s) => {
-            s.node.label = label.clone();
+        PlStatement::ForEach(mut s) => {
+            s.node.label = Some(label);
+            PlStatement::ForEach(s)
         }
-        PlStatement::Block(s) => {
-            s.node.label = label.clone();
+        PlStatement::Block(mut s) => {
+            s.node.label = Some(label);
+            PlStatement::Block(s)
         }
-        _ => {}
+        // Standalone label before non-control statement: wrap in a labeled Block
+        // so the label is preserved in the AST for GOTO target analysis.
+        other => PlStatement::Block(Spanned::new(PlBlock {
+            label: Some(label),
+            declarations: Vec::new(),
+            body: vec![other],
+            exception_block: None,
+            end_label: None,
+        }, None)),
     }
-    stmt
 }
 
 impl Parser {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -13878,3 +13878,36 @@ fn test_cursor_attribute_format_roundtrip() {
         output
     );
 }
+
+#[test]
+fn test_plpgsql_standalone_label_before_null() {
+    let block = parse_do_block("DO $$ BEGIN NULL; <<cleanup>> NULL; END $$");
+    println!("Body has {} statements:", block.body.len());
+    for (i, s) in block.body.iter().enumerate() {
+        println!("  [{}] {:?}", i, s);
+    }
+    // First statement is plain Null
+    assert!(matches!(block.body[0], PlStatement::Null));
+    // Second should be a labeled Block wrapping Null
+    match &block.body[1] {
+        PlStatement::Block(b) => {
+            assert_eq!(b.label.as_deref(), Some("cleanup"));
+        }
+        other => panic!("expected labeled Block, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_plpgsql_standalone_label_before_delete() {
+    let block = parse_do_block("DO $$ BEGIN <<cleanup>> DELETE FROM t; END $$");
+    println!("Body has {} statements:", block.body.len());
+    for (i, s) in block.body.iter().enumerate() {
+        println!("  [{}] {:?}", i, s);
+    }
+    match &block.body[0] {
+        PlStatement::Block(b) => {
+            assert_eq!(b.label.as_deref(), Some("cleanup"));
+        }
+        other => panic!("expected labeled Block, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

- Labels before non-control statements (e.g. `<<cleanup>> DELETE ...`) were silently dropped during `attach_label`. Now wrapped in `PlStatement::Block` to preserve labels.
- Adds comprehensive tests for standalone label Block-wrapping behavior.

## Changed files

- `src/parser/plpgsql.rs` — Core fix: wrap standalone labels in `PlStatement::Block` instead of discarding
- `src/parser/tests.rs` — New test cases for the Block-wrapping behavior

## Testing

- All existing tests pass
- New tests verify standalone labels are preserved via Block-wrapping