### PR TITLE
feat: validate package spec vs body parameter consistency

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1123,5 +1123,294 @@ impl TransactionAnalyzer {
     }
 }
 
+// ── Package Spec vs Body Consistency Validation ──
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PackageConsistencyError {
+    pub package_name: String,
+    pub subprogram_name: String,
+    pub kind: PackageConsistencyErrorKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum PackageConsistencyErrorKind {
+    /// A subprogram exists in the spec but is missing from the body
+    MissingInBody,
+    /// A subprogram exists in the body but is not declared in the spec
+    ExtraInBody,
+    /// Parameter count differs between spec and body
+    ParamCountMismatch { spec_count: usize, body_count: usize },
+    /// A parameter has a default value in the spec but not in the body (or vice versa)
+    DefaultMismatch { param_name: String, spec_default: Option<String>, body_default: Option<String> },
+    /// A parameter has a different data type in spec vs body
+    TypeMismatch { param_name: String, spec_type: String, body_type: String },
+}
+
+/// Validate that all package specs and bodies in the parsed statements are consistent.
+/// Returns a list of errors/warnings for each mismatch found.
+pub fn validate_package_consistency(
+    stmts: &[crate::ast::StatementInfo],
+) -> Vec<PackageConsistencyError> {
+    use crate::ast::{Statement, CreatePackageStatement, CreatePackageBodyStatement};
+
+    let mut specs: std::collections::HashMap<String, &CreatePackageStatement> =
+        std::collections::HashMap::new();
+    let mut bodies: std::collections::HashMap<String, &CreatePackageBodyStatement> =
+        std::collections::HashMap::new();
+
+    for si in stmts {
+        match &si.statement {
+            Statement::CreatePackage(spec) => {
+                let name = object_name_str(&spec.name);
+                specs.insert(name, spec);
+            }
+            Statement::CreatePackageBody(body) => {
+                let name = object_name_str(&body.name);
+                bodies.insert(name, body);
+            }
+            _ => {}
+        }
+    }
+
+    let mut errors = Vec::new();
+
+    for (pkg_name, spec) in &specs {
+        if let Some(body) = bodies.get(pkg_name) {
+            validate_single_package(pkg_name, spec, body, &mut errors);
+        }
+    }
+
+    errors
+}
+
+fn object_name_str(name: &crate::ast::ObjectName) -> String {
+    name.iter()
+        .map(|s| s.to_uppercase())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn validate_single_package(
+    pkg_name: &str,
+    spec: &crate::ast::CreatePackageStatement,
+    body: &crate::ast::CreatePackageBodyStatement,
+    errors: &mut Vec<PackageConsistencyError>,
+) {
+    use crate::ast::PackageItem;
+
+    let spec_funcs: std::collections::HashMap<String, &crate::ast::PackageFunction> = spec.items
+        .iter()
+        .filter_map(|item| match item {
+            PackageItem::Function(f) => {
+                let name = object_name_str(&f.name);
+                Some((name, f))
+            }
+            _ => None,
+        })
+        .collect();
+
+    let spec_procs: std::collections::HashMap<String, &crate::ast::PackageProcedure> = spec.items
+        .iter()
+        .filter_map(|item| match item {
+            PackageItem::Procedure(p) => {
+                let name = object_name_str(&p.name);
+                Some((name, p))
+            }
+            _ => None,
+        })
+        .collect();
+
+    let body_funcs: std::collections::HashMap<String, &crate::ast::PackageFunction> = body.items
+        .iter()
+        .filter_map(|item| match item {
+            PackageItem::Function(f) => {
+                let name = object_name_str(&f.name);
+                Some((name, f))
+            }
+            _ => None,
+        })
+        .collect();
+
+    let body_procs: std::collections::HashMap<String, &crate::ast::PackageProcedure> = body.items
+        .iter()
+        .filter_map(|item| match item {
+            PackageItem::Procedure(p) => {
+                let name = object_name_str(&p.name);
+                Some((name, p))
+            }
+            _ => None,
+        })
+        .collect();
+
+    for (func_name, spec_func) in &spec_funcs {
+        if let Some(body_func) = body_funcs.get(func_name) {
+            compare_params(
+                pkg_name,
+                func_name,
+                &spec_func.parameters,
+                &body_func.parameters,
+                errors,
+            );
+        } else {
+            errors.push(PackageConsistencyError {
+                package_name: pkg_name.to_string(),
+                subprogram_name: func_name.clone(),
+                kind: PackageConsistencyErrorKind::MissingInBody,
+                detail: Some("FUNCTION declared in package spec but not defined in package body".to_string()),
+            });
+        }
+    }
+
+    for (proc_name, spec_proc) in &spec_procs {
+        if let Some(body_proc) = body_procs.get(proc_name) {
+            compare_params(
+                pkg_name,
+                proc_name,
+                &spec_proc.parameters,
+                &body_proc.parameters,
+                errors,
+            );
+        } else {
+            errors.push(PackageConsistencyError {
+                package_name: pkg_name.to_string(),
+                subprogram_name: proc_name.clone(),
+                kind: PackageConsistencyErrorKind::MissingInBody,
+                detail: Some("PROCEDURE declared in package spec but not defined in package body".to_string()),
+            });
+        }
+    }
+
+    for func_name in body_funcs.keys() {
+        if !spec_funcs.contains_key(func_name) {
+            errors.push(PackageConsistencyError {
+                package_name: pkg_name.to_string(),
+                subprogram_name: func_name.clone(),
+                kind: PackageConsistencyErrorKind::ExtraInBody,
+                detail: Some("FUNCTION defined in package body but not declared in package spec".to_string()),
+            });
+        }
+    }
+
+    for proc_name in body_procs.keys() {
+        if !spec_procs.contains_key(proc_name) {
+            errors.push(PackageConsistencyError {
+                package_name: pkg_name.to_string(),
+                subprogram_name: proc_name.clone(),
+                kind: PackageConsistencyErrorKind::ExtraInBody,
+                detail: Some("PROCEDURE defined in package body but not declared in package spec".to_string()),
+            });
+        }
+    }
+}
+
+fn compare_params(
+    pkg_name: &str,
+    subprogram_name: &str,
+    spec_params: &[crate::ast::RoutineParam],
+    body_params: &[crate::ast::RoutineParam],
+    errors: &mut Vec<PackageConsistencyError>,
+) {
+    if spec_params.len() != body_params.len() {
+        errors.push(PackageConsistencyError {
+            package_name: pkg_name.to_string(),
+            subprogram_name: subprogram_name.to_string(),
+            kind: PackageConsistencyErrorKind::ParamCountMismatch {
+                spec_count: spec_params.len(),
+                body_count: body_params.len(),
+            },
+            detail: None,
+        });
+    }
+
+    let max_len = spec_params.len().max(body_params.len());
+    for i in 0..max_len {
+        let spec_p = match spec_params.get(i) {
+            Some(p) => p,
+            None => continue,
+        };
+        let body_p = match body_params.get(i) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        match (&spec_p.default_value, &body_p.default_value) {
+            (Some(_), None) => {
+                errors.push(PackageConsistencyError {
+                    package_name: pkg_name.to_string(),
+                    subprogram_name: subprogram_name.to_string(),
+                    kind: PackageConsistencyErrorKind::DefaultMismatch {
+                        param_name: spec_p.name.clone(),
+                        spec_default: spec_p.default_value.clone(),
+                        body_default: None,
+                    },
+                    detail: Some(format!(
+                        "Parameter '{}' has DEFAULT value '{}' in spec but no DEFAULT in body",
+                        spec_p.name,
+                        spec_p.default_value.as_deref().unwrap_or("")
+                    )),
+                });
+            }
+            (None, Some(_)) => {
+                errors.push(PackageConsistencyError {
+                    package_name: pkg_name.to_string(),
+                    subprogram_name: subprogram_name.to_string(),
+                    kind: PackageConsistencyErrorKind::DefaultMismatch {
+                        param_name: body_p.name.clone(),
+                        spec_default: None,
+                        body_default: body_p.default_value.clone(),
+                    },
+                    detail: Some(format!(
+                        "Parameter '{}' has no DEFAULT in spec but has DEFAULT '{}' in body",
+                        body_p.name,
+                        body_p.default_value.as_deref().unwrap_or("")
+                    )),
+                });
+            }
+            (Some(spec_def), Some(body_def)) => {
+                if !default_values_equivalent(spec_def, body_def) {
+                    errors.push(PackageConsistencyError {
+                        package_name: pkg_name.to_string(),
+                        subprogram_name: subprogram_name.to_string(),
+                        kind: PackageConsistencyErrorKind::DefaultMismatch {
+                            param_name: spec_p.name.clone(),
+                            spec_default: Some(spec_def.clone()),
+                            body_default: Some(body_def.clone()),
+                        },
+                        detail: Some(format!(
+                            "Parameter '{}' DEFAULT value differs: spec has '{}', body has '{}'",
+                            spec_p.name, spec_def, body_def
+                        )),
+                    });
+                }
+            }
+            (None, None) => {}
+        }
+
+        let spec_type = spec_p.data_type.to_uppercase().replace(' ', "");
+        let body_type = body_p.data_type.to_uppercase().replace(' ', "");
+        if spec_type != body_type {
+            errors.push(PackageConsistencyError {
+                package_name: pkg_name.to_string(),
+                subprogram_name: subprogram_name.to_string(),
+                kind: PackageConsistencyErrorKind::TypeMismatch {
+                    param_name: spec_p.name.clone(),
+                    spec_type: spec_p.data_type.clone(),
+                    body_type: body_p.data_type.clone(),
+                },
+                detail: None,
+            });
+        }
+    }
+}
+
+/// Compare default values for semantic equivalence.
+/// Handles common cases like "NULL" vs "null", extra whitespace, etc.
+fn default_values_equivalent(a: &str, b: &str) -> bool {
+    let normalize = |s: &str| s.trim().to_uppercase();
+    normalize(a) == normalize(b)
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -534,7 +534,6 @@ fn test_template_extraction_unknown() {
 
 #[test]
 fn test_template_extraction_all_static_concat() {
-    // Concatenation of only literals - no dynamic params
     let trace = TraceChain::Concatenation {
         parts: vec![
             TraceChain::LiteralAssignment {
@@ -545,6 +544,200 @@ fn test_template_extraction_all_static_concat() {
             },
         ],
     };
-    // All static parts, no dynamic params -> None
     assert!(extract_template(&trace).is_none());
+}
+
+// ── Package Consistency Tests ──
+
+fn parse_stmts(sql: &str) -> Vec<crate::ast::StatementInfo> {
+    let options = crate::ParseOptions { preserve_comments: false, mybatis_params: false };
+    crate::Parser::parse_sql_with_options(sql, options).statements
+}
+
+#[test]
+fn test_package_default_value_mismatch() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE BIGFUND.PKG_XML_MANAGE IS
+  FUNCTION gen_xml_head(p_fcode         IN VARCHAR2,
+                        p_i_seq_no      IN NUMBER,
+                        p_i_retcode     IN VARCHAR2 DEFAULT NULL,
+                        p_i_retmsg      IN VARCHAR2 DEFAULT NULL)
+    RETURN XMLTYPE;
+END PKG_XML_MANAGE;
+/
+
+CREATE OR REPLACE PACKAGE BODY BIGFUND.PKG_XML_MANAGE IS
+  FUNCTION gen_xml_head(p_fcode         IN VARCHAR2,
+                        p_i_seq_no      IN NUMBER,
+                        p_i_retcode     IN VARCHAR2,
+                        p_i_retmsg      IN VARCHAR2)
+    RETURN XMLTYPE IS
+  BEGIN
+    RETURN NULL;
+  END;
+END PKG_XML_MANAGE;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    assert!(!errors.is_empty(), "should detect default value mismatches");
+
+    let default_mismatches: Vec<_> = errors.iter()
+        .filter(|e| matches!(e.kind, PackageConsistencyErrorKind::DefaultMismatch { .. }))
+        .collect();
+    assert!(default_mismatches.len() >= 2, "should detect at least 2 default mismatches (p_i_retcode, p_i_retmsg), got {:?}", default_mismatches.len());
+}
+
+#[test]
+fn test_package_param_count_mismatch() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg1 IS
+  PROCEDURE my_proc(a IN VARCHAR2, b IN NUMBER);
+END pkg1;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg1 IS
+  PROCEDURE my_proc(a IN VARCHAR2, b IN NUMBER, c IN VARCHAR2) IS
+  BEGIN
+    NULL;
+  END;
+END pkg1;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    let count_mismatch = errors.iter()
+        .any(|e| matches!(e.kind, PackageConsistencyErrorKind::ParamCountMismatch { spec_count: 2, body_count: 3 }));
+    assert!(count_mismatch, "should detect parameter count mismatch (2 vs 3)");
+}
+
+#[test]
+fn test_package_missing_subprogram_in_body() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg2 IS
+  FUNCTION get_name(id IN NUMBER) RETURN VARCHAR2;
+  PROCEDURE set_name(id IN NUMBER, name IN VARCHAR2);
+END pkg2;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg2 IS
+  FUNCTION get_name(id IN NUMBER) RETURN VARCHAR2 IS
+  BEGIN
+    RETURN NULL;
+  END;
+END pkg2;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    let missing = errors.iter()
+        .any(|e| matches!(e.kind, PackageConsistencyErrorKind::MissingInBody) && e.subprogram_name.contains("SET_NAME"));
+    assert!(missing, "should detect set_name missing from body");
+}
+
+#[test]
+fn test_package_extra_subprogram_in_body() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg3 IS
+  PROCEDURE do_stuff(a IN NUMBER);
+END pkg3;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg3 IS
+  PROCEDURE do_stuff(a IN NUMBER) IS
+  BEGIN
+    NULL;
+  END;
+  PROCEDURE hidden_proc(x IN VARCHAR2) IS
+  BEGIN
+    NULL;
+  END;
+END pkg3;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    let extra = errors.iter()
+        .any(|e| matches!(e.kind, PackageConsistencyErrorKind::ExtraInBody) && e.subprogram_name.contains("HIDDEN_PROC"));
+    assert!(extra, "should detect hidden_proc as extra in body");
+}
+
+#[test]
+fn test_package_consistent_spec_and_body() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg4 IS
+  FUNCTION add(a IN NUMBER, b IN NUMBER) RETURN NUMBER;
+END pkg4;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg4 IS
+  FUNCTION add(a IN NUMBER, b IN NUMBER) RETURN NUMBER IS
+  BEGIN
+    RETURN a + b;
+  END;
+END pkg4;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    assert!(errors.is_empty(), "matching spec and body should produce no errors, got: {:?}", errors);
+}
+
+#[test]
+fn test_package_no_body_is_ok() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg5 IS
+  PROCEDURE hello;
+END pkg5;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    assert!(errors.is_empty(), "spec without body is valid");
+}
+
+#[test]
+fn test_package_default_value_differs() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg6 IS
+  PROCEDURE test_proc(a IN VARCHAR2 DEFAULT 'hello');
+END pkg6;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg6 IS
+  PROCEDURE test_proc(a IN VARCHAR2 DEFAULT 'world') IS
+  BEGIN
+    NULL;
+  END;
+END pkg6;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    let default_diff = errors.iter()
+        .any(|e| matches!(e.kind, PackageConsistencyErrorKind::DefaultMismatch { .. }));
+    assert!(default_diff, "should detect different default values");
+}
+
+#[test]
+fn test_package_type_mismatch() {
+    let sql = r#"
+CREATE OR REPLACE PACKAGE pkg7 IS
+  PROCEDURE test_proc(a IN VARCHAR2);
+END pkg7;
+/
+
+CREATE OR REPLACE PACKAGE BODY pkg7 IS
+  PROCEDURE test_proc(a IN NUMBER) IS
+  BEGIN
+    NULL;
+  END;
+END pkg7;
+/
+"#;
+    let stmts = parse_stmts(sql);
+    let errors = validate_package_consistency(&stmts);
+    let type_mismatch = errors.iter()
+        .any(|e| matches!(e.kind, PackageConsistencyErrorKind::TypeMismatch { .. }));
+    assert!(type_mismatch, "should detect type mismatch VARCHAR2 vs NUMBER");
 }

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -936,17 +936,37 @@ fn cmd_validate(cli: &Cli) {
     let sql = read_input(cli.file.as_deref());
     let output = parse_input(&sql, false, cli.mybatis);
     let stmts = output.statements;
-    let errors = output.errors;
+    let mut errors = output.errors;
+
+    let pkg_errors = ogsql_parser::validate_package_consistency(&stmts);
+    if !pkg_errors.is_empty() {
+        for pe in &pkg_errors {
+            let msg = match &pe.detail {
+                Some(d) => format!("package {}: {} — {}", pe.package_name, pe.subprogram_name, d),
+                None => format!("package {}: {} — {:?}", pe.package_name, pe.subprogram_name, pe.kind),
+            };
+            errors.push(ogsql_parser::ParserError::Warning {
+                message: msg,
+                location: ogsql_parser::SourceLocation::default(),
+            });
+        }
+    }
 
     if cli.json {
         let warnings: Vec<_> = errors.iter().filter(|e| is_warning(e)).collect();
         let real_errors: Vec<_> = errors.iter().filter(|e| !is_warning(e)).collect();
-        let out = serde_json::json!({
+        let mut out = serde_json::json!({
             "valid": real_errors.is_empty(),
             "error_count": real_errors.len(),
             "warning_count": warnings.len(),
             "errors": errors,
         });
+        if !pkg_errors.is_empty() {
+            out.as_object_mut().unwrap().insert(
+                "package_consistency_errors".to_string(),
+                serde_json::json!(pkg_errors),
+            );
+        }
         println!("{}", serde_json::to_string_pretty(&out).unwrap());
     } else {
         let real_errors: Vec<_> = errors.iter().filter(|e| !is_warning(e)).collect();
@@ -1393,11 +1413,35 @@ mod api {
     )]
     pub async fn handle_validate(Json(input): Json<SqlInput>) -> Json<serde_json::Value> {
         let output = super::parse_input(&input.sql, false, false);
-        Json(serde_json::json!({
-            "valid": output.errors.is_empty(),
-            "error_count": output.errors.len(),
-            "errors": output.errors,
-        }))
+        let pkg_errors = ogsql_parser::validate_package_consistency(&output.statements);
+        let has_pkg_issues = !pkg_errors.is_empty();
+        let mut errors = output.errors;
+        if has_pkg_issues {
+            for pe in &pkg_errors {
+                let msg = match &pe.detail {
+                    Some(d) => format!("package {}: {} — {}", pe.package_name, pe.subprogram_name, d),
+                    None => format!("package {}: {} — {:?}", pe.package_name, pe.subprogram_name, pe.kind),
+                };
+                errors.push(ogsql_parser::ParserError::Warning {
+                    message: msg,
+                    location: ogsql_parser::SourceLocation::default(),
+                });
+            }
+        }
+        let has_real_errors = errors.iter().any(|e| !super::is_warning(e));
+        let mut result = serde_json::json!({
+            "valid": !has_real_errors,
+            "error_count": errors.iter().filter(|e| !super::is_warning(e)).count(),
+            "warning_count": errors.iter().filter(|e| super::is_warning(e)).count(),
+            "errors": errors,
+        });
+        if has_pkg_issues {
+            result.as_object_mut().unwrap().insert(
+                "package_consistency_errors".to_string(),
+                serde_json::json!(pkg_errors),
+            );
+        }
+        Json(result)
     }
 
     /// Convert JSON (from /api/parse) back to SQL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod parser;
 pub mod token;
 pub mod token_formatter;
 
-pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, DynamicSqlReport, QueryFingerprint, TransactionReport};
+pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_package_consistency, DynamicSqlReport, PackageConsistencyError, PackageConsistencyErrorKind, QueryFingerprint, TransactionReport};
 pub use analyzer::schema::{SchemaMap, SchemaResolutionReport, load_schema, resolve_schema};
 
 pub use ast::visitor::{

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -216,15 +216,35 @@ impl OgsqlServer {
                 mybatis_params: false,
             },
         );
-        let errors = output.errors;
+        let pkg_errors = crate::validate_package_consistency(&output.statements);
+        let mut errors = output.errors;
+        if !pkg_errors.is_empty() {
+            for pe in &pkg_errors {
+                let msg = match &pe.detail {
+                    Some(d) => format!("package {}: {} — {}", pe.package_name, pe.subprogram_name, d),
+                    None => format!("package {}: {} — {:?}", pe.package_name, pe.subprogram_name, pe.kind),
+                };
+                errors.push(crate::ParserError::Warning {
+                    message: msg,
+                    location: crate::SourceLocation::default(),
+                });
+            }
+        }
         let has_real_errors = errors.iter().any(|e| !is_warning(e));
-        serde_json::to_string_pretty(&serde_json::json!({
+        let mut result = serde_json::json!({
             "valid": !has_real_errors,
             "error_count": errors.iter().filter(|e| !is_warning(e)).count(),
             "warning_count": errors.iter().filter(|e| is_warning(e)).count(),
             "errors": errors,
-        }))
-        .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
+        });
+        if !pkg_errors.is_empty() {
+            result.as_object_mut().unwrap().insert(
+                "package_consistency_errors".to_string(),
+                serde_json::json!(pkg_errors),
+            );
+        }
+        serde_json::to_string_pretty(&result)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
     }
 
     #[tool(description = "Convert JSON AST (from parse tool output) back to SQL text")]


### PR DESCRIPTION
## Summary

- Add `validate_package_consistency()` in analyzer module to detect mismatches between Oracle package specs (包头) and bodies (包体)
- Detects: parameter count differences, default value mismatches, missing/extra subprograms, type mismatches
- Integrated into `ogsql validate` CLI, HTTP `/api/validate`, and MCP `validate` tool
- Package consistency issues reported as warnings with structured `package_consistency_errors` field in JSON output

## Test plan

- [x] 8 new unit tests covering all mismatch scenarios
- [x] Verified with user's original example (PKG_XML_MANAGE) — correctly detects param count mismatch + 2 default value mismatches
- [x] `cargo test test_package_` — all 9 package-related tests pass
- [x] `cargo check --features cli` — compiles cleanly