### PR TITLE
fix: parse SET and RESET statements inside PL/pgSQL blocks

### DIFF
--- a/src/ast/plpgsql.rs
+++ b/src/ast/plpgsql.rs
@@ -222,6 +222,10 @@ pub enum PlStatement {
     PipeRow {
         expression: crate::ast::Expr,
     },
+
+    VariableSet(Spanned<crate::ast::VariableSetStatement>),
+
+    VariableReset(Spanned<crate::ast::VariableResetStatement>),
 }
 
 // ── Statement Detail Types ──

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -5139,6 +5139,12 @@ impl SqlFormatter {
             PlStatement::PipeRow { expression } => {
                 format!("{}({});", self.kw("PIPE ROW"), self.format_expr(expression))
             }
+            PlStatement::VariableSet(set_stmt) => {
+                format!("{};", self.format_variable_set(set_stmt))
+            }
+            PlStatement::VariableReset(reset_stmt) => {
+                format!("{};", self.format_variable_reset(reset_stmt))
+            }
         }
     }
 

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -699,19 +699,18 @@ impl Parser {
                 self.advance();
                 self.parse_pl_set_transaction()
             } else {
-                self.try_parse_dml_as_pl_statement()
-                    .ok_or_else(|| ParserError::UnexpectedToken {
-                        location: self.current_location(),
-                        expected: "statement".to_string(),
-                        got: format!("{:?}", self.peek()),
-                    })
+                self.advance();
+                let set_stmt = self.parse_set()?;
+                self.try_consume_semicolon();
+                Ok(PlStatement::VariableSet(Spanned::new(set_stmt, None)))
             }
+        } else if self.match_ident_str("reset") {
+            self.advance();
+            let reset_stmt = self.parse_reset()?;
+            self.try_consume_semicolon();
+            Ok(PlStatement::VariableReset(Spanned::new(reset_stmt, None)))
         } else if let Some(stmt) = self.try_parse_dml_as_pl_statement() {
             Ok(stmt)
-        } else if self.match_ident_str("set") && self.lookahead_is_transaction() {
-            self.advance();
-            self.advance();
-            self.parse_pl_set_transaction()
         } else {
             self.parse_pl_sql_or_assignment()
         }?;


### PR DESCRIPTION
## Summary
- Parse `SET variable = value` and `RESET variable` as valid statements inside PL/pgSQL `BEGIN...END` blocks (previously only `SET TRANSACTION` was recognized)
- Add `PlStatement::VariableSet` and `PlStatement::VariableReset` AST variants with full formatter support

## Problem
`SET xmloption = 'document'` and `RESET xmloption` inside package body procedures caused parse errors:
```
Error: unexpected token at line 366, column 8: expected statement, got Keyword(SET)
```

The parser's `parse_pl_statement()` only handled `SET TRANSACTION` in PL blocks — standalone SET/RESET fell through to DML parsing which failed.

## Changes
- **AST** (`src/ast/plpgsql.rs`): Add `VariableSet` and `VariableReset` variants to `PlStatement` enum
- **Parser** (`src/parser/plpgsql.rs`): Handle non-transaction SET via existing `parse_set()`, add RESET branch via `parse_reset()`, remove dead duplicate SET TRANSACTION check
- **Formatter** (`src/formatter.rs`): Format new variants using existing `format_variable_set()`/`format_variable_reset()`

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` — all 1123 tests pass
- [x] Manual validation: `BEGIN SET xmloption = 'document'; RESET xmloption; END;` → VALID
- [x] Format round-trip verified