### PR TITLE
fix: parse UNION ALL after bracketed INSERT subquery instead of erroring

### DIFF
--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -112,22 +112,15 @@ impl Parser {
                 if *kw == Keyword::SELECT || *kw == Keyword::WITH {
                     self.advance();
                     let paren_loc = self.current_location();
-                    let select = self.parse_select_statement()?;
+                    let mut select = self.parse_select_statement()?;
                     self.expect_token(&Token::RParen)?;
-                    // Detect unsupported pattern: INSERT INTO ... (SELECT ...) UNION ALL (SELECT ...)
-                    // GaussDB/openGauss does not support UNION ALL with bracketed subqueries in INSERT source.
+                    // Detect pattern: INSERT INTO ... (SELECT ...) UNION ALL (SELECT ...)
+                    // GaussDB/openGauss supports this syntax; emit a compatibility warning.
                     if let Some(Token::Keyword(kw)) = self.tokens.get(self.pos).map(|tws| &tws.token) {
                         if matches!(kw, Keyword::UNION | Keyword::INTERSECT | Keyword::EXCEPT | Keyword::MINUS_P) {
                             self.add_error(ParserError::Warning {
                                 message: format!(
-                                    "bracketed INSERT ... (SELECT ...) {} is not supported in GaussDB/openGauss — remove the parentheses around each SELECT branch to use {} with INSERT",
-                                    match kw {
-                                        Keyword::UNION => "UNION",
-                                        Keyword::INTERSECT => "INTERSECT",
-                                        Keyword::EXCEPT => "EXCEPT",
-                                        Keyword::MINUS_P => "MINUS",
-                                        _ => unreachable!(),
-                                    },
+                                    "bracketed INSERT ... (SELECT ...) {} — consider removing parentheses around each SELECT branch for clarity",
                                     match kw {
                                         Keyword::UNION => "UNION",
                                         Keyword::INTERSECT => "INTERSECT",
@@ -138,6 +131,7 @@ impl Parser {
                                 ),
                                 location: paren_loc,
                             });
+                            select = self.parse_set_operations(select)?;
                         }
                     }
                     InsertSource::Select(Box::new(select))

--- a/src/parser/select.rs
+++ b/src/parser/select.rs
@@ -45,7 +45,7 @@ impl Parser {
         Ok(stmt)
     }
 
-    fn parse_set_operations(&mut self, mut stmt: SelectStatement) -> Result<SelectStatement, ParserError> {
+    pub(crate) fn parse_set_operations(&mut self, mut stmt: SelectStatement) -> Result<SelectStatement, ParserError> {
         loop {
             let (op, all) = match self.peek_keyword() {
                 Some(Keyword::UNION) => {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -5223,6 +5223,57 @@ fn test_insert_all_into_with_columns() {
 }
 
 #[test]
+fn test_insert_bracketed_select_union_all_warning_only() {
+    let sql = "INSERT INTO otab (a, b, c) (SELECT x, y, z FROM t1 WHERE id = 1) UNION ALL (SELECT NULL, NULL, '0' FROM sys_dummy)";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+
+    assert_eq!(stmts.len(), 1, "should parse as a single INSERT statement");
+
+    let errors = parser.errors();
+    let warnings: Vec<_> = errors
+        .iter()
+        .filter(|e| matches!(e, ParserError::Warning { .. }))
+        .collect();
+    let hard_errors: Vec<_> = errors
+        .iter()
+        .filter(|e| !matches!(e, ParserError::Warning { .. }))
+        .collect();
+
+    assert_eq!(warnings.len(), 1, "should produce exactly one warning");
+    assert!(
+        warnings[0].to_string().contains("bracketed INSERT"),
+        "warning should mention bracketed INSERT"
+    );
+    assert!(
+        hard_errors.is_empty(),
+        "should produce no hard errors, got: {:?}",
+        hard_errors
+    );
+
+    match &stmts[0] {
+        Statement::Insert(ins) => match &ins.source {
+            InsertSource::Select(sel) => {
+                assert!(
+                    sel.set_operation.is_some(),
+                    "UNION ALL should be captured in set_operation"
+                );
+                match sel.set_operation.as_ref().unwrap() {
+                    SetOperation::Union { all, right } => {
+                        assert!(all, "should be UNION ALL");
+                        assert_eq!(right.from.len(), 1);
+                    }
+                    _ => panic!("expected Union set operation"),
+                }
+            }
+            _ => panic!("expected Select source"),
+        },
+        _ => panic!("expected Insert statement"),
+    }
+}
+
+#[test]
 fn test_pivot() {
     let stmt = parse_one(
         "SELECT * FROM sales PIVOT (SUM(amount) FOR quarter IN ('Q1' AS q1, 'Q2' AS q2))",


### PR DESCRIPTION
## Summary
- `INSERT INTO t(cols) (SELECT ...) UNION ALL (SELECT ...)` 这种带括号的写法在高斯数据库中合法支持，但之前解析器在发出 Warning 后停止解析，导致 `UnexpectedToken` 硬错误
- 修改为：Warning 之后继续调用 `parse_set_operations` 消费 UNION ALL 分支，完整解析为 AST，仅保留兼容性提示，不再中断处理
- 新增守护测试 `test_insert_bracketed_select_union_all_warning_only`：验证只有 Warning 无 Error、UNION ALL 正确进入 `set_operation`、右侧 SELECT 正确解析

## Test plan
- [x] `cargo test` — 1142 passed, 0 failed
- [x] 新增守护测试验证 warning-only 行为
- [x] CLI 验证 `ogsql parse -j` 输出仅含 Warning、AST 包含完整 UNION ALL