### PR TITLE
fix: support WITH ... INSERT/UPDATE/DELETE inside PL/pgSQL procedure bodies

### DIFF
--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -809,7 +809,7 @@ impl Parser {
         let save_pos = self.pos;
         let start_pos = self.pos;
                 let result = match self.peek() {
-            Token::Keyword(Keyword::SELECT) | Token::Keyword(Keyword::WITH) => {
+            Token::Keyword(Keyword::SELECT) => {
                 self.pl_into_mode = true;
                 let result = match self.parse_select_statement() {
                     Ok(mut stmt) => {
@@ -822,6 +822,74 @@ impl Parser {
                 };
                 self.pl_into_mode = false;
                 result
+            }
+            Token::Keyword(Keyword::WITH) => {
+                if self.is_with_dml_at(self.pos) {
+                    // WITH ... INSERT/UPDATE/DELETE pattern
+                    let with = match self.parse_with_clause() {
+                        Ok(Some(w)) => w,
+                        _ => { self.pos = save_pos; return None; }
+                    };
+                    self.pl_into_mode = true;
+                    let result = match self.peek_keyword() {
+                        Some(Keyword::INSERT) => {
+                            self.advance();
+                            match self.parse_insert() {
+                                Ok(mut stmt) => {
+                                    stmt.with = Some(with);
+                                    let mut merged = hints;
+                                    merged.append(&mut stmt.hints);
+                                    stmt.hints = merged;
+                                    Some(crate::ast::Statement::Insert(crate::ast::Spanned::new(stmt, None)))
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                        Some(Keyword::UPDATE) => {
+                            self.advance();
+                            match self.parse_update() {
+                                Ok(mut stmt) => {
+                                    stmt.with = Some(with);
+                                    let mut merged = hints;
+                                    merged.append(&mut stmt.hints);
+                                    stmt.hints = merged;
+                                    Some(crate::ast::Statement::Update(crate::ast::Spanned::new(stmt, None)))
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                        Some(Keyword::DELETE_P) => {
+                            self.advance();
+                            match self.parse_delete() {
+                                Ok(mut stmt) => {
+                                    stmt.with = Some(with);
+                                    let mut merged = hints;
+                                    merged.append(&mut stmt.hints);
+                                    stmt.hints = merged;
+                                    Some(crate::ast::Statement::Delete(crate::ast::Spanned::new(stmt, None)))
+                                }
+                                Err(_) => None,
+                            }
+                        }
+                        _ => None,
+                    };
+                    self.pl_into_mode = false;
+                    result
+                } else {
+                    // Plain WITH ... SELECT (CTE)
+                    self.pl_into_mode = true;
+                    let result = match self.parse_select_statement() {
+                        Ok(mut stmt) => {
+                            let mut merged = hints;
+                            merged.append(&mut stmt.hints);
+                            stmt.hints = merged;
+                            Some(crate::ast::Statement::Select(crate::ast::Spanned::new(stmt, None)))
+                        }
+                        Err(_) => None,
+                    };
+                    self.pl_into_mode = false;
+                    result
+                }
             }
             Token::Keyword(Keyword::INSERT) => {
                 self.pl_into_mode = true;
@@ -919,10 +987,58 @@ impl Parser {
         let save_pos = self.pos;
 
         let result = match self.peek() {
-            Token::Keyword(Keyword::SELECT) | Token::Keyword(Keyword::WITH) => {
+            Token::Keyword(Keyword::SELECT) => {
                 match self.parse_select_statement() {
                     Ok(stmt) => Some(crate::ast::Statement::Select(crate::ast::Spanned::new(stmt, None))),
                     Err(_) => None,
+                }
+            }
+            Token::Keyword(Keyword::WITH) => {
+                if self.is_with_dml_at(self.pos) {
+                    // WITH ... INSERT/UPDATE/DELETE pattern
+                    let with = match self.parse_with_clause() {
+                        Ok(Some(w)) => w,
+                        _ => { self.pos = save_pos; return None; }
+                    };
+                    match self.peek_keyword() {
+                        Some(Keyword::INSERT) => {
+                            self.advance();
+                            match self.parse_insert() {
+                                Ok(mut stmt) => {
+                                    stmt.with = Some(with);
+                                    Some(crate::ast::Statement::Insert(crate::ast::Spanned::new(stmt, None)))
+                                }
+                                Err(_) => { self.pos = save_pos; None }
+                            }
+                        }
+                        Some(Keyword::UPDATE) => {
+                            self.advance();
+                            match self.parse_update() {
+                                Ok(mut stmt) => {
+                                    stmt.with = Some(with);
+                                    Some(crate::ast::Statement::Update(crate::ast::Spanned::new(stmt, None)))
+                                }
+                                Err(_) => { self.pos = save_pos; None }
+                            }
+                        }
+                        Some(Keyword::DELETE_P) => {
+                            self.advance();
+                            match self.parse_delete() {
+                                Ok(mut stmt) => {
+                                    stmt.with = Some(with);
+                                    Some(crate::ast::Statement::Delete(crate::ast::Spanned::new(stmt, None)))
+                                }
+                                Err(_) => { self.pos = save_pos; None }
+                            }
+                        }
+                        _ => { self.pos = save_pos; None }
+                    }
+                } else {
+                    // Plain WITH ... SELECT (CTE)
+                    match self.parse_select_statement() {
+                        Ok(stmt) => Some(crate::ast::Statement::Select(crate::ast::Spanned::new(stmt, None))),
+                        Err(_) => None,
+                    }
                 }
             }
             Token::LParen if self.looks_like_parenthesized_query() => {

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -614,3 +614,140 @@ fn test_pl_call_inside_package_body() {
         other => panic!("expected CreatePackageBody, got {:?}", other),
     }
 }
+
+#[test]
+fn test_with_insert_in_procedure_body() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY my_pkg IS
+               PROCEDURE proc1 IS
+               BEGIN
+                 WITH cte AS (SELECT id FROM t1)
+                 INSERT INTO t2 SELECT * FROM cte;
+               END proc1;
+               END my_pkg;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            let proc = p.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::SqlStatement { statement, .. } => {
+                    match statement.as_ref() {
+                        crate::ast::Statement::Insert(ins) => {
+                            assert!(ins.node.with.is_some(), "INSERT should have WITH clause");
+                            assert_eq!(ins.node.table, vec!["t2"]);
+                        }
+                        other => panic!("expected Insert, got {:?}", other),
+                    }
+                }
+                other => panic!("expected SqlStatement, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_with_update_in_procedure_body() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY my_pkg IS
+               PROCEDURE proc1 IS
+               BEGIN
+                 WITH cte AS (SELECT id, name FROM t1)
+                 UPDATE t2 SET name = cte.name FROM cte WHERE t2.id = cte.id;
+               END proc1;
+               END my_pkg;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            let proc = p.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::SqlStatement { statement, .. } => {
+                    match statement.as_ref() {
+                        crate::ast::Statement::Update(upd) => {
+                            assert!(upd.node.with.is_some(), "UPDATE should have WITH clause");
+                        }
+                        other => panic!("expected Update, got {:?}", other),
+                    }
+                }
+                other => panic!("expected SqlStatement, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_with_delete_in_procedure_body() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY my_pkg IS
+               PROCEDURE proc1 IS
+               BEGIN
+                 WITH cte AS (SELECT id FROM t1 WHERE status = 'inactive')
+                 DELETE FROM t2 USING cte WHERE t2.id = cte.id;
+               END proc1;
+               END my_pkg;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            let proc = p.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::SqlStatement { statement, .. } => {
+                    match statement.as_ref() {
+                        crate::ast::Statement::Delete(del) => {
+                            assert!(del.node.with.is_some(), "DELETE should have WITH clause");
+                        }
+                        other => panic!("expected Delete, got {:?}", other),
+                    }
+                }
+                other => panic!("expected SqlStatement, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_with_select_cte_still_works_in_procedure_body() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY my_pkg IS
+               PROCEDURE proc1 IS
+                 v_result INTEGER;
+               BEGIN
+                 WITH cte AS (SELECT id FROM t1) SELECT COUNT(*) INTO v_result FROM cte;
+               END proc1;
+               END my_pkg;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            let proc = p.items.iter().find_map(|i| match i {
+                PackageItem::Procedure(pr) => Some(pr),
+                _ => None,
+            }).expect("should have a procedure");
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::SqlStatement { statement, .. } => {
+                    match statement.as_ref() {
+                        crate::ast::Statement::Select(sel) => {
+                            assert!(sel.node.with.is_some(), "SELECT should have WITH clause");
+                        }
+                        other => panic!("expected Select, got {:?}", other),
+                    }
+                }
+                other => panic!("expected SqlStatement, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

- Fix PL block statement dispatcher to recognize `WITH ... INSERT/UPDATE/DELETE` pattern inside procedure bodies
- Add `is_with_dml_at()` pre-scan to `try_parse_dml_as_pl_statement()` and `try_parse_dml_statement()`, mirroring the existing top-level dispatcher logic in `mod.rs`

## Problem

PL block statement parsing routed `WITH` directly to `parse_select_statement()` without checking if the CTE is followed by `INSERT/UPDATE/DELETE` instead of `SELECT`. This caused:
- Parse error: `unexpected token ... expected end of statement, got Keyword(END_P)`
- 7 cascading `reserved keyword "xxx" cannot be used as identifier` warnings

## Test plan

- [x] 4 new unit tests: `test_with_insert_in_procedure_body`, `test_with_update_in_procedure_body`, `test_with_delete_in_procedure_body`, `test_with_select_cte_still_works_in_procedure_body`
- [x] Full regression: 1137 tests passed, 0 failures
- [x] Verified against complex real-world SQL (3 CTEs, UNION ALL, nested CASE, subqueries)