### PR TITLE
feat(cli): extract embedded SQL from FOR/OPEN cursor constructs in CSV output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -216,18 +216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -247,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -507,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -629,12 +627,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -684,9 +682,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -696,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -771,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.4.0"
+version = "0.4.4"
 dependencies = [
  "axum",
  "clap",
@@ -905,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -1017,9 +1015,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -1039,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1232,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1337,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1392,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
@@ -1520,9 +1518,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap",
  "serde",
@@ -1532,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1559,9 +1557,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1572,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1582,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1595,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -622,6 +622,7 @@ fn format_params(params: &[ogsql_parser::ast::RoutineParam]) -> String {
         .join(", ")
 }
 
+#[derive(Clone)]
 enum ConcatPart {
     Literal(String),
     Variable(String),
@@ -901,6 +902,13 @@ fn format_pl_expr(expr: &ogsql_parser::ast::Expr) -> String {
         Expr::Literal(Literal::DollarString { tag: None, body }) => format!("$${}$$", body),
         Expr::Literal(Literal::DollarString { tag: Some(t), body }) => format!("${}${}", t, body),
         Expr::Literal(Literal::EscapeString(s)) => format!("E'{}'", s),
+        Expr::Literal(Literal::Integer(n)) => n.to_string(),
+        Expr::Literal(Literal::Float(s)) => s.clone(),
+        Expr::Literal(Literal::Boolean(b)) => b.to_string(),
+        Expr::Literal(Literal::Null) => "NULL".into(),
+        Expr::Literal(Literal::BitString(s)) => format!("B'{}'", s),
+        Expr::Literal(Literal::HexString(s)) => format!("X'{}'", s),
+        Expr::Literal(Literal::NationalString(s)) => format!("N'{}'", s),
         Expr::ColumnRef(names) | Expr::PlVariable(names) => names.join("."),
         Expr::BinaryOp { op, left, right, .. } => {
             format!("{} {} {}", format_pl_expr(left), op, format_pl_expr(right))
@@ -944,6 +952,215 @@ fn extract_block_sql(block: &ogsql_parser::ast::plpgsql::PlBlock) -> String {
     parts.join("\\n")
 }
 
+fn format_using_args_pl(args: &[ogsql_parser::ast::plpgsql::PlUsingArg]) -> String {
+    if args.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = args.iter().map(|a| {
+        let mode_prefix = match a.mode {
+            ogsql_parser::ast::plpgsql::PlUsingMode::In => "",
+            ogsql_parser::ast::plpgsql::PlUsingMode::Out => "OUT ",
+            ogsql_parser::ast::plpgsql::PlUsingMode::InOut => "INOUT ",
+        };
+        format!("{}{}", mode_prefix, format_pl_expr(&a.argument))
+    }).collect();
+    format!("USING {}", parts.join(", "))
+}
+
+fn format_using_args_exprs(args: &[ogsql_parser::ast::Expr]) -> String {
+    if args.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = args.iter().map(|a| format_pl_expr(a)).collect();
+    parts.join(", ")
+}
+
+fn build_dynamic_sql_from_expr(
+    expr: &ogsql_parser::ast::Expr,
+    vars: &std::collections::HashMap<String, Option<String>>,
+    assigns: &std::collections::HashMap<String, Vec<ConcatPart>>,
+) -> String {
+    use ogsql_parser::ast::{Expr, Literal};
+
+    match expr {
+        Expr::Literal(Literal::String(s)) => replace_pl_vars_in_sql(s.trim(), vars),
+        Expr::Literal(Literal::DollarString { body, .. }) => replace_pl_vars_in_sql(body.trim(), vars),
+        Expr::Literal(Literal::EscapeString(s)) => replace_pl_vars_in_sql(s.trim(), vars),
+        Expr::ColumnRef(names) | Expr::PlVariable(names) if names.len() == 1 => {
+            let var_name = &names[0];
+            if let Some(traced_parts) = assigns.get(&var_name.to_ascii_lowercase()) {
+                let has_vars = traced_parts.iter().any(|p| !matches!(p, ConcatPart::Literal(_)));
+                if has_vars {
+                    return join_concat_parts(traced_parts, &replace_pl_vars_in_sql_raw, vars, assigns);
+                } else {
+                    let flat: String = traced_parts.iter().map(|p| match p {
+                        ConcatPart::Literal(s) => s.as_str(), _ => ""
+                    }).collect();
+                    return replace_pl_vars_in_sql_raw(flat.trim(), vars);
+                }
+            }
+            format_pl_expr(expr)
+        }
+        Expr::BinaryOp { op, .. } if op == "||" => {
+            let parts = eval_concat_expr(expr);
+            join_concat_parts(&parts, &replace_pl_vars_in_sql_raw, vars, assigns)
+        }
+        _ => format_pl_expr(expr),
+    }
+}
+
+fn resolve_for_query_text(
+    query: &str,
+    vars: &std::collections::HashMap<String, Option<String>>,
+    assigns: &std::collections::HashMap<String, Vec<ConcatPart>>,
+) -> (String, String) {
+    let q = query.trim();
+    if q.is_empty() {
+        return ("Embedded/Select".into(), String::new());
+    }
+
+    let is_execute_prefix = q.to_ascii_lowercase().starts_with("execute ");
+    let looks_like_static_sql = ["select ", "insert ", "update ", "delete ", "merge ", "with "]
+        .iter()
+        .any(|kw| q.to_ascii_lowercase().starts_with(kw));
+
+    if is_execute_prefix {
+        let after_execute = q[8..].trim_start();
+        let after_execute = if after_execute.to_ascii_lowercase().starts_with("immediate ") {
+            after_execute[9..].trim_start()
+        } else {
+            after_execute
+        };
+        let inner = strip_trailing_using(after_execute);
+        let sql = resolve_dynamic_query_text(inner.trim(), vars, assigns);
+        let using_part = extract_trailing_using_text(after_execute);
+        let full_sql = if using_part.is_empty() {
+            sql
+        } else {
+            format!("{}\nUSING {}", sql, replace_pl_vars_in_sql(&using_part, vars))
+        };
+        return ("Embedded/Execute".into(), full_sql);
+    }
+
+    if looks_like_static_sql {
+        let (sql_part, using_part) = split_query_and_using(q);
+        let sql = replace_pl_vars_in_sql(sql_part.trim(), vars);
+        let full_sql = if using_part.is_empty() {
+            sql
+        } else {
+            format!("{}\nUSING {}", sql, replace_pl_vars_in_sql(&using_part, vars))
+        };
+        return ("Embedded/Select".into(), full_sql);
+    }
+
+    let inner = strip_trailing_using(q);
+    let using_part = extract_trailing_using_text(q);
+    let sql = resolve_dynamic_query_text(inner.trim(), vars, assigns);
+    let full_sql = if using_part.is_empty() {
+        sql
+    } else {
+        format!("{}\nUSING {}", sql, replace_pl_vars_in_sql(&using_part, vars))
+    };
+    ("Embedded/Execute".into(), full_sql)
+}
+
+fn split_query_and_using(text: &str) -> (String, String) {
+    if let Some(pos) = find_using_keyword_pos(text) {
+        (text[..pos].to_string(), text[pos + 5..].trim().to_string())
+    } else {
+        (text.to_string(), String::new())
+    }
+}
+
+fn strip_trailing_using(text: &str) -> String {
+    if let Some(pos) = find_using_keyword_pos(text) {
+        text[..pos].to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+fn extract_trailing_using_text(text: &str) -> String {
+    if let Some(pos) = find_using_keyword_pos(text) {
+        text[pos + 5..].trim().to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn find_using_keyword_pos(text: &str) -> Option<usize> {
+    let lower = text.to_ascii_lowercase();
+    let mut in_string_single = false;
+    let mut in_string_double = false;
+    let mut i = 0;
+    let bytes = lower.as_bytes();
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'\'' && !in_string_double {
+            in_string_single = !in_string_single;
+            i += 1;
+            continue;
+        }
+        if c == b'"' && !in_string_single {
+            in_string_double = !in_string_double;
+            i += 1;
+            continue;
+        }
+        if !in_string_single && !in_string_double && lower[i..].starts_with("using ") {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn resolve_dynamic_query_text(
+    text: &str,
+    vars: &std::collections::HashMap<String, Option<String>>,
+    assigns: &std::collections::HashMap<String, Vec<ConcatPart>>,
+) -> String {
+    let t = text.trim();
+    if t.is_empty() {
+        return String::new();
+    }
+    if t.contains("||") {
+        let (stmts, _) = ogsql_parser::parser::Parser::parse_sql(&format!("SELECT {}", t));
+        if let Some(si) = stmts.first() {
+            if let ogsql_parser::Statement::Select(ref sel) = si.statement {
+                if let Some(ref first_item) = sel.node.targets.first() {
+                    if let ogsql_parser::ast::SelectTarget::Expr(expr, _) = first_item {
+                        let parts = eval_concat_expr(expr);
+                        return join_concat_parts(&parts, &replace_pl_vars_in_sql_raw, vars, assigns);
+                    }
+                }
+            }
+        }
+    }
+    if let Some(rest) = t.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+        return replace_pl_vars_in_sql(rest.trim(), vars);
+    }
+    if let Some(rest) = t.strip_prefix("E'").and_then(|s| s.strip_suffix('\'')) {
+        return replace_pl_vars_in_sql(rest.trim(), vars);
+    }
+    if t.starts_with("$$") {
+        if let Some(rest) = t.strip_prefix("$$").and_then(|s| s.strip_suffix("$$")) {
+            return replace_pl_vars_in_sql(rest.trim(), vars);
+        }
+    }
+    if let Some(traced_parts) = assigns.get(&t.to_ascii_lowercase()) {
+        let has_vars = traced_parts.iter().any(|p| !matches!(p, ConcatPart::Literal(_)));
+        if has_vars {
+            return join_concat_parts(traced_parts, &replace_pl_vars_in_sql_raw, vars, assigns);
+        } else {
+            let flat: String = traced_parts.iter().map(|p| match p {
+                ConcatPart::Literal(s) => s.as_str(), _ => ""
+            }).collect();
+            return replace_pl_vars_in_sql_raw(flat.trim(), vars);
+        }
+    }
+    replace_pl_vars_in_sql(t, vars)
+}
+
 /// Recursively collect SQL rows from a PL/pgSQL block into individual CSV rows.
 fn collect_block_sql_rows(
     block: &ogsql_parser::ast::plpgsql::PlBlock,
@@ -951,8 +1168,19 @@ fn collect_block_sql_rows(
     fallback_line: usize,
     vars: &std::collections::HashMap<String, Option<String>>,
 ) -> Vec<ParseCsvRow> {
+    use ogsql_parser::ast::plpgsql::PlDeclaration;
     let mut rows = Vec::new();
     let mut assigns: std::collections::HashMap<String, Vec<ConcatPart>> = std::collections::HashMap::new();
+    for decl in &block.declarations {
+        if let PlDeclaration::Variable(ref v) = decl {
+            if let Some(ref expr) = v.default {
+                let parts = eval_concat_expr(expr);
+                if !parts.is_empty() {
+                    assigns.insert(v.name.to_ascii_lowercase(), parts);
+                }
+            }
+        }
+    }
     for stmt in &block.body {
         collect_pl_stmt_rows(stmt, parent_name, fallback_line, vars, &mut assigns, &mut rows);
     }
@@ -1050,7 +1278,21 @@ fn collect_pl_stmt_rows(
                 _ => String::new(),
             };
             if !target_name.is_empty() {
-                assigns.insert(target_name.to_ascii_lowercase(), eval_concat_expr(expression));
+                let key = target_name.to_ascii_lowercase();
+                let mut parts = eval_concat_expr(expression);
+                if let Some(prev) = assigns.get(&key).cloned() {
+                    let mut resolved = Vec::with_capacity(parts.len());
+                    for part in &parts {
+                        match part {
+                            ConcatPart::Variable(name) if name.to_ascii_lowercase() == key => {
+                                resolved.extend(prev.iter().cloned());
+                            }
+                            other => resolved.push(other.clone()),
+                        }
+                    }
+                    parts = resolved;
+                }
+                assigns.insert(key, parts);
             }
         }
 
@@ -1172,7 +1414,59 @@ fn collect_pl_stmt_rows(
         }
         PlStatement::For(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
-            for s in &spanned.node.body {
+            let for_stmt = &spanned.node;
+            match &for_stmt.kind {
+                ogsql_parser::ast::plpgsql::PlForKind::Query { query, parsed_query, using_args: _ } => {
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "ForQuery".into(),
+                        name: for_stmt.variable.clone(),
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: String::new(),
+                        sql: String::new(),
+                    });
+                    if let Some(ref stmt) = parsed_query {
+                        let formatter = ogsql_parser::SqlFormatter::new();
+                        let formatted = formatter.format_statement(stmt);
+                        let sql = replace_pl_vars_in_sql(&formatted, vars);
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: "Embedded/Select".into(),
+                            name: String::new(),
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: String::new(),
+                            sql,
+                        });
+                    } else {
+                        let (embedded_type, sql) = resolve_for_query_text(query, vars, assigns);
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: embedded_type,
+                            name: String::new(),
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: String::new(),
+                            sql,
+                        });
+                    }
+                }
+                ogsql_parser::ast::plpgsql::PlForKind::Cursor { cursor_name, arguments } => {
+                    let args_str: Vec<String> = arguments.iter().map(|a| format_pl_expr(a)).collect();
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "ForCursor".into(),
+                        name: for_stmt.variable.clone(),
+                        parent: parent_name.to_string(),
+                        parameters: args_str.join(", "),
+                        return_type: String::new(),
+                        sql: String::new(),
+                    });
+                }
+                _ => {}
+            }
+            for s in &for_stmt.body {
                 collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
             }
         }
@@ -1195,6 +1489,109 @@ fn collect_pl_stmt_rows(
                     return_type: String::new(),
                     sql: body.trim().to_string(),
                 });
+            }
+        }
+        PlStatement::Open(spanned) => {
+            let line = spanned_line(&spanned.span).max(fallback_line);
+            let open_stmt = &spanned.node;
+            let cursor_name = format_pl_expr(&open_stmt.cursor);
+            match &open_stmt.kind {
+                ogsql_parser::ast::plpgsql::PlOpenKind::ForQuery { scroll: _, query, parsed_query } => {
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "Open/ForQuery".into(),
+                        name: cursor_name,
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: String::new(),
+                        sql: String::new(),
+                    });
+                    if let Some(ref stmt) = parsed_query {
+                        let formatter = ogsql_parser::SqlFormatter::new();
+                        let formatted = formatter.format_statement(stmt);
+                        let sql = replace_pl_vars_in_sql(&formatted, vars);
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: "Embedded/Select".into(),
+                            name: String::new(),
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: String::new(),
+                            sql,
+                        });
+                    } else {
+                        let (embedded_type, sql) = resolve_for_query_text(query, vars, assigns);
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: embedded_type,
+                            name: String::new(),
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: String::new(),
+                            sql,
+                        });
+                    }
+                }
+                ogsql_parser::ast::plpgsql::PlOpenKind::ForExecute { query, using_args } => {
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "Open/ForExecute".into(),
+                        name: cursor_name,
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: String::new(),
+                        sql: String::new(),
+                    });
+                    let dynamic_sql = build_dynamic_sql_from_expr(query, vars, assigns);
+                    let using_suffix = format_using_args_exprs(using_args);
+                    let full_sql = if using_suffix.is_empty() {
+                        dynamic_sql
+                    } else {
+                        format!("{}\nUSING {}", dynamic_sql, using_suffix)
+                    };
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "Embedded/Execute".into(),
+                        name: String::new(),
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: String::new(),
+                        sql: full_sql,
+                    });
+                }
+                ogsql_parser::ast::plpgsql::PlOpenKind::ForUsing { expressions } => {
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "Open/ForUsing".into(),
+                        name: cursor_name,
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: String::new(),
+                        sql: String::new(),
+                    });
+                    let exprs: Vec<String> = expressions.iter().map(|e| format_pl_expr(e)).collect();
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "Embedded/Execute".into(),
+                        name: String::new(),
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: String::new(),
+                        sql: exprs.join(", "),
+                    });
+                }
+                ogsql_parser::ast::plpgsql::PlOpenKind::Simple { arguments } => {
+                    let args_str: Vec<String> = arguments.iter().map(|a| format_pl_expr(a)).collect();
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "Open/Simple".into(),
+                        name: cursor_name,
+                        parent: parent_name.to_string(),
+                        parameters: args_str.join(", "),
+                        return_type: String::new(),
+                        sql: String::new(),
+                    });
+                }
             }
         }
         _ => {}
@@ -1479,23 +1876,26 @@ fn output_csv_parse_rows(
     errors: &[ogsql_parser::ParserError],
     mybatis: bool,
 ) {
-    let real_errors: Vec<String> = errors
-        .iter()
-        .filter(|e| !is_warning(e))
-        .map(|e| e.to_string())
-        .collect();
-    let warnings: Vec<String> = errors
-        .iter()
-        .filter(|e| is_warning(e))
-        .map(|e| e.to_string())
-        .collect();
-
-    let file_err = real_errors.join("; ");
-    let file_warn = warnings.join("; ");
-
     for si in statements {
+        let stmt_start = si.start_line;
+        let stmt_end = si.end_line;
+
+        let stmt_errors: Vec<&ogsql_parser::ParserError> = errors
+            .iter()
+            .filter(|e| {
+                let eline = error_line(e);
+                eline == 0 || (eline >= stmt_start && eline <= stmt_end)
+            })
+            .collect();
+
         let rows = flatten_statement(si, mybatis);
         for row in rows {
+            let (row_err, row_warn) = filter_errors_for_row(
+                &stmt_errors,
+                &si.statement,
+                row.line,
+            );
+
             let sql = row.sql.trim().replace('\n', "\\n").replace('\r', "");
             println!(
                 "{},{},{},{},{},{},{},{},{},{},{}",
@@ -1508,11 +1908,77 @@ fn output_csv_parse_rows(
                 csv_escape(&row.parameters),
                 csv_escape(&row.return_type),
                 csv_escape(&sql),
-                csv_escape(&file_err),
-                csv_escape(&file_warn),
+                csv_escape(&row_err),
+                csv_escape(&row_warn),
             );
         }
     }
+}
+
+fn filter_errors_for_row(
+    errors: &[&ogsql_parser::ParserError],
+    stmt: &ogsql_parser::Statement,
+    row_line: usize,
+) -> (String, String) {
+    use ogsql_parser::ast::PackageItem;
+
+    let sub_range: Option<(usize, usize)> = match stmt {
+        ogsql_parser::Statement::CreatePackageBody(pkg) => {
+            pkg.items.iter().find_map(|item| match item {
+                PackageItem::Procedure(p)
+                    if p.start_line > 0 && row_line >= p.start_line && row_line <= p.end_line =>
+                {
+                    Some((p.start_line, p.end_line))
+                }
+                PackageItem::Function(f)
+                    if f.start_line > 0 && row_line >= f.start_line && row_line <= f.end_line =>
+                {
+                    Some((f.start_line, f.end_line))
+                }
+                _ => None,
+            })
+        }
+        ogsql_parser::Statement::CreatePackage(pkg) => {
+            pkg.items.iter().find_map(|item| match item {
+                PackageItem::Procedure(p)
+                    if p.start_line > 0 && row_line >= p.start_line && row_line <= p.end_line =>
+                {
+                    Some((p.start_line, p.end_line))
+                }
+                PackageItem::Function(f)
+                    if f.start_line > 0 && row_line >= f.start_line && row_line <= f.end_line =>
+                {
+                    Some((f.start_line, f.end_line))
+                }
+                _ => None,
+            })
+        }
+        _ => None,
+    };
+
+    let (range_start, range_end) = sub_range.unwrap_or((row_line, row_line));
+
+    let real_errors: Vec<String> = errors
+        .iter()
+        .filter(|e| !is_warning(e))
+        .filter(|e| {
+            let eline = error_line(e);
+            eline >= range_start && eline <= range_end
+        })
+        .map(|e| e.to_string())
+        .collect();
+
+    let warnings: Vec<String> = errors
+        .iter()
+        .filter(|e| is_warning(e))
+        .filter(|e| {
+            let eline = error_line(e);
+            eline >= range_start && eline <= range_end
+        })
+        .map(|e| e.to_string())
+        .collect();
+
+    (real_errors.join("; "), warnings.join("; "))
 }
 
 fn extract_pl_block(

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1266,12 +1266,13 @@ impl Parser {
                     let next = &self.tokens[self.pos + 1].token;
                     let next2 = &self.tokens[self.pos + 2].token;
                     if matches!(next, Token::Plus) && matches!(next2, Token::RParen) {
+                        let loc = self.current_location();
                         self.advance();
                         self.advance();
                         self.advance();
                         self.add_error(ParserError::Warning {
                             message: "Oracle-style outer join operator '(+)' is deprecated, use standard JOIN syntax instead".to_string(),
-                            location: self.current_location(),
+                            location: loc,
                         });
                         return Ok(Expr::ColumnRef(obj_name));
                     }
@@ -1299,12 +1300,13 @@ impl Parser {
                 let next = &self.tokens[self.pos + 1].token;
                 let next2 = &self.tokens[self.pos + 2].token;
                 if matches!(next, Token::Plus) && matches!(next2, Token::RParen) {
+                    let loc = self.current_location();
                     self.advance();
                     self.advance();
                     self.advance();
                     self.add_error(ParserError::Warning {
                         message: "Oracle-style outer join operator '(+)' is deprecated, use standard JOIN syntax instead".to_string(),
-                        location: self.current_location(),
+                        location: loc,
                     });
                     return Ok(Expr::ColumnRef(name));
                 }


### PR DESCRIPTION
## Summary

- Extract and emit embedded SQL from `FOR..IN SELECT/EXECUTE` and `OPEN..FOR SELECT/EXECUTE..USING` cursor constructs as separate rows in `--csv` output
- Dynamic SQL variables are traced through assignments and concatenation expressions are resolved, matching existing `EXECUTE` row behavior
- New row types: `Embedded/Select` (static SQL) and `Embedded/Execute` (dynamic SQL)
- Version bump to 0.4.4