### PR TITLE
fix: support IS TRUE/FALSE expressions (fixes #122)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1255,6 +1255,11 @@ pub enum Expr {
         expr: Box<Expr>,
         negated: bool,
     },
+    IsBoolean {
+        expr: Box<Expr>,
+        value: bool,
+        negated: bool,
+    },
     TypeCast {
         expr: Box<Expr>,
         type_name: DataType,

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -1056,6 +1056,11 @@ fn walk_expr(visitor: &mut dyn Visitor, expr: &Expr) -> VisitorResult {
                 return VisitorResult::Stop;
             }
         }
+        Expr::IsBoolean { expr, .. } => {
+            if walk_expr(visitor, expr) == VisitorResult::Stop {
+                return VisitorResult::Stop;
+            }
+        }
         Expr::TypeCast { expr, default, format, .. } => {
             if walk_expr(visitor, expr) == VisitorResult::Stop {
                 return VisitorResult::Stop;

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1155,6 +1155,28 @@ impl SqlFormatter {
                     self.kw("NULL")
                 )
             }
+            Expr::IsBoolean {
+                expr,
+                value,
+                negated,
+            } => {
+                let not_str = if *negated {
+                    format!(" {}", self.kw("NOT"))
+                } else {
+                    String::new()
+                };
+                let bool_str = if *value {
+                    self.kw("TRUE")
+                } else {
+                    self.kw("FALSE")
+                };
+                format!(
+                    "{} IS{} {}",
+                    self.format_expr(expr),
+                    not_str,
+                    bool_str
+                )
+            }
             Expr::TypeCast {
                 expr,
                 type_name,

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -300,6 +300,28 @@ impl Parser {
                                     };
                                     return Ok(true);
                                 }
+                                if matches!(&next2.token, Token::Keyword(Keyword::TRUE_P)) {
+                                    self.advance();
+                                    self.advance();
+                                    self.advance();
+                                    *left = Expr::IsBoolean {
+                                        expr: Box::new(std::mem::replace(left, Expr::Default)),
+                                        value: true,
+                                        negated: true,
+                                    };
+                                    return Ok(true);
+                                }
+                                if matches!(&next2.token, Token::Keyword(Keyword::FALSE_P)) {
+                                    self.advance();
+                                    self.advance();
+                                    self.advance();
+                                    *left = Expr::IsBoolean {
+                                        expr: Box::new(std::mem::replace(left, Expr::Default)),
+                                        value: false,
+                                        negated: true,
+                                    };
+                                    return Ok(true);
+                                }
                                 if matches!(&next2.token, Token::Keyword(Keyword::DISTINCT)) {
                                     if let Some(next3) = self.tokens.get(self.pos + 3) {
                                         if matches!(&next3.token, Token::Keyword(Keyword::FROM)) {
@@ -319,6 +341,26 @@ impl Parser {
                                     }
                                 }
                             }
+                        }
+                        Token::Keyword(Keyword::TRUE_P) => {
+                            self.advance();
+                            self.advance();
+                            *left = Expr::IsBoolean {
+                                expr: Box::new(std::mem::replace(left, Expr::Default)),
+                                value: true,
+                                negated: false,
+                            };
+                            return Ok(true);
+                        }
+                        Token::Keyword(Keyword::FALSE_P) => {
+                            self.advance();
+                            self.advance();
+                            *left = Expr::IsBoolean {
+                                expr: Box::new(std::mem::replace(left, Expr::Default)),
+                                value: false,
+                                negated: false,
+                            };
+                            return Ok(true);
                         }
                         Token::Keyword(Keyword::DISTINCT) => {
                             if let Some(next2) = self.tokens.get(self.pos + 2) {

--- a/src/parser/tests_plsql_fixes.rs
+++ b/src/parser/tests_plsql_fixes.rs
@@ -751,3 +751,263 @@ fn test_with_select_cte_still_works_in_procedure_body() {
         other => panic!("expected CreatePackageBody, got {:?}", other),
     }
 }
+
+// ========== IS TRUE / IS FALSE expression support (issue #122) ==========
+
+#[test]
+fn test_is_true_in_select() {
+    let sql = "SELECT * FROM t WHERE active IS TRUE";
+    let stmts = parse(sql);
+    assert!(stmts.len() == 1);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            let where_clause = sel.node.where_clause.as_ref().expect("should have WHERE");
+            match where_clause {
+                Expr::IsBoolean { expr, value, negated } => {
+                    assert!(matches!(expr.as_ref(), Expr::ColumnRef(_)));
+                    assert!(*value);
+                    assert!(!negated);
+                }
+                other => panic!("expected IsBoolean, got {:?}", other),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_false_in_select() {
+    let sql = "SELECT * FROM t WHERE active IS FALSE";
+    let stmts = parse(sql);
+    assert!(stmts.len() == 1);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            let where_clause = sel.node.where_clause.as_ref().expect("should have WHERE");
+            match where_clause {
+                Expr::IsBoolean { expr, value, negated } => {
+                    assert!(matches!(expr.as_ref(), Expr::ColumnRef(_)));
+                    assert!(!value);
+                    assert!(!negated);
+                }
+                other => panic!("expected IsBoolean, got {:?}", other),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_not_true_in_select() {
+    let sql = "SELECT * FROM t WHERE active IS NOT TRUE";
+    let stmts = parse(sql);
+    assert!(stmts.len() == 1);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            let where_clause = sel.node.where_clause.as_ref().expect("should have WHERE");
+            match where_clause {
+                Expr::IsBoolean { expr, value, negated } => {
+                    assert!(matches!(expr.as_ref(), Expr::ColumnRef(_)));
+                    assert!(*value);
+                    assert!(*negated);
+                }
+                other => panic!("expected IsBoolean, got {:?}", other),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_not_false_in_select() {
+    let sql = "SELECT * FROM t WHERE active IS NOT FALSE";
+    let stmts = parse(sql);
+    assert!(stmts.len() == 1);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            let where_clause = sel.node.where_clause.as_ref().expect("should have WHERE");
+            match where_clause {
+                Expr::IsBoolean { expr, value, negated } => {
+                    assert!(matches!(expr.as_ref(), Expr::ColumnRef(_)));
+                    assert!(!value);
+                    assert!(*negated);
+                }
+                other => panic!("expected IsBoolean, got {:?}", other),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_true_in_plpgsql_if() {
+    let sql = "CREATE OR REPLACE FUNCTION test_fn(p_flag IN BOOLEAN) RETURN NUMBER IS
+    BEGIN
+        IF p_flag IS TRUE THEN RETURN 1; ELSE RETURN 0; END IF;
+    END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateFunction(f) => {
+            let block = f.block.as_ref().expect("function should have a body");
+            assert_eq!(block.body.len(), 1);
+            match &block.body[0] {
+                PlStatement::If(if_stmt) => {
+                    match &if_stmt.node.condition {
+                        Expr::IsBoolean { expr, value, negated } => {
+                            assert!(matches!(expr.as_ref(), Expr::PlVariable(_)));
+                            assert!(*value);
+                            assert!(!negated);
+                        }
+                        other => panic!("expected IsBoolean condition, got {:?}", other),
+                    }
+                    assert_eq!(if_stmt.node.then_stmts.len(), 1);
+                    assert_eq!(if_stmt.node.else_stmts.len(), 1);
+                }
+                other => panic!("expected If statement, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateFunction, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_false_in_plpgsql_if() {
+    let sql = "CREATE OR REPLACE FUNCTION test_fn(p_flag IN BOOLEAN) RETURN NUMBER IS
+    BEGIN
+        IF p_flag IS FALSE THEN RETURN 0; END IF;
+    END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateFunction(f) => {
+            let block = f.block.as_ref().expect("function should have a body");
+            match &block.body[0] {
+                PlStatement::If(if_stmt) => {
+                    match &if_stmt.node.condition {
+                        Expr::IsBoolean { value, negated, .. } => {
+                            assert!(!value);
+                            assert!(!negated);
+                        }
+                        other => panic!("expected IsBoolean, got {:?}", other),
+                    }
+                }
+                other => panic!("expected If, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateFunction, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_not_true_in_plpgsql_if() {
+    let sql = "CREATE OR REPLACE FUNCTION test_fn(p_flag IN BOOLEAN) RETURN NUMBER IS
+    BEGIN
+        IF p_flag IS NOT TRUE THEN RETURN 0; END IF;
+    END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateFunction(f) => {
+            let block = f.block.as_ref().expect("function should have a body");
+            match &block.body[0] {
+                PlStatement::If(if_stmt) => {
+                    match &if_stmt.node.condition {
+                        Expr::IsBoolean { value, negated, .. } => {
+                            assert!(*value);
+                            assert!(*negated);
+                        }
+                        other => panic!("expected IsBoolean, got {:?}", other),
+                    }
+                }
+                other => panic!("expected If, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreateFunction, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_true_formatter_roundtrip() {
+    let sql = "SELECT * FROM t WHERE active IS TRUE";
+    let stmts = parse(sql);
+    let formatter = SqlFormatter::new();
+    let output = formatter.format_statement(&stmts[0]);
+    assert!(output.contains("IS TRUE"), "formatted output should contain 'IS TRUE': {}", output);
+}
+
+#[test]
+fn test_is_not_false_formatter_roundtrip() {
+    let sql = "SELECT * FROM t WHERE active IS NOT FALSE";
+    let stmts = parse(sql);
+    let formatter = SqlFormatter::new();
+    let output = formatter.format_statement(&stmts[0]);
+    assert!(output.contains("IS NOT FALSE"), "formatted output should contain 'IS NOT FALSE': {}", output);
+}
+
+#[test]
+fn test_package_body_overloaded_functions_with_is_true() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY complex_clearing_pkg AS
+        FUNCTION calc_fee(p_amount IN NUMERIC) RETURN NUMERIC IS
+        BEGIN RETURN p_amount; END;
+        FUNCTION calc_fee(p_amount IN NUMERIC, p_vip_level IN INT DEFAULT 1) RETURN NUMERIC IS
+            v_rate NUMERIC;
+        BEGIN
+            v_rate := 0.0015;
+            RETURN ROUND(p_amount * v_rate, 2);
+        END;
+        FUNCTION calc_fee(p_amount IN NUMERIC, p_discount_rate IN NUMERIC, p_apply_ceil IN BOOLEAN) RETURN NUMERIC IS
+            v_raw NUMERIC;
+        BEGIN
+            v_raw := p_amount * p_discount_rate;
+            IF p_apply_ceil IS TRUE THEN RETURN CEIL(v_raw); ELSE RETURN v_raw; END IF;
+        END;
+    END;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            let funcs: Vec<_> = p
+                .items
+                .iter()
+                .filter_map(|item| match item {
+                    PackageItem::Function(f) => Some(f.clone()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(funcs.len(), 3, "should have 3 overloaded calc_fee functions, got {}", funcs.len());
+            assert_eq!(funcs[0].name, vec!["calc_fee"]);
+            assert_eq!(funcs[0].parameters.len(), 1);
+            assert!(funcs[0].block.is_some());
+            assert_eq!(funcs[1].name, vec!["calc_fee"]);
+            assert_eq!(funcs[1].parameters.len(), 2);
+            assert!(funcs[1].block.is_some());
+            assert_eq!(funcs[2].name, vec!["calc_fee"]);
+            assert_eq!(funcs[2].parameters.len(), 3);
+            assert!(funcs[2].block.is_some());
+
+            let block3 = funcs[2].block.as_ref().expect("3rd overload should have body");
+            assert_eq!(block3.body.len(), 2, "3rd overload body should have 2 statements");
+            match &block3.body[1] {
+                PlStatement::If(if_stmt) => {
+                    match &if_stmt.node.condition {
+                        Expr::IsBoolean { value, negated, .. } => {
+                            assert!(*value, "condition should be IS TRUE");
+                            assert!(!negated);
+                        }
+                        other => panic!("expected IsBoolean in 3rd overload IF condition, got {:?}", other),
+                    }
+                }
+                other => panic!("expected If in 3rd overload body, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_is_true_json_roundtrip() {
+    let sql = "SELECT * FROM t WHERE x IS TRUE AND y IS NOT FALSE";
+    let stmts = parse(sql);
+    let json = serde_json::to_string(&stmts).unwrap();
+    let restored: Vec<Statement> = serde_json::from_str(&json).unwrap();
+    let formatter = SqlFormatter::new();
+    let output = formatter.format_statement(&restored[0]);
+    assert!(output.contains("IS TRUE"));
+    assert!(output.contains("IS NOT FALSE"));
+}


### PR DESCRIPTION
## Summary

- Add `Expr::IsBoolean` AST variant with full parser support for `IS TRUE`, `IS FALSE`, `IS NOT TRUE`, `IS NOT FALSE` postfix operators
- Add formatter output, visitor walk, and JSON serde support for the new expression type
- Add 11 regression tests covering SELECT WHERE, PL/pgSQL IF conditions, formatter/JSON roundtrip, and Package Body overloaded functions

## Root Cause

Issue #122 表面现象是"Package Body 第 3 个重载的 body 被丢弃"，实际根因是 **Pratt parser 的 `try_postfix_op` 不支持 `IS TRUE` / `IS FALSE` 后缀表达式**。

当 `parse_pl_if` 解析 `IF p_apply_ceil IS TRUE THEN ...` 时，`parse_expr()` 不识别 `IS TRUE`，导致 `IS` 未被消费，`expect_ident_str("then")` 失败，整个函数解析 error recovery 后退化为 `Raw` fallback。

## Changes

| File | Change |
|------|--------|
| `src/ast/mod.rs` | +`Expr::IsBoolean { expr, value, negated }` |
| `src/parser/expr.rs` | `try_postfix_op` IS 分支新增 `TRUE_P`/`FALSE_P` 匹配 |
| `src/formatter.rs` | `IsBoolean` 格式化输出 |
| `src/ast/visitor.rs` | `IsBoolean` walk 遍历 |
| `src/parser/tests_plsql_fixes.rs` | 11 new tests |

## Test plan

- [x] 1153 tests pass (1142 baseline + 11 new)
- [x] Issue #122 reproduction SQL parses with 0 errors, all 3 overloads present
- [x] Formatter roundtrip preserves `IS TRUE` / `IS NOT FALSE`
- [x] JSON serde roundtrip preserves semantics

Fixes #122