### PR TITLE
fix(cli): prevent stack overflow in variable chain resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -667,28 +667,46 @@ fn join_concat_parts(
     vars: &std::collections::HashMap<String, Option<String>>,
     assigns: &std::collections::HashMap<String, Vec<ConcatPart>>,
 ) -> String {
+    join_concat_parts_inner(parts, replace_fn, vars, assigns, &mut std::collections::HashSet::new())
+}
+
+fn join_concat_parts_inner(
+    parts: &[ConcatPart],
+    replace_fn: &dyn Fn(&str, &std::collections::HashMap<String, Option<String>>) -> String,
+    vars: &std::collections::HashMap<String, Option<String>>,
+    assigns: &std::collections::HashMap<String, Vec<ConcatPart>>,
+    visited: &mut std::collections::HashSet<String>,
+) -> String {
     let vars_empty = vars.is_empty();
     let mut sql = String::new();
     for part in parts {
         match part {
             ConcatPart::Literal(s) => sql.push_str(s),
             ConcatPart::Variable(name) => {
-                if let Some(traced_parts) = assigns.get(&name.to_ascii_lowercase()) {
-                    let has_inner_vars = traced_parts.iter().any(|p| !matches!(p, ConcatPart::Literal(_)));
-                    if has_inner_vars {
-                        sql.push_str(&join_concat_parts(traced_parts, replace_fn, vars, assigns));
-                    } else {
-                        let flat: String = traced_parts.iter().map(|p| match p {
-                            ConcatPart::Literal(s) => s.as_str(), _ => ""
-                        }).collect();
-                        sql.push_str(&flat);
+                let key = name.to_ascii_lowercase();
+                if !visited.contains(&key) {
+                    if let Some(traced_parts) = assigns.get(&key) {
+                        let has_inner_vars = traced_parts.iter().any(|p| !matches!(p, ConcatPart::Literal(_)));
+                        if has_inner_vars {
+                            visited.insert(key.clone());
+                            sql.push_str(&join_concat_parts_inner(traced_parts, replace_fn, vars, assigns, visited));
+                            visited.remove(&key);
+                            continue;
+                        } else {
+                            let flat: String = traced_parts.iter().map(|p| match p {
+                                ConcatPart::Literal(s) => s.as_str(), _ => ""
+                            }).collect();
+                            sql.push_str(&flat);
+                            continue;
+                        }
                     }
-                } else if vars_empty {
+                }
+                if vars_empty {
                     sql.push_str(name);
                 } else {
                     let single_var: std::collections::HashMap<String, Option<String>> = {
                         let mut m = std::collections::HashMap::new();
-                        m.insert(name.to_ascii_lowercase(), vars.get(&name.to_ascii_lowercase()).cloned().flatten());
+                        m.insert(key.clone(), vars.get(&key).cloned().flatten());
                         m
                     };
                     let replaced = replace_fn(name, &single_var);


### PR DESCRIPTION
## Summary
- Add cycle detection via `visited` HashSet in `join_concat_parts_inner` to prevent infinite recursion when variables are self-referencing (e.g. `v_sql := v_sql || ' extra'`) or mutually referential
- Bump version to 0.4.3

## Test plan
- [x] Reproduces the crash: `v_sql := v_sql || ' extra'` → stack overflow before fix
- [x] After fix: self-referencing var outputs `v_sql extra` (keeps var name, no crash)
- [x] Multi-level chain still resolves correctly: `v3 → v2 → v1` flattens to full SQL
- [x] Real file `PKG_WARPDRIVER_STRESS_TEST.sql` still produces correct output
- [x] All 1179 tests pass (1153 lib + 26 bin)