### PR TITLE
feat: annotate SQL returned via OUT REFCURSOR with branch path tracking

### DIFF
--- a/docs/plans/2026-05-16-return-cursor-sql-annotation.md
+++ b/docs/plans/2026-05-16-return-cursor-sql-annotation.md
@@ -1,0 +1,1427 @@
+# Return Cursor SQL Annotation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Annotate SQL statements that are returned via OUT REFCURSOR parameters (or function RETURNS REFCURSOR) with structured metadata, including branch path tracking for conditional opens.
+
+**Architecture:** A new analyzer module `return_cursor` computes `ReturnCursorAnnotation` structs by walking PL/pgSQL blocks with branch context. The annotation is injected into JSON output (both in-place on Open/ReturnQuery statements and as a summary `routine_analysis` section) and surfaces as a new `ReturnCursorSQL` CSV row type. The core AST types are NOT modified — annotation is purely computed and layered on output.
+
+**Tech Stack:** Rust, serde (JSON serialization), existing analyzer patterns.
+
+---
+
+## Key Files Reference
+
+| File | Role |
+|------|------|
+| `src/ast/mod.rs` | `RoutineParam`, `CreateFunctionStatement`, `CreateProcedureStatement`, `PackageProcedure`, `PackageFunction`, `StatementInfo` |
+| `src/ast/plpgsql.rs` | `PlStatement::Open`, `PlOpenKind`, `PlReturnQueryStmt`, `PlStatement::Return`, `PlBlock`, branch types |
+| `src/analyzer/mod.rs` | Existing `find_ref_cursor_queries()`, `RefCursorQuery`, `DynamicSqlReport`, injection patterns |
+| `src/analyzer/return_cursor.rs` | **NEW** — Core annotation computation module |
+| `src/analyzer/tests.rs` | Existing `parse_proc_block()` helper, ref_cursor tests |
+| `src/bin/ogsql.rs` | CSV `ParseCsvRow`, `flatten_statement()`, `collect_pl_stmt_rows()`, JSON injection in `cmd_parse()` |
+| `src/lib.rs` | Public re-exports |
+
+---
+
+## Task 1: Define Annotation Data Structures
+
+**Files:**
+- Create: `src/analyzer/return_cursor.rs`
+
+**Step 1: Create the module with data structures**
+
+```rust
+// src/analyzer/return_cursor.rs
+//! Annotation of SQL statements returned via OUT REFCURSOR parameters.
+//!
+//! When a stored procedure has an OUT parameter of type REFCURSOR,
+//! and the body contains `OPEN param FOR SELECT ...`, the SQL is
+//! the actual data returned to the caller. This module identifies
+//! those SQL statements and annotates them with structured metadata.
+
+use std::collections::HashSet;
+use crate::ast::plpgsql::{PlBlock, PlStatement, PlOpenKind};
+use crate::ast::RoutineParam;
+use serde::{Serialize, Deserialize};
+
+/// Annotation attached to a SQL statement that is returned via a cursor OUT parameter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReturnCursorAnnotation {
+    /// Name of the OUT parameter (e.g., "out_list") or "<return>" for function return
+    pub out_param: String,
+    /// 1-based parameter position in the routine signature (for JDBC bind)
+    pub out_position: usize,
+    /// The cursor type string: "REFCURSOR", "SYS_REFCURSOR", etc.
+    pub out_type: String,
+    /// Branch path leading to this SQL: "", "IF.then", "IF.elsif#1.then", "IF.else", "LOOP.body"
+    pub branch_path: String,
+    /// The branch condition expression: "p_flag = 'Y'", "" for top-level or else
+    pub branch_condition: String,
+    /// JDBC type constant name: "REF_CURSOR" (oracle.jdbc.OracleTypes.CURSOR = -10)
+    pub jdbc_type: String,
+    /// The SQL text (resolved, with PL variables substituted if possible)
+    pub sql: String,
+    /// Whether the SQL is static ("static") or dynamic via EXECUTE ("dynamic")
+    pub sql_source: String,
+    /// Parsed SQL statement (if the SQL is static and parseable)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parsed_query: Option<Box<crate::ast::Statement>>,
+    /// Result set column info (if inferrable from the SQL)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub result_columns: Vec<ResultColumn>,
+}
+
+/// A column in the result set returned by the cursor SQL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResultColumn {
+    /// Column name or alias
+    pub name: String,
+    /// Inferred data type (requires schema; None if not inferrable)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inferred_type: Option<String>,
+    /// Original expression in the SELECT target
+    pub expression: String,
+}
+
+/// Summary of all return cursor annotations for a single routine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutineReturnAnalysis {
+    /// Name of the routine
+    pub routine_name: String,
+    /// "Procedure" or "Function"
+    pub routine_kind: String,
+    /// All return cursor annotations, grouped by out parameter
+    pub return_cursors: Vec<ReturnCursorGroup>,
+}
+
+/// A single OUT REFCURSOR parameter and its associated SQL branches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReturnCursorGroup {
+    /// OUT parameter name
+    pub out_param: String,
+    /// 1-based position
+    pub position: usize,
+    /// Type string
+    pub cursor_type: String,
+    /// JDBC type
+    pub jdbc_type: String,
+    /// All SQL branches that can be returned via this cursor
+    pub branches: Vec<ReturnCursorBranch>,
+}
+
+/// One possible SQL that can be returned via a cursor (a branch in the code path).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReturnCursorBranch {
+    /// Branch path: "", "IF.then", "IF.elsif#1.then", "IF.else", "LOOP.body"
+    pub path: String,
+    /// Branch condition expression
+    pub condition: String,
+    /// The SQL text
+    pub sql: String,
+    /// "static" or "dynamic"
+    pub sql_source: String,
+    /// Dynamic SQL trace info (for EXECUTE-based opens)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace: Option<DynamicTrace>,
+    /// Result columns
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub result_columns: Vec<ResultColumn>,
+}
+
+/// Trace information for dynamic SQL returned via cursor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DynamicTrace {
+    /// Source variable name
+    pub variable: String,
+    /// SQL template with placeholders
+    pub template: String,
+    /// Dynamic parameters
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dynamic_params: Vec<DynamicParam>,
+}
+
+// Reuse existing DynamicParam from analyzer if possible, or define our own
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DynamicParam {
+    pub source: String,
+    pub param_name: String,
+}
+
+// ── Context for branch tracking ──
+
+#[derive(Debug, Clone, Default)]
+struct BranchContext {
+    path: String,
+    condition: String,
+}
+
+// ── Public API ──
+
+/// Analyze a PL/pgSQL block for return cursor SQL annotations.
+///
+/// `params` — the routine's parameters
+/// `routine_name` — fully qualified routine name (e.g., "PKG_TEST.prc_query")
+/// `routine_kind` — "Procedure" or "Function"
+/// `return_type` — for functions, the RETURNS type (e.g., "REFCURSOR"); None for procedures
+pub fn analyze_return_cursors(
+    block: &PlBlock,
+    params: &[RoutineParam],
+    routine_name: &str,
+    routine_kind: &str,
+    return_type: Option<&str>,
+) -> RoutineReturnAnalysis {
+    // Collect OUT REFCURSOR params
+    let out_cursors = extract_out_cursors(params);
+    let mut annotations: Vec<ReturnCursorAnnotation> = Vec::new();
+
+    collect_annotations(
+        &block.body,
+        &out_cursors,
+        &BranchContext::default(),
+        &mut annotations,
+    );
+
+    // Also handle function RETURNS REFCURSOR — any OPEN ... FOR in the body
+    // where the cursor variable is assigned to a REFCURSOR-typed local variable
+    // that gets RETURNed, OR if the function has a local REFCURSOR variable
+    // that is RETURNed.
+    // For simplicity in this implementation: if return_type contains REFCURSOR,
+    // we look for all OPEN ... FOR statements regardless of cursor name
+    // and mark them with out_param = "<return>".
+    if let Some(rt) = return_type {
+        if rt.to_uppercase().contains("REFCURSOR") {
+            collect_annotations_for_return(
+                &block.body,
+                &BranchContext::default(),
+                &mut annotations,
+            );
+        }
+    }
+
+    // Group annotations by out_param
+    let groups = group_annotations(annotations, params, return_type);
+
+    RoutineReturnAnalysis {
+        routine_name: routine_name.to_string(),
+        routine_kind: routine_kind.to_string(),
+        return_cursors: groups,
+    }
+}
+
+/// Quick check: does this routine have any OUT REFCURSOR params or return REFCURSOR?
+pub fn has_return_cursors(
+    params: &[RoutineParam],
+    return_type: Option<&str>,
+) -> bool {
+    params.iter().any(|p| {
+        p.mode.as_deref() == Some("OUT")
+            && p.data_type.to_uppercase().contains("REFCURSOR")
+    }) || return_type.map_or(false, |rt| rt.to_uppercase().contains("REFCURSOR"))
+}
+
+// ── Internal ──
+
+type OutCursorSet = Vec<(String, usize, String)>; // (name, position, type)
+
+fn extract_out_cursors(params: &[RoutineParam]) -> OutCursorSet {
+    params
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| {
+            let is_out = p.mode.as_deref() == Some("OUT")
+                || p.mode.as_deref() == Some("INOUT")
+                || p.mode.as_deref() == Some("IN OUT");
+            let is_cursor = p.data_type.to_uppercase().contains("REFCURSOR");
+            is_out && is_cursor
+        })
+        .map(|(i, p)| {
+            (p.name.to_lowercase(), i + 1, p.data_type.clone())
+        })
+        .collect()
+}
+
+fn collect_annotations(
+    stmts: &[PlStatement],
+    out_cursors: &OutCursorSet,
+    branch_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    for stmt in stmts {
+        match stmt {
+            PlStatement::Open(spanned) => {
+                let open = &spanned.node;
+                if let Some(cursor_name) = extract_cursor_name(&open.cursor) {
+                    if let Some((pos, typ)) = find_out_cursor(&cursor_name, out_cursors) {
+                        let ann = build_annotation(
+                            &cursor_name, pos, &typ,
+                            branch_ctx, &open.kind,
+                        );
+                        annotations.push(ann);
+                    }
+                }
+            }
+            PlStatement::If(s) => {
+                let cond_str = format_expr(&s.node.condition);
+                let then_ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "IF.then"),
+                    condition: cond_str.clone(),
+                };
+                collect_annotations(&s.node.then_stmts, out_cursors, &then_ctx, annotations);
+                for (i, elsif) in s.node.elsifs.iter().enumerate() {
+                    let elsif_ctx = BranchContext {
+                        path: join_path(&branch_ctx.path, &format!("IF.elsif#{}.then", i + 1)),
+                        condition: format_expr(&elsif.condition),
+                    };
+                    collect_annotations(&elsif.stmts, out_cursors, &elsif_ctx, annotations);
+                }
+                let else_ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "IF.else"),
+                    condition: cond_str,
+                };
+                collect_annotations(&s.node.else_stmts, out_cursors, &else_ctx, annotations);
+            }
+            PlStatement::Case(s) => {
+                for (i, when) in s.node.whens.iter().enumerate() {
+                    let ctx = BranchContext {
+                        path: join_path(&branch_ctx.path, &format!("CASE.when#{}", i + 1)),
+                        condition: format_expr(&when.condition),
+                    };
+                    collect_annotations(&when.stmts, out_cursors, &ctx, annotations);
+                }
+                let else_ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "CASE.else"),
+                    condition: String::new(),
+                };
+                collect_annotations(&s.node.else_stmts, out_cursors, &else_ctx, annotations);
+            }
+            PlStatement::Loop(s) => {
+                let ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "LOOP.body"),
+                    condition: String::new(),
+                };
+                collect_annotations(&s.node.body, out_cursors, &ctx, annotations);
+            }
+            PlStatement::While(s) => {
+                let ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "WHILE.body"),
+                    condition: format_expr(&s.node.condition),
+                };
+                collect_annotations(&s.node.body, out_cursors, &ctx, annotations);
+            }
+            PlStatement::For(s) => {
+                let ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "FOR.body"),
+                    condition: String::new(),
+                };
+                collect_annotations(&s.node.body, out_cursors, &ctx, annotations);
+            }
+            PlStatement::Block(s) => {
+                collect_annotations(&s.node.body, out_cursors, branch_ctx, annotations);
+                if let Some(ref exc) = s.node.exception_block {
+                    for handler in &exc.handlers {
+                        let ctx = BranchContext {
+                            path: join_path(&branch_ctx.path, "EXCEPTION.handler"),
+                            condition: handler.conditions.join(", "),
+                        };
+                        collect_annotations(&handler.statements, out_cursors, &ctx, annotations);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// For functions returning REFCURSOR: collect ALL OPEN ... FOR statements.
+fn collect_annotations_for_return(
+    stmts: &[PlStatement],
+    branch_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    for stmt in stmts {
+        match stmt {
+            PlStatement::Open(spanned) => {
+                let open = &spanned.node;
+                let cursor_name = extract_cursor_name(&open.cursor).unwrap_or_default();
+                let ann = build_annotation(
+                    &cursor_name, 0, "SYS_REFCURSOR",
+                    branch_ctx, &open.kind,
+                );
+                // Override out_param to indicate function return
+                let mut ann = ann;
+                ann.out_param = "<return>".to_string();
+                annotations.push(ann);
+            }
+            PlStatement::ReturnQuery(spanned) => {
+                let rq = &spanned.node;
+                if !rq.is_dynamic {
+                    if let Some(ref parsed) = rq.parsed_query {
+                        // handled via Open path — but RETURN QUERY without OPEN
+                    }
+                    let sql = rq.query.clone();
+                    annotations.push(ReturnCursorAnnotation {
+                        out_param: "<return>".to_string(),
+                        out_position: 0,
+                        out_type: "SYS_REFCURSOR".to_string(),
+                        branch_path: branch_ctx.path.clone(),
+                        branch_condition: branch_ctx.condition.clone(),
+                        jdbc_type: "REF_CURSOR".to_string(),
+                        sql,
+                        sql_source: "static".to_string(),
+                        parsed_query: None,
+                        result_columns: Vec::new(),
+                    });
+                }
+            }
+            // Recurse into branches (same as collect_annotations but without out_cursors filter)
+            PlStatement::If(s) => {
+                let cond_str = format_expr(&s.node.condition);
+                let then_ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "IF.then"),
+                    condition: cond_str.clone(),
+                };
+                collect_annotations_for_return(&s.node.then_stmts, &then_ctx, annotations);
+                for (i, elsif) in s.node.elsifs.iter().enumerate() {
+                    let elsif_ctx = BranchContext {
+                        path: join_path(&branch_ctx.path, &format!("IF.elsif#{}.then", i + 1)),
+                        condition: format_expr(&elsif.condition),
+                    };
+                    collect_annotations_for_return(&elsif.stmts, &elsif_ctx, annotations);
+                }
+                let else_ctx = BranchContext {
+                    path: join_path(&branch_ctx.path, "IF.else"),
+                    condition: cond_str,
+                };
+                collect_annotations_for_return(&s.node.else_stmts, &else_ctx, annotations);
+            }
+            PlStatement::Block(s) => {
+                collect_annotations_for_return(&s.node.body, branch_ctx, annotations);
+            }
+            PlStatement::Loop(s) => {
+                let ctx = BranchContext { path: join_path(&branch_ctx.path, "LOOP.body"), condition: String::new() };
+                collect_annotations_for_return(&s.node.body, &ctx, annotations);
+            }
+            PlStatement::While(s) => {
+                let ctx = BranchContext { path: join_path(&branch_ctx.path, "WHILE.body"), condition: format_expr(&s.node.condition) };
+                collect_annotations_for_return(&s.node.body, &ctx, annotations);
+            }
+            PlStatement::For(s) => {
+                let ctx = BranchContext { path: join_path(&branch_ctx.path, "FOR.body"), condition: String::new() };
+                collect_annotations_for_return(&s.node.body, &ctx, annotations);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn build_annotation(
+    cursor_name: &str,
+    position: usize,
+    cursor_type: &str,
+    branch_ctx: &BranchContext,
+    kind: &PlOpenKind,
+) -> ReturnCursorAnnotation {
+    match kind {
+        PlOpenKind::ForQuery { query, parsed_query, .. } => {
+            let result_columns = extract_result_columns(parsed_query.as_deref());
+            ReturnCursorAnnotation {
+                out_param: cursor_name.to_string(),
+                out_position: position,
+                out_type: cursor_type.to_string(),
+                branch_path: branch_ctx.path.clone(),
+                branch_condition: branch_ctx.condition.clone(),
+                jdbc_type: "REF_CURSOR".to_string(),
+                sql: query.clone(),
+                sql_source: "static".to_string(),
+                parsed_query: parsed_query.clone(),
+                result_columns,
+            }
+        }
+        PlOpenKind::ForExecute { query, .. } => {
+            let sql = match query {
+                crate::ast::Expr::PlVariable(n) | crate::ast::Expr::ColumnRef(n) => n.join("."),
+                crate::ast::Expr::Literal(crate::ast::Literal::String(s)) => s.clone(),
+                other => format_expr(other),
+            };
+            ReturnCursorAnnotation {
+                out_param: cursor_name.to_string(),
+                out_position: position,
+                out_type: cursor_type.to_string(),
+                branch_path: branch_ctx.path.clone(),
+                branch_condition: branch_ctx.condition.clone(),
+                jdbc_type: "REF_CURSOR".to_string(),
+                sql,
+                sql_source: "dynamic".to_string(),
+                parsed_query: None,
+                result_columns: Vec::new(),
+            }
+        }
+        _ => ReturnCursorAnnotation {
+            out_param: cursor_name.to_string(),
+            out_position: position,
+            out_type: cursor_type.to_string(),
+            branch_path: branch_ctx.path.clone(),
+            branch_condition: branch_ctx.condition.clone(),
+            jdbc_type: "REF_CURSOR".to_string(),
+            sql: String::new(),
+            sql_source: String::new(),
+            parsed_query: None,
+            result_columns: Vec::new(),
+        }
+    }
+}
+
+fn extract_cursor_name(expr: &crate::ast::Expr) -> Option<String> {
+    match expr {
+        crate::ast::Expr::PlVariable(names) | crate::ast::Expr::ColumnRef(names) if names.len() == 1 => {
+            Some(names[0].clone())
+        }
+        _ => None,
+    }
+}
+
+fn find_out_cursor(name: &str, out_cursors: &OutCursorSet) -> Option<(usize, String)> {
+    let name_lower = name.to_lowercase();
+    for (n, pos, typ) in out_cursors {
+        if n.to_lowercase() == name_lower {
+            return Some((*pos, typ.clone()));
+        }
+    }
+    None
+}
+
+fn join_path(parent: &str, segment: &str) -> String {
+    if parent.is_empty() {
+        segment.to_string()
+    } else {
+        format!("{}.{}", parent, segment)
+    }
+}
+
+fn format_expr(expr: &crate::ast::Expr) -> String {
+    // Use formatter for a readable expression string
+    let formatter = crate::formatter::SqlFormatter::new();
+    formatter.format_expr(expr)
+}
+
+fn extract_result_columns(stmt: Option<&crate::ast::Statement>) -> Vec<ResultColumn> {
+    let stmt = match stmt {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let select = match stmt {
+        crate::ast::Statement::Select(s) => s,
+        _ => return Vec::new(),
+    };
+    select.targets.iter().map(|t| {
+        match t {
+            crate::ast::SelectTarget::Expr(expr, alias) => {
+                let name = alias.clone().unwrap_or_else(|| format_expr(expr));
+                let expression = format_expr(expr);
+                ResultColumn {
+                    name,
+                    inferred_type: None,
+                    expression,
+                }
+            }
+            _ => ResultColumn {
+                name: "*".to_string(),
+                inferred_type: None,
+                expression: "*".to_string(),
+            }
+        }
+    }).collect()
+}
+
+fn group_annotations(
+    annotations: Vec<ReturnCursorAnnotation>,
+    params: &[RoutineParam],
+    return_type: Option<&str>,
+) -> Vec<ReturnCursorGroup> {
+    // Group by out_param
+    let mut param_map: std::collections::HashMap<String, Vec<&ReturnCursorAnnotation>> =
+        std::collections::HashMap::new();
+    for ann in &annotations {
+        param_map
+            .entry(ann.out_param.clone())
+            .or_default()
+            .push(ann);
+    }
+
+    let mut groups = Vec::new();
+
+    for (param_name, anns) in param_map {
+        let first = anns[0];
+        let branches: Vec<ReturnCursorBranch> = anns.iter().map(|a| {
+            ReturnCursorBranch {
+                path: a.branch_path.clone(),
+                condition: a.branch_condition.clone(),
+                sql: a.sql.clone(),
+                sql_source: a.sql_source.clone(),
+                trace: None, // TODO: integrate with DynamicSqlReport for dynamic traces
+                result_columns: a.result_columns.clone(),
+            }
+        }).collect();
+
+        groups.push(ReturnCursorGroup {
+            out_param: param_name,
+            position: first.out_position,
+            cursor_type: first.out_type.clone(),
+            jdbc_type: first.jdbc_type.clone(),
+            branches,
+        });
+    }
+
+    groups
+}
+```
+
+**Step 2: Register the module**
+
+In `src/analyzer/mod.rs`, add at the top:
+```rust
+pub mod return_cursor;
+```
+
+And add the public re-export in `src/lib.rs`:
+```rust
+pub use analyzer::return_cursor::{
+    ReturnCursorAnnotation, RoutineReturnAnalysis, ReturnCursorGroup,
+    ReturnCursorBranch, ResultColumn, analyze_return_cursors, has_return_cursors,
+};
+```
+
+**Step 3: Verify compilation**
+
+Run: `cargo build 2>&1 | head -50`
+Expected: Compiles with possible warnings about unused imports. Fix any compile errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/analyzer/return_cursor.rs src/analyzer/mod.rs src/lib.rs
+git commit -m "feat: add return cursor annotation data structures and core analysis"
+```
+
+---
+
+## Task 2: Add Unit Tests for Core Analysis
+
+**Files:**
+- Modify: `src/analyzer/return_cursor.rs` (add `#[cfg(test)] mod tests` at bottom)
+
+**Step 1: Write tests**
+
+Append to `src/analyzer/return_cursor.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::Parser;
+    use crate::Tokenizer;
+    use crate::ast::PackageItem;
+
+    /// Helper: parse a package body and extract the first procedure's block + params
+    fn parse_proc(sql: &str) -> (PlBlock, Vec<RoutineParam>, String) {
+        let tokens = Tokenizer::new(sql).tokenize().unwrap();
+        let stmts = Parser::new(tokens).parse();
+        match &stmts[0] {
+            crate::ast::Statement::CreatePackageBody(pkg) => {
+                for item in &pkg.node.items {
+                    if let PackageItem::Procedure(p) = item {
+                        let block = p.block.as_ref().expect("procedure should have block").clone();
+                        return (block, p.parameters.clone(), p.name.join("."));
+                    }
+                }
+                panic!("no procedure found in package body");
+            }
+            crate::ast::Statement::CreateProcedure(p) => {
+                let block = p.block.as_ref().expect("procedure should have block").clone();
+                return (block, p.parameters.clone(), p.name.join("."));
+            }
+            other => panic!("expected package body or procedure, got {:?}", other),
+        }
+    }
+
+    /// Helper: parse a function and extract block + params + return_type
+    fn parse_func(sql: &str) -> (PlBlock, Vec<RoutineParam>, String, Option<String>) {
+        let tokens = Tokenizer::new(sql).tokenize().unwrap();
+        let stmts = Parser::new(tokens).parse();
+        match &stmts[0] {
+            crate::ast::Statement::CreateFunction(f) => {
+                let block = f.block.as_ref().expect("function should have block").clone();
+                return (block, f.parameters.clone(), f.name.join("."), f.return_type.clone());
+            }
+            other => panic!("expected function, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_basic_out_refcursor_static() {
+        let (block, params, name) = parse_proc(
+            r#"CREATE OR REPLACE PACKAGE BODY PKG AS
+              PROCEDURE get_users(p_status VARCHAR, p_cur OUT REFCURSOR) AS
+              BEGIN
+                OPEN p_cur FOR SELECT id, name FROM t_users WHERE status = p_status;
+              END;
+            END PKG;"#
+        );
+        let analysis = analyze_return_cursors(&block, &params, &name, "Procedure", None);
+        assert_eq!(analysis.return_cursors.len(), 1);
+        let group = &analysis.return_cursors[0];
+        assert_eq!(group.out_param, "p_cur");
+        assert_eq!(group.position, 2);
+        assert_eq!(group.branches.len(), 1);
+        assert!(group.branches[0].sql.contains("t_users"));
+        assert_eq!(group.branches[0].path, "");
+        assert_eq!(group.branches[0].sql_source, "static");
+    }
+
+    #[test]
+    fn test_conditional_branches() {
+        let (block, params, name) = parse_proc(
+            r#"CREATE OR REPLACE PACKAGE BODY PKG AS
+              PROCEDURE search(p_type INT, p_cur OUT REFCURSOR) AS
+              BEGIN
+                IF p_type = 1 THEN
+                  OPEN p_cur FOR SELECT id FROM t1;
+                ELSIF p_type = 2 THEN
+                  OPEN p_cur FOR SELECT id, name FROM t2;
+                ELSE
+                  OPEN p_cur FOR SELECT * FROM t3;
+                END IF;
+              END;
+            END PKG;"#
+        );
+        let analysis = analyze_return_cursors(&block, &params, &name, "Procedure", None);
+        assert_eq!(analysis.return_cursors.len(), 1);
+        let group = &analysis.return_cursors[0];
+        assert_eq!(group.branches.len(), 3);
+        assert_eq!(group.branches[0].path, "IF.then");
+        assert_eq!(group.branches[0].condition, "p_type = 1");
+        assert_eq!(group.branches[1].path, "IF.elsif#1.then");
+        assert_eq!(group.branches[1].condition, "p_type = 2");
+        assert_eq!(group.branches[2].path, "IF.else");
+    }
+
+    #[test]
+    fn test_in_cursor_not_annotated() {
+        let (block, params, name) = parse_proc(
+            r#"CREATE OR REPLACE PACKAGE BODY PKG AS
+              PROCEDURE proc(cur IN REFCURSOR) AS
+              BEGIN
+                OPEN cur FOR SELECT 1;
+              END;
+            END PKG;"#
+        );
+        let analysis = analyze_return_cursors(&block, &params, &name, "Procedure", None);
+        assert!(analysis.return_cursors.is_empty());
+    }
+
+    #[test]
+    fn test_no_cursor_params() {
+        let (block, params, name) = parse_proc(
+            r#"CREATE OR REPLACE PACKAGE BODY PKG AS
+              PROCEDURE proc(p_id INT) AS
+              BEGIN
+                NULL;
+              END;
+            END PKG;"#
+        );
+        let analysis = analyze_return_cursors(&block, &params, &name, "Procedure", None);
+        assert!(analysis.return_cursors.is_empty());
+    }
+
+    #[test]
+    fn test_function_returns_refcursor() {
+        let (block, params, name, return_type) = parse_func(
+            r#"CREATE FUNCTION get_user(p_id INT) RETURNS SYS_REFCURSOR AS $$
+              DECLARE v_cur SYS_REFCURSOR;
+              BEGIN
+                OPEN v_cur FOR SELECT id, name FROM t_users WHERE id = p_id;
+                RETURN v_cur;
+              END;
+            $$ LANGUAGE plpgsql"#
+        );
+        let analysis = analyze_return_cursors(
+            &block, &params, &name, "Function", return_type.as_deref(),
+        );
+        assert_eq!(analysis.return_cursors.len(), 1);
+        assert_eq!(analysis.return_cursors[0].out_param, "<return>");
+    }
+
+    #[test]
+    fn test_dynamic_execute_cursor() {
+        let (block, params, name) = parse_proc(
+            r#"CREATE OR REPLACE PACKAGE BODY PKG AS
+              PROCEDURE dyn_query(p_table VARCHAR, p_cur OUT REFCURSOR) AS
+              BEGIN
+                OPEN p_cur FOR EXECUTE 'SELECT * FROM ' || p_table;
+              END;
+            END PKG;"#
+        );
+        let analysis = analyze_return_cursors(&block, &params, &name, "Procedure", None);
+        assert_eq!(analysis.return_cursors.len(), 1);
+        assert_eq!(analysis.return_cursors[0].branches[0].sql_source, "dynamic");
+    }
+
+    #[test]
+    fn test_has_return_cursors() {
+        let params_no = vec![RoutineParam {
+            name: "p".to_string(), mode: None,
+            data_type: "INT".to_string(), default_value: None,
+        }];
+        assert!(!has_return_cursors(&params_no, None));
+
+        let params_yes = vec![RoutineParam {
+            name: "cur".to_string(), mode: Some("OUT".to_string()),
+            data_type: "REFCURSOR".to_string(), default_value: None,
+        }];
+        assert!(has_return_cursors(&params_yes, None));
+        assert!(has_return_cursors(&params_no, Some("SYS_REFCURSOR")));
+    }
+
+    #[test]
+    fn test_result_columns_extracted() {
+        let (block, params, name) = parse_proc(
+            r#"CREATE OR REPLACE PACKAGE BODY PKG AS
+              PROCEDURE get_users(p_cur OUT REFCURSOR) AS
+              BEGIN
+                OPEN p_cur FOR SELECT id, name AS user_name, email FROM t_users;
+              END;
+            END PKG;"#
+        );
+        let analysis = analyze_return_cursors(&block, &params, &name, "Procedure", None);
+        let cols = &analysis.return_cursors[0].branches[0].result_columns;
+        assert!(cols.len() >= 2);
+        // Check that alias is picked up
+        assert!(cols.iter().any(|c| c.name == "user_name"));
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test return_cursor -- --nocapture`
+Expected: All 8 tests pass.
+
+**Step 3: Fix any compilation issues**
+
+The `format_expr` method on `SqlFormatter` may or may not exist. If not, check `src/formatter.rs` for the correct method name (likely `format_expression`). Also `SelectTarget` enum variant names may differ — check `src/ast/mod.rs` for exact names.
+
+**Step 4: Commit**
+
+```bash
+git add src/analyzer/return_cursor.rs
+git commit -m "test: add return cursor annotation unit tests (8 tests)"
+```
+
+---
+
+## Task 3: CSV Output — New Row Type
+
+**Files:**
+- Modify: `src/bin/ogsql.rs`
+
+**Step 1: Extend ParseCsvRow with branch fields**
+
+Find `ParseCsvRow` struct (around line 604) and add:
+```rust
+struct ParseCsvRow {
+    line: usize,
+    stmt_type: String,
+    name: String,
+    parent: String,
+    parameters: String,
+    return_type: String,
+    sql: String,
+    // NEW: branch tracking for ReturnCursorSQL rows
+    branch_path: String,
+    branch_condition: String,
+}
+```
+
+**Step 2: Update CSV header**
+
+Find `output_csv_parse_header()` (line 600) and change to:
+```rust
+fn output_csv_parse_header() {
+    println!("file,directory,line,type,name,parent,parameters,return_type,sql,error,warning,branch_path,branch_condition");
+}
+```
+
+**Step 3: Update CSV row output**
+
+Find `output_csv_parse_rows()` (line 1866). In the print statement, add the two new fields:
+```rust
+println!(
+    "{},{},{},{},{},{},{},{},{},{},{},{},{}",
+    csv_escape(file_name),
+    csv_escape(rel_dir),
+    row.line,
+    csv_escape(&row.stmt_type),
+    csv_escape(&row.name),
+    csv_escape(&row.parent),
+    csv_escape(&row.parameters),
+    csv_escape(&row.return_type),
+    csv_escape(&sql),
+    csv_escape(&row_err),
+    csv_escape(&row_warn),
+    csv_escape(&row.branch_path),
+    csv_escape(&row.branch_condition),
+);
+```
+
+**Step 4: Update ALL ParseCsvRow construction sites**
+
+Every `ParseCsvRow { ... }` in the codebase needs the two new fields. Add `branch_path: String::new(), branch_condition: String::new()` to every existing construction. There are ~30 construction sites — use the compiler to find them all:
+```bash
+cargo build 2>&1 | grep "missing field"
+```
+
+**Step 5: Modify `collect_pl_stmt_rows` to generate ReturnCursorSQL rows**
+
+Add new parameters to the function:
+```rust
+fn collect_pl_stmt_rows(
+    pl_stmt: &ogsql_parser::ast::plpgsql::PlStatement,
+    parent_name: &str,
+    fallback_line: usize,
+    vars: &std::collections::HashMap<String, Option<String>>,
+    assigns: &mut std::collections::HashMap<String, Vec<ConcatPart>>,
+    rows: &mut Vec<ParseCsvRow>,
+    // NEW:
+    out_cursors: &std::collections::HashSet<String>,
+    branch_path: &str,
+    branch_condition: &str,
+)
+```
+
+In the `PlStatement::Open` arm, when the cursor is in `out_cursors`:
+```rust
+PlStatement::Open(spanned) => {
+    let open = &spanned.node;
+    let cursor_name = format_pl_expr(&open_stmt.cursor); // keep existing var name
+    let is_return_cursor = out_cursors.contains(&cursor_name.to_lowercase());
+
+    match &open.kind {
+        PlOpenKind::ForQuery { scroll: _, query, parsed_query } => {
+            if is_return_cursor {
+                // NEW: ReturnCursorSQL row (merges Open + SQL into one)
+                if let Some(ref stmt) = parsed_query {
+                    let formatter = ogsql_parser::SqlFormatter::new();
+                    let formatted = formatter.format_statement(stmt);
+                    let sql = replace_pl_vars_in_sql(&formatted, vars);
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "ReturnCursorSQL".into(),
+                        name: cursor_name,
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: "REFCURSOR".into(),
+                        sql,
+                        branch_path: branch_path.to_string(),
+                        branch_condition: branch_condition.to_string(),
+                    });
+                } else {
+                    let (_, sql) = resolve_for_query_text(query, vars, assigns);
+                    rows.push(ParseCsvRow {
+                        line,
+                        stmt_type: "ReturnCursorSQL".into(),
+                        name: cursor_name,
+                        parent: parent_name.to_string(),
+                        parameters: String::new(),
+                        return_type: "REFCURSOR".into(),
+                        sql,
+                        branch_path: branch_path.to_string(),
+                        branch_condition: branch_condition.to_string(),
+                    });
+                }
+            } else {
+                // EXISTING: keep the old Open/ForQuery + Embedded/Select rows unchanged
+                // ... (copy existing code)
+            }
+        }
+        PlOpenKind::ForExecute { query, using_args } => {
+            if is_return_cursor {
+                let dynamic_sql = build_dynamic_sql_from_expr(query, vars, assigns);
+                let using_suffix = format_using_args_exprs(using_args);
+                let full_sql = if using_suffix.is_empty() {
+                    dynamic_sql
+                } else {
+                    format!("{}\nUSING {}", dynamic_sql, using_suffix)
+                };
+                rows.push(ParseCsvRow {
+                    line,
+                    stmt_type: "ReturnCursorSQL".into(),
+                    name: cursor_name,
+                    parent: parent_name.to_string(),
+                    parameters: String::new(),
+                    return_type: "REFCURSOR".into(),
+                    sql: full_sql,
+                    branch_path: branch_path.to_string(),
+                    branch_condition: branch_condition.to_string(),
+                });
+            } else {
+                // EXISTING: keep old behavior
+            }
+        }
+        // Simple, ForUsing — keep existing, no change
+        _ => { /* existing code */ }
+    }
+}
+```
+
+**Step 6: Thread branch context through recursive calls**
+
+Update all recursive calls to `collect_pl_stmt_rows` within `collect_pl_stmt_rows` to pass branch context. For the `If` arm:
+```rust
+PlStatement::If(spanned) => {
+    let line = spanned_line(&spanned.span).max(fallback_line);
+    let if_stmt = &spanned.node;
+    let cond_str = format_pl_expr(&if_stmt.condition);
+    for s in &if_stmt.then_stmts {
+        collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors,
+            &join_branch(branch_path, "IF.then"), &cond_str);
+    }
+    for (i, elsif) in if_stmt.elsifs.iter().enumerate() {
+        let elsif_cond = format_pl_expr(&elsif.condition);
+        for s in &elsif.stmts {
+            collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors,
+                &join_branch(branch_path, &format!("IF.elsif#{}.then", i + 1)), &elsif_cond);
+        }
+    }
+    for s in &if_stmt.else_stmts {
+        collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors,
+            &join_branch(branch_path, "IF.else"), &cond_str);
+    }
+}
+```
+
+Similarly for `Loop`, `While`, `For`, `Case`, `Block`.
+
+**Step 7: Thread out_cursors from flatten_statement**
+
+In `flatten_statement()`, before calling `collect_block_sql_rows`, compute out_cursors:
+```rust
+Statement::CreateProcedure(s) => {
+    let proc_name = s.name.join(".");
+    let out_cursors: std::collections::HashSet<String> = s.parameters.iter()
+        .filter(|p| {
+            let is_out = p.mode.as_deref() == Some("OUT")
+                || p.mode.as_deref() == Some("INOUT")
+                || p.mode.as_deref() == Some("IN OUT");
+            let is_cursor = p.data_type.to_uppercase().contains("REFCURSOR");
+            is_out && is_cursor
+        })
+        .map(|p| p.name.to_lowercase())
+        .collect();
+    rows.push(ParseCsvRow { /* existing */ });
+    if let Some(ref block) = s.block {
+        rows.extend(collect_block_sql_rows(block, &proc_name, si.start_line, &vars, &out_cursors));
+    }
+}
+```
+
+Do similarly for `CreateFunction`, `CreatePackageBody` (iterate items), `CreatePackage` (iterate items), `Do`, `AnonyBlock`.
+
+**Step 8: Update `collect_block_sql_rows` signature**
+
+```rust
+fn collect_block_sql_rows(
+    block: &ogsql_parser::ast::plpgsql::PlBlock,
+    parent_name: &str,
+    fallback_line: usize,
+    vars: &std::collections::HashMap<String, Option<String>>,
+    out_cursors: &std::collections::HashSet<String>,
+) -> Vec<ParseCsvRow> {
+    // ... pass out_cursors to collect_pl_stmt_rows
+}
+```
+
+**Step 9: Helper function**
+
+```rust
+fn join_branch(parent: &str, segment: &str) -> String {
+    if parent.is_empty() { segment.to_string() } else { format!("{}.{}", parent, segment) }
+}
+```
+
+**Step 10: Build and test**
+
+Run: `cargo build 2>&1 | head -50`
+Fix all missing field errors. Then:
+```bash
+echo 'CREATE OR REPLACE PROCEDURE test_proc(p_cur OUT REFCURSOR) AS BEGIN OPEN p_cur FOR SELECT 1; END;' | cargo run --features cli -- parse --csv
+```
+Expected output includes a `ReturnCursorSQL` row.
+
+**Step 11: Commit**
+
+```bash
+git add src/bin/ogsql.rs
+git commit -m "feat: ReturnCursorSQL CSV row type with branch path tracking"
+```
+
+---
+
+## Task 4: JSON Output — In-Place and Summary Injection
+
+**Files:**
+- Modify: `src/bin/ogsql.rs`
+
+**Step 1: Add JSON injection in cmd_parse**
+
+Find the JSON output section in `cmd_parse` (around line 301). After the existing `dynamic_sql_analysis` injection, add:
+
+```rust
+// After existing dynamic_sql_analysis injection block:
+// Inject return cursor analysis for routines
+if has_routine_return_cursors(&si.statement) {
+    if let Some(analysis) = compute_routine_analysis(&si.statement) {
+        obj.as_object_mut().unwrap().insert(
+            "routine_analysis".to_string(),
+            serde_json::json!(analysis),
+        );
+    }
+}
+```
+
+**Step 2: Implement helper functions**
+
+```rust
+fn has_routine_return_cursors(stmt: &ogsql_parser::Statement) -> bool {
+    use ogsql_parser::Statement;
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            ogsql_parser::has_return_cursors(&p.parameters, None)
+        }
+        Statement::CreateFunction(f) => {
+            ogsql_parser::has_return_cursors(&f.parameters, f.return_type.as_deref())
+        }
+        Statement::CreatePackageBody(pkg) => {
+            pkg.items.iter().any(|item| match item {
+                ogsql_parser::ast::PackageItem::Procedure(p) =>
+                    ogsql_parser::has_return_cursors(&p.parameters, None),
+                ogsql_parser::ast::PackageItem::Function(f) =>
+                    ogsql_parser::has_return_cursors(&f.parameters, f.return_type.as_deref()),
+                _ => false,
+            })
+        }
+        _ => false,
+    }
+}
+
+fn compute_routine_analysis(stmt: &ogsql_parser::Statement) -> Option<serde_json::Value> {
+    use ogsql_parser::Statement;
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref()?;
+            let analysis = ogsql_parser::analyze_return_cursors(
+                block, &p.parameters, &p.name.join("."), "Procedure", None,
+            );
+            Some(serde_json::json!(analysis))
+        }
+        Statement::CreateFunction(f) => {
+            let block = f.block.as_ref()?;
+            let analysis = ogsql_parser::analyze_return_cursors(
+                block, &f.parameters, &f.name.join("."), "Function",
+                f.return_type.as_deref(),
+            );
+            Some(serde_json::json!(analysis))
+        }
+        Statement::CreatePackageBody(pkg) => {
+            let mut analyses = Vec::new();
+            for item in &pkg.items {
+                match item {
+                    ogsql_parser::ast::PackageItem::Procedure(p) => {
+                        if let Some(ref block) = p.block {
+                            let analysis = ogsql_parser::analyze_return_cursors(
+                                block, &p.parameters, &p.name.join("."),
+                                "Procedure", None,
+                            );
+                            if !analysis.return_cursors.is_empty() {
+                                analyses.push(analysis);
+                            }
+                        }
+                    }
+                    ogsql_parser::ast::PackageItem::Function(f) => {
+                        if let Some(ref block) = f.block {
+                            let analysis = ogsql_parser::analyze_return_cursors(
+                                block, &f.parameters, &f.name.join("."),
+                                "Function", f.return_type.as_deref(),
+                            );
+                            if !analysis.return_cursors.is_empty() {
+                                analyses.push(analysis);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if analyses.is_empty() { None } else { Some(serde_json::json!(analyses)) }
+        }
+        _ => None,
+    }
+}
+```
+
+**Step 3: Test JSON output**
+
+```bash
+echo 'CREATE OR REPLACE PROCEDURE test_proc(p_cur OUT REFCURSOR) AS BEGIN OPEN p_cur FOR SELECT id, name FROM t_users; END;' | cargo run --features cli -- parse -j
+```
+
+Expected: JSON output includes `routine_analysis` field with return_cursors array.
+
+```bash
+echo 'CREATE OR REPLACE PACKAGE BODY PKG AS PROCEDURE p(p_cur OUT REFCURSOR) AS BEGIN IF f = 1 THEN OPEN p_cur FOR SELECT 1; ELSE OPEN p_cur FOR SELECT 2; END IF; END; END PKG;' | cargo run --features cli -- parse -j
+```
+
+Expected: `routine_analysis` with 1 group, 2 branches.
+
+**Step 4: Commit**
+
+```bash
+git add src/bin/ogsql.rs
+git commit -m "feat: inject routine_analysis into JSON output for cursor return annotations"
+```
+
+---
+
+## Task 5: Handle RETURN QUERY and RETURN QUERY EXECUTE
+
+**Files:**
+- Modify: `src/analyzer/return_cursor.rs`
+- Modify: `src/bin/ogsql.rs`
+
+**Step 1: Add RETURN QUERY handling in analyzer**
+
+In `collect_annotations_for_return()`, enhance the `PlStatement::ReturnQuery` arm:
+
+```rust
+PlStatement::ReturnQuery(spanned) => {
+    let rq = &spanned.node;
+    if rq.is_dynamic {
+        // RETURN QUERY EXECUTE expr [USING args]
+        let sql = match &rq.dynamic_expr {
+            Some(expr) => format_expr(expr),
+            None => rq.query.clone(),
+        };
+        annotations.push(ReturnCursorAnnotation {
+            out_param: "<return>".to_string(),
+            out_position: 0,
+            out_type: "SYS_REFCURSOR".to_string(),
+            branch_path: branch_ctx.path.clone(),
+            branch_condition: branch_ctx.condition.clone(),
+            jdbc_type: "REF_CURSOR".to_string(),
+            sql,
+            sql_source: "dynamic".to_string(),
+            parsed_query: None,
+            result_columns: Vec::new(),
+        });
+    } else {
+        // RETURN QUERY SELECT ...
+        let result_columns = extract_result_columns(rq.parsed_query.as_ref().map(|b| b.as_ref()));
+        annotations.push(ReturnCursorAnnotation {
+            out_param: "<return>".to_string(),
+            out_position: 0,
+            out_type: "SYS_REFCURSOR".to_string(),
+            branch_path: branch_ctx.path.clone(),
+            branch_condition: branch_ctx.condition.clone(),
+            jdbc_type: "REF_CURSOR".to_string(),
+            sql: rq.query.clone(),
+            sql_source: "static".to_string(),
+            parsed_query: None,
+            result_columns,
+        });
+    }
+}
+```
+
+**Step 2: Add RETURN QUERY handling in CSV**
+
+In `collect_pl_stmt_rows()`, add a new arm:
+```rust
+PlStatement::ReturnQuery(spanned) => {
+    let line = spanned_line(&spanned.span).max(fallback_line);
+    let rq = &spanned.node;
+    // Check if this is in a function that returns REFCURSOR
+    if !out_cursors.is_empty() || /* has function return refcursor flag */ false {
+        // ReturnCursorSQL row
+        let sql = replace_pl_vars_in_sql(&rq.query, vars);
+        rows.push(ParseCsvRow {
+            line,
+            stmt_type: "ReturnCursorSQL".into(),
+            name: "<return>".into(),
+            parent: parent_name.to_string(),
+            parameters: String::new(),
+            return_type: "REFCURSOR".into(),
+            sql,
+            branch_path: branch_path.to_string(),
+            branch_condition: branch_condition.to_string(),
+        });
+    } else {
+        // Normal RETURN QUERY — just show as query row
+        rows.push(ParseCsvRow {
+            line,
+            stmt_type: "ReturnQuery".into(),
+            name: String::new(),
+            parent: parent_name.to_string(),
+            parameters: String::new(),
+            return_type: String::new(),
+            sql: replace_pl_vars_in_sql(&rq.query, vars),
+            branch_path: String::new(),
+            branch_condition: String::new(),
+        });
+    }
+}
+```
+
+Note: The "has function return refcursor flag" needs to be threaded through. The simplest approach: for functions, add `"<return>"` to the `out_cursors` set when `return_type` contains REFCURSOR.
+
+**Step 3: Commit**
+
+```bash
+git add src/analyzer/return_cursor.rs src/bin/ogsql.rs
+git commit -m "feat: handle RETURN QUERY and RETURN QUERY EXECUTE as return cursor SQL"
+```
+
+---
+
+## Task 6: Integration Test — Full Package Body
+
+**Files:**
+- Create test SQL file and verify end-to-end
+
+**Step 1: Create integration test file**
+
+`/tmp/test_return_cursor.sql`:
+```sql
+CREATE OR REPLACE PACKAGE BODY PKG_USER AS
+
+  PROCEDURE get_users(p_status VARCHAR, p_result OUT REFCURSOR) AS
+  BEGIN
+    OPEN p_result FOR SELECT id, name, email, status FROM t_users WHERE status = p_status;
+  END;
+
+  PROCEDURE search_users(p_type INTEGER, p_cur OUT REFCURSOR) AS
+  BEGIN
+    IF p_type = 1 THEN
+      OPEN p_cur FOR SELECT id, name FROM t_users WHERE status = 'active';
+    ELSIF p_type = 2 THEN
+      OPEN p_cur FOR SELECT id, name, dept FROM t_users WHERE dept IS NOT NULL;
+    ELSE
+      OPEN p_cur FOR SELECT id, name FROM t_users_backup;
+    END IF;
+  END;
+
+  PROCEDURE dynamic_query(p_table VARCHAR, p_cur OUT REFCURSOR) AS
+    v_sql VARCHAR;
+  BEGIN
+    v_sql := 'SELECT * FROM ' || p_table || ' WHERE 1=1';
+    OPEN p_cur FOR EXECUTE v_sql;
+  END;
+
+  FUNCTION get_user_by_id(p_id INT) RETURN SYS_REFCURSOR AS
+    v_cur SYS_REFCURSOR;
+  BEGIN
+    OPEN v_cur FOR SELECT id, name, email FROM t_users WHERE id = p_id;
+    RETURN v_cur;
+  END;
+
+END PKG_USER;
+/
+```
+
+**Step 2: Test CSV output**
+
+```bash
+cargo run --features cli -- -f /tmp/test_return_cursor.sql parse --csv
+```
+
+Expected:
+- Procedure `get_users`: 1 ReturnCursorSQL row, no branch
+- Procedure `search_users`: 3 ReturnCursorSQL rows with different branch paths
+- Procedure `dynamic_query`: 1 ReturnCursorSQL row with dynamic SQL
+- Function `get_user_by_id`: 1 ReturnCursorSQL row with `<return>` param
+
+**Step 3: Test JSON output**
+
+```bash
+cargo run --features cli -- -f /tmp/test_return_cursor.sql parse -j | python3 -m json.tool
+```
+
+Expected: Each routine has `routine_analysis` with `return_cursors` array containing proper annotations.
+
+**Step 4: Test round-trip (json2sql)**
+
+```bash
+cargo run --features cli -- -f /tmp/test_return_cursor.sql parse -j | cargo run --features cli -- json2sql
+```
+
+Expected: The `routine_analysis` field is ignored by json2sql (it's an extra field, not part of the core AST), and the SQL is reconstructed correctly.
+
+**Step 5: Commit**
+
+```bash
+git commit --allow-empty -m "test: integration test for return cursor annotation"
+```
+
+---
+
+## Task 7: MCP Server Integration
+
+**Files:**
+- Modify: `src/mcp/mod.rs`
+
+**Step 1: Add return cursor analysis to MCP parse tool**
+
+Find the `parse` tool handler. After the existing JSON output construction, add:
+
+```rust
+// Inject routine analysis for statements with return cursors
+for value in &mut stmt_values {
+    if let Some(stmt_value) = value.get_mut("statement") {
+        // Check if this is a routine with return cursors
+        // ... (same pattern as Task 4)
+    }
+}
+```
+
+Or simpler: construct the output the same way as the CLI, reusing `compute_routine_analysis`.
+
+**Step 2: Test MCP**
+
+```bash
+echo '{"sql":"CREATE PROCEDURE p(cur OUT REFCURSOR) AS BEGIN OPEN cur FOR SELECT 1; END;"}' | cargo run --features mcp -- parse
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/mcp/mod.rs
+git commit -m "feat: return cursor annotation in MCP parse output"
+```
+
+---
+
+## Summary
+
+| Task | Description | Key Files |
+|------|-------------|-----------|
+| 1 | Data structures + core analysis | `src/analyzer/return_cursor.rs` (new) |
+| 2 | Unit tests (8 tests) | `src/analyzer/return_cursor.rs` |
+| 3 | CSV ReturnCursorSQL row type | `src/bin/ogsql.rs` |
+| 4 | JSON routine_analysis injection | `src/bin/ogsql.rs` |
+| 5 | RETURN QUERY support | `return_cursor.rs` + `ogsql.rs` |
+| 6 | Integration test (full package) | CLI testing |
+| 7 | MCP server integration | `src/mcp/mod.rs` |
+
+**Risk areas:**
+- `SqlFormatter::format_expr()` — may not exist; need to check method name
+- `SelectTarget` enum variants — need to verify exact names in AST
+- `PlStatement` variants — ReturnQuery/Return may not be handled in CSV yet (falls through to `_ => {}`)
+- Thread safety — all new state is local to function calls, no global state

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,3 +1,4 @@
+pub mod return_cursor;
 pub mod schema;
 
 use std::collections::HashMap;

--- a/src/analyzer/return_cursor.rs
+++ b/src/analyzer/return_cursor.rs
@@ -1,0 +1,811 @@
+use std::collections::HashMap;
+
+use crate::ast::plpgsql::{
+    PlBlock, PlCaseStmt, PlForStmt, PlIfStmt, PlLoopStmt, PlOpenKind, PlOpenStmt,
+    PlReturnQueryStmt, PlStatement, PlWhileStmt,
+};
+use crate::ast::{Expr, Literal, RoutineParam, SelectTarget, Spanned, Statement};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReturnCursorAnnotation {
+    pub out_param: String,
+    pub out_position: usize,
+    pub out_type: String,
+    pub branch_path: String,
+    pub branch_condition: String,
+    pub jdbc_type: String,
+    pub sql: String,
+    pub sql_source: String,
+    pub parsed_query: Option<Box<Statement>>,
+    pub result_columns: Vec<ResultColumn>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ResultColumn {
+    pub name: String,
+    pub inferred_type: Option<String>,
+    pub expression: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RoutineReturnAnalysis {
+    pub routine_name: String,
+    pub routine_kind: String,
+    pub return_cursors: Vec<ReturnCursorGroup>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReturnCursorGroup {
+    pub out_param: String,
+    pub position: usize,
+    pub cursor_type: String,
+    pub jdbc_type: String,
+    pub branches: Vec<ReturnCursorBranch>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReturnCursorBranch {
+    pub path: String,
+    pub condition: String,
+    pub sql: String,
+    pub sql_source: String,
+    pub result_columns: Vec<ResultColumn>,
+}
+
+struct BranchContext {
+    path: String,
+    condition: String,
+}
+
+struct OutCursorInfo {
+    name: String,
+    position: usize,
+    cursor_type: String,
+}
+
+fn is_out_refcursor(param: &RoutineParam) -> bool {
+    let mode_ok = param
+        .mode
+        .as_ref()
+        .map(|m| {
+            let upper = m.to_uppercase();
+            upper == "OUT" || upper == "INOUT" || upper == "IN OUT"
+        })
+        .unwrap_or(false);
+    let type_ok = param.data_type.to_uppercase().contains("REFCURSOR");
+    mode_ok && type_ok
+}
+
+fn is_return_refcursor(return_type: Option<&str>) -> bool {
+    return_type
+        .map(|rt| rt.to_uppercase().contains("REFCURSOR"))
+        .unwrap_or(false)
+}
+
+pub fn has_return_cursors(params: &[RoutineParam], return_type: Option<&str>) -> bool {
+    params.iter().any(is_out_refcursor) || is_return_refcursor(return_type)
+}
+
+fn extract_cursor_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::PlVariable(names) | Expr::ColumnRef(names) if names.len() == 1 => {
+            Some(names[0].clone())
+        }
+        _ => None,
+    }
+}
+
+fn format_expr_brief(expr: &Expr) -> String {
+    match expr {
+        Expr::Literal(Literal::String(s)) => format!("'{}'", s),
+        Expr::Literal(lit) => format!("{:?}", lit),
+        Expr::ColumnRef(names) | Expr::PlVariable(names) => names.join("."),
+        Expr::BinaryOp { left, op, right } => format!(
+            "{} {} {}",
+            format_expr_brief(left),
+            op,
+            format_expr_brief(right)
+        ),
+        Expr::UnaryOp { op, expr: inner } => format!("{}{}", op, format_expr_brief(inner)),
+        Expr::Parenthesized(inner) => format!("({})", format_expr_brief(inner)),
+        Expr::FunctionCall { name, args, .. } => {
+            let arg_strs: Vec<String> = args.iter().map(format_expr_brief).collect();
+            format!("{}({})", name.join("."), arg_strs.join(", "))
+        }
+        Expr::IsNull { expr: inner, negated } => {
+            if *negated {
+                format!("{} IS NOT NULL", format_expr_brief(inner))
+            } else {
+                format!("{} IS NULL", format_expr_brief(inner))
+            }
+        }
+        Expr::TypeCast { expr: inner, type_name, .. } => {
+            format!("{}::{:?}", format_expr_brief(inner), type_name)
+        }
+        _ => format!("{:?}", expr),
+    }
+}
+
+fn extract_result_columns(stmt: &Statement) -> Vec<ResultColumn> {
+    let select = match stmt {
+        Statement::Select(s) => &s.node,
+        _ => return Vec::new(),
+    };
+    let mut columns = Vec::new();
+    for target in &select.targets {
+        match target {
+            SelectTarget::Expr(expr, alias) => {
+                let name = alias
+                    .clone()
+                    .or_else(|| infer_column_name(expr))
+                    .unwrap_or_else(|| "?".to_string());
+                columns.push(ResultColumn {
+                    name,
+                    inferred_type: None,
+                    expression: format_expr_brief(expr),
+                });
+            }
+            SelectTarget::Star(table) => {
+                let name = table
+                    .as_ref()
+                    .map(|t| format!("{}.*", t))
+                    .unwrap_or_else(|| "*".to_string());
+                columns.push(ResultColumn {
+                    name,
+                    inferred_type: None,
+                    expression: "*".to_string(),
+                });
+            }
+        }
+    }
+    columns
+}
+
+fn infer_column_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::ColumnRef(names) => names.last().cloned(),
+        Expr::PlVariable(names) => names.last().cloned(),
+        Expr::Literal(Literal::String(_)) => Some("?column?".to_string()),
+        _ => None,
+    }
+}
+
+fn make_annotation(
+    out_param: &str,
+    position: usize,
+    cursor_type: &str,
+    branch_ctx: &BranchContext,
+    sql: String,
+    sql_source: &str,
+    parsed_query: Option<Box<Statement>>,
+    result_columns: Vec<ResultColumn>,
+) -> ReturnCursorAnnotation {
+    ReturnCursorAnnotation {
+        out_param: out_param.to_string(),
+        out_position: position,
+        out_type: cursor_type.to_string(),
+        branch_path: branch_ctx.path.clone(),
+        branch_condition: branch_ctx.condition.clone(),
+        jdbc_type: "REF_CURSOR".to_string(),
+        sql,
+        sql_source: sql_source.to_string(),
+        parsed_query,
+        result_columns,
+    }
+}
+
+fn process_open_stmt(
+    open: &Spanned<PlOpenStmt>,
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    branch_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    let cursor_name = extract_cursor_name(&open.cursor);
+
+    let matched_out = cursor_name
+        .as_ref()
+        .and_then(|name| out_cursors.iter().find(|c| c.name.eq_ignore_ascii_case(name)));
+
+    if matched_out.is_none() && !is_func_return {
+        return;
+    }
+
+    let (out_param, position, cursor_type) = if let Some(info) = matched_out {
+        (
+            info.name.clone(),
+            info.position,
+            info.cursor_type.clone(),
+        )
+    } else if is_func_return {
+        (
+            "<return>".to_string(),
+            0,
+            return_cursor_type.unwrap_or("REFCURSOR").to_string(),
+        )
+    } else {
+        return;
+    };
+
+    match &open.kind {
+        PlOpenKind::ForQuery {
+            query,
+            parsed_query,
+            ..
+        } => {
+            let result_columns = parsed_query
+                .as_ref()
+                .map(|pq| extract_result_columns(pq))
+                .unwrap_or_default();
+            annotations.push(make_annotation(
+                &out_param,
+                position,
+                &cursor_type,
+                branch_ctx,
+                query.clone(),
+                "static",
+                parsed_query.clone(),
+                result_columns,
+            ));
+        }
+        PlOpenKind::ForExecute { query, using_args } => {
+            let query_str = format_expr_brief(&query);
+            let parsed = crate::parser::Parser::parse_statement_from_str(&query_str);
+            let result_columns = parsed
+                .as_ref()
+                .map(|pq| extract_result_columns(pq))
+                .unwrap_or_default();
+            annotations.push(make_annotation(
+                &out_param,
+                position,
+                &cursor_type,
+                branch_ctx,
+                query_str,
+                "dynamic",
+                parsed,
+                result_columns,
+            ));
+            let _ = using_args;
+        }
+        PlOpenKind::Simple { .. } | PlOpenKind::ForUsing { .. } => {}
+    }
+}
+
+fn process_return_query(
+    rq: &Spanned<PlReturnQueryStmt>,
+    return_cursor_type: Option<&str>,
+    branch_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    let sql_source = if rq.is_dynamic {
+        "dynamic"
+    } else {
+        "static"
+    };
+    let sql = if rq.is_dynamic {
+        rq.dynamic_expr
+            .as_ref()
+            .map(format_expr_brief)
+            .unwrap_or_else(|| rq.query.clone())
+    } else {
+        rq.query.clone()
+    };
+    let parsed = crate::parser::Parser::parse_statement_from_str(&sql);
+    let result_columns = parsed
+        .as_ref()
+        .map(|pq| extract_result_columns(pq))
+        .unwrap_or_default();
+    annotations.push(make_annotation(
+        "<return>",
+        0,
+        return_cursor_type.unwrap_or("REFCURSOR"),
+        branch_ctx,
+        sql,
+        sql_source,
+        parsed,
+        result_columns,
+    ));
+}
+
+fn walk_statements(
+    stmts: &[PlStatement],
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    branch_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    for stmt in stmts {
+        match stmt {
+            PlStatement::Open(open) => {
+                process_open_stmt(
+                    open,
+                    out_cursors,
+                    is_func_return,
+                    return_cursor_type,
+                    branch_ctx,
+                    annotations,
+                );
+            }
+            PlStatement::ReturnQuery(rq) if is_func_return => {
+                process_return_query(rq, return_cursor_type, branch_ctx, annotations);
+            }
+            PlStatement::If(if_stmt) => {
+                walk_if(if_stmt, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+            }
+            PlStatement::Case(case_stmt) => {
+                walk_case(case_stmt, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+            }
+            PlStatement::Loop(loop_stmt) => {
+                walk_loop(loop_stmt, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+            }
+            PlStatement::While(while_stmt) => {
+                walk_while(while_stmt, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+            }
+            PlStatement::For(for_stmt) => {
+                walk_for(for_stmt, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+            }
+            PlStatement::Block(block) => {
+                walk_statements(&block.body, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+                if let Some(ref eb) = block.exception_block {
+                    for handler in &eb.handlers {
+                        walk_statements(&handler.statements, out_cursors, is_func_return, return_cursor_type, branch_ctx, annotations);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn push_path(parent: &str, segment: &str) -> String {
+    if parent.is_empty() {
+        segment.to_string()
+    } else {
+        format!("{}.{}", parent, segment)
+    }
+}
+
+fn walk_if(
+    if_stmt: &PlIfStmt,
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    parent_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    let then_path = push_path(&parent_ctx.path, "IF.then");
+    let then_ctx = BranchContext {
+        path: then_path,
+        condition: format_expr_brief(&if_stmt.condition),
+    };
+    walk_statements(&if_stmt.then_stmts, out_cursors, is_func_return, return_cursor_type, &then_ctx, annotations);
+
+    for (i, elsif) in if_stmt.elsifs.iter().enumerate() {
+        let elsif_path = push_path(&parent_ctx.path, &format!("IF.elsif#{}.then", i + 1));
+        let elsif_ctx = BranchContext {
+            path: elsif_path,
+            condition: format_expr_brief(&elsif.condition),
+        };
+        walk_statements(&elsif.stmts, out_cursors, is_func_return, return_cursor_type, &elsif_ctx, annotations);
+    }
+
+    if !if_stmt.else_stmts.is_empty() {
+        let else_path = push_path(&parent_ctx.path, "IF.else");
+        let else_ctx = BranchContext {
+            path: else_path,
+            condition: String::new(),
+        };
+        walk_statements(&if_stmt.else_stmts, out_cursors, is_func_return, return_cursor_type, &else_ctx, annotations);
+    }
+}
+
+fn walk_case(
+    case_stmt: &PlCaseStmt,
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    parent_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    for (i, when) in case_stmt.whens.iter().enumerate() {
+        let when_path = push_path(&parent_ctx.path, &format!("CASE.when#{}", i + 1));
+        let when_ctx = BranchContext {
+            path: when_path,
+            condition: format_expr_brief(&when.condition),
+        };
+        walk_statements(&when.stmts, out_cursors, is_func_return, return_cursor_type, &when_ctx, annotations);
+    }
+
+    if !case_stmt.else_stmts.is_empty() {
+        let else_path = push_path(&parent_ctx.path, "CASE.else");
+        let else_ctx = BranchContext {
+            path: else_path,
+            condition: String::new(),
+        };
+        walk_statements(&case_stmt.else_stmts, out_cursors, is_func_return, return_cursor_type, &else_ctx, annotations);
+    }
+}
+
+fn walk_loop(
+    loop_stmt: &PlLoopStmt,
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    parent_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    let path = push_path(&parent_ctx.path, "LOOP.body");
+    let ctx = BranchContext {
+        path,
+        condition: String::new(),
+    };
+    walk_statements(&loop_stmt.body, out_cursors, is_func_return, return_cursor_type, &ctx, annotations);
+}
+
+fn walk_while(
+    while_stmt: &PlWhileStmt,
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    parent_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    let path = push_path(&parent_ctx.path, "WHILE.body");
+    let ctx = BranchContext {
+        path,
+        condition: format_expr_brief(&while_stmt.condition),
+    };
+    walk_statements(&while_stmt.body, out_cursors, is_func_return, return_cursor_type, &ctx, annotations);
+}
+
+fn walk_for(
+    for_stmt: &PlForStmt,
+    out_cursors: &[OutCursorInfo],
+    is_func_return: bool,
+    return_cursor_type: Option<&str>,
+    parent_ctx: &BranchContext,
+    annotations: &mut Vec<ReturnCursorAnnotation>,
+) {
+    let path = push_path(&parent_ctx.path, "FOR.body");
+    let ctx = BranchContext {
+        path,
+        condition: String::new(),
+    };
+    walk_statements(&for_stmt.body, out_cursors, is_func_return, return_cursor_type, &ctx, annotations);
+}
+
+fn group_annotations(annotations: Vec<ReturnCursorAnnotation>) -> Vec<ReturnCursorGroup> {
+    let mut map: HashMap<String, ReturnCursorGroup> = HashMap::new();
+    for ann in annotations {
+        let key = format!("{}:{}", ann.out_param, ann.out_position);
+        let group = map.entry(key).or_insert_with(|| ReturnCursorGroup {
+            out_param: ann.out_param.clone(),
+            position: ann.out_position,
+            cursor_type: ann.out_type.clone(),
+            jdbc_type: ann.jdbc_type.clone(),
+            branches: Vec::new(),
+        });
+        group.branches.push(ReturnCursorBranch {
+            path: ann.branch_path,
+            condition: ann.branch_condition,
+            sql: ann.sql,
+            sql_source: ann.sql_source,
+            result_columns: ann.result_columns,
+        });
+    }
+    let mut groups: Vec<ReturnCursorGroup> = map.into_values().collect();
+    groups.sort_by(|a, b| a.position.cmp(&b.position).then_with(|| a.out_param.cmp(&b.out_param)));
+    groups
+}
+
+pub fn analyze_return_cursors(
+    block: &PlBlock,
+    params: &[RoutineParam],
+    routine_name: &str,
+    routine_kind: &str,
+    return_type: Option<&str>,
+) -> RoutineReturnAnalysis {
+    let mut out_cursors = Vec::new();
+    for (i, param) in params.iter().enumerate() {
+        if is_out_refcursor(param) {
+            out_cursors.push(OutCursorInfo {
+                name: param.name.clone(),
+                position: i + 1,
+                cursor_type: param.data_type.clone(),
+            });
+        }
+    }
+
+    let is_func_return = is_return_refcursor(return_type);
+    let return_cursor_type = return_type.map(|rt| {
+        if rt.to_uppercase().contains("REFCURSOR") {
+            rt.to_string()
+        } else {
+            rt.to_string()
+        }
+    });
+
+    let root_ctx = BranchContext {
+        path: String::new(),
+        condition: String::new(),
+    };
+
+    let mut annotations = Vec::new();
+    walk_statements(
+        &block.body,
+        &out_cursors,
+        is_func_return,
+        return_cursor_type.as_deref(),
+        &root_ctx,
+        &mut annotations,
+    );
+
+    let groups = group_annotations(annotations);
+
+    RoutineReturnAnalysis {
+        routine_name: routine_name.to_string(),
+        routine_kind: routine_kind.to_string(),
+        return_cursors: groups,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::Parser;
+    use crate::token::tokenizer::Tokenizer;
+
+    fn parse_pl(sql: &str) -> Vec<crate::ast::Statement> {
+        let tokens = Tokenizer::new(sql).tokenize().unwrap();
+        Parser::new(tokens).parse()
+    }
+
+    fn first_stmt(stmts: &[crate::ast::Statement]) -> Option<&crate::ast::Statement> {
+        stmts.first()
+    }
+
+    fn extract_block(stmts: &[crate::ast::Statement]) -> Option<PlBlock> {
+        match first_stmt(stmts)? {
+            crate::ast::Statement::CreateProcedure(p) => p.block.clone(),
+            crate::ast::Statement::CreateFunction(f) => f.block.clone(),
+            _ => None,
+        }
+    }
+
+    fn extract_params(stmts: &[crate::ast::Statement]) -> Vec<RoutineParam> {
+        match first_stmt(stmts) {
+            Some(crate::ast::Statement::CreateProcedure(p)) => p.parameters.clone(),
+            Some(crate::ast::Statement::CreateFunction(f)) => f.parameters.clone(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn extract_return_type(stmts: &[crate::ast::Statement]) -> Option<String> {
+        match first_stmt(stmts)? {
+            crate::ast::Statement::CreateFunction(f) => f.return_type.clone(),
+            _ => None,
+        }
+    }
+
+    fn extract_name(stmts: &[crate::ast::Statement]) -> String {
+        match first_stmt(stmts) {
+            Some(crate::ast::Statement::CreateProcedure(p)) => p.name.join("."),
+            Some(crate::ast::Statement::CreateFunction(f)) => f.name.join("."),
+            _ => "unknown".to_string(),
+        }
+    }
+
+    fn extract_kind(stmts: &[crate::ast::Statement]) -> String {
+        match first_stmt(stmts) {
+            Some(crate::ast::Statement::CreateProcedure(_)) => "Procedure".to_string(),
+            Some(crate::ast::Statement::CreateFunction(_)) => "Function".to_string(),
+            _ => "Unknown".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_basic_out_refcursor_static() {
+        let sql = r#"
+            CREATE PROCEDURE get_users(p_cur OUT SYS_REFCURSOR) AS
+            BEGIN
+                OPEN p_cur FOR SELECT id, name FROM users;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+        let name = extract_name(&stmts);
+        let kind = extract_kind(&stmts);
+
+        let result = analyze_return_cursors(&block, &params, &name, &kind, None);
+
+        assert_eq!(result.routine_name, "get_users");
+        assert_eq!(result.routine_kind, "Procedure");
+        assert_eq!(result.return_cursors.len(), 1);
+        let group = &result.return_cursors[0];
+        assert_eq!(group.out_param, "p_cur");
+        assert_eq!(group.position, 1);
+        assert_eq!(group.cursor_type.to_uppercase(), "SYS_REFCURSOR");
+        assert_eq!(group.jdbc_type, "REF_CURSOR");
+        assert_eq!(group.branches.len(), 1);
+        let branch = &group.branches[0];
+        assert_eq!(branch.path, "");
+        assert_eq!(branch.sql_source, "static");
+        assert!(branch.sql.to_uppercase().contains("SELECT"));
+        assert!(branch.sql.to_uppercase().contains("USERS"));
+    }
+
+    #[test]
+    fn test_conditional_branches() {
+        let sql = r#"
+            CREATE PROCEDURE get_data(p_cur OUT SYS_REFCURSOR, p_type INTEGER) AS
+            BEGIN
+                IF p_type = 1 THEN
+                    OPEN p_cur FOR SELECT id, name FROM users;
+                ELSIF p_type = 2 THEN
+                    OPEN p_cur FOR SELECT id, title FROM posts;
+                ELSE
+                    OPEN p_cur FOR SELECT id, value FROM config;
+                END IF;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+
+        let result = analyze_return_cursors(&block, &params, "get_data", "Procedure", None);
+
+        assert_eq!(result.return_cursors.len(), 1);
+        let group = &result.return_cursors[0];
+        assert_eq!(group.branches.len(), 3);
+
+        assert_eq!(group.branches[0].path, "IF.then");
+        assert!(group.branches[0].sql.to_uppercase().contains("USERS"));
+
+        assert_eq!(group.branches[1].path, "IF.elsif#1.then");
+        assert!(group.branches[1].sql.to_uppercase().contains("POSTS"));
+
+        assert_eq!(group.branches[2].path, "IF.else");
+        assert!(group.branches[2].sql.to_uppercase().contains("CONFIG"));
+    }
+
+    #[test]
+    fn test_in_cursor_not_annotated() {
+        let sql = r#"
+            CREATE PROCEDURE process_cursor(p_cur IN SYS_REFCURSOR) AS
+            BEGIN
+                NULL;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+
+        let result = analyze_return_cursors(&block, &params, "process_cursor", "Procedure", None);
+
+        assert_eq!(result.return_cursors.len(), 0);
+    }
+
+    #[test]
+    fn test_no_cursor_params() {
+        let sql = r#"
+            CREATE PROCEDURE no_cursors(p_id INTEGER) AS
+            BEGIN
+                NULL;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+
+        let result = analyze_return_cursors(&block, &params, "no_cursors", "Procedure", None);
+
+        assert_eq!(result.return_cursors.len(), 0);
+    }
+
+    #[test]
+    fn test_function_returns_refcursor() {
+        let sql = r#"
+            CREATE FUNCTION get_users_func RETURN SYS_REFCURSOR AS
+            BEGIN
+                OPEN rc FOR SELECT id, name FROM users;
+                RETURN rc;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+        let ret_type = extract_return_type(&stmts);
+
+        let result = analyze_return_cursors(
+            &block,
+            &params,
+            "get_users_func",
+            "Function",
+            ret_type.as_deref(),
+        );
+
+        assert_eq!(result.return_cursors.len(), 1);
+        let group = &result.return_cursors[0];
+        assert_eq!(group.out_param, "<return>");
+        assert_eq!(group.position, 0);
+        assert_eq!(group.branches.len(), 1);
+        assert_eq!(group.branches[0].sql_source, "static");
+        assert!(group.branches[0].sql.to_uppercase().contains("SELECT"));
+    }
+
+    #[test]
+    fn test_dynamic_execute_cursor() {
+        let sql = r#"
+            CREATE PROCEDURE dyn_cursor(p_cur OUT SYS_REFCURSOR, v_sql VARCHAR) AS
+            BEGIN
+                OPEN p_cur FOR EXECUTE v_sql;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+
+        let result = analyze_return_cursors(&block, &params, "dyn_cursor", "Procedure", None);
+
+        assert_eq!(result.return_cursors.len(), 1);
+        let group = &result.return_cursors[0];
+        assert_eq!(group.branches.len(), 1);
+        assert_eq!(group.branches[0].sql_source, "dynamic");
+    }
+
+    #[test]
+    fn test_has_return_cursors() {
+        let out_cursor = RoutineParam {
+            name: "p_cur".to_string(),
+            mode: Some("OUT".to_string()),
+            data_type: "SYS_REFCURSOR".to_string(),
+            default_value: None,
+        };
+        assert!(has_return_cursors(&[out_cursor.clone()], None));
+
+        let in_cursor = RoutineParam {
+            name: "p_cur".to_string(),
+            mode: Some("IN".to_string()),
+            data_type: "SYS_REFCURSOR".to_string(),
+            default_value: None,
+        };
+        assert!(!has_return_cursors(&[in_cursor], None));
+
+        let no_cursor = RoutineParam {
+            name: "p_id".to_string(),
+            mode: Some("IN".to_string()),
+            data_type: "INTEGER".to_string(),
+            default_value: None,
+        };
+        assert!(!has_return_cursors(&[no_cursor], None));
+
+        assert!(has_return_cursors(&[], Some("SYS_REFCURSOR")));
+        assert!(!has_return_cursors(&[], Some("INTEGER")));
+    }
+
+    #[test]
+    fn test_result_columns_extracted() {
+        let sql = r#"
+            CREATE PROCEDURE get_cols(p_cur OUT SYS_REFCURSOR) AS
+            BEGIN
+                OPEN p_cur FOR SELECT id, name AS user_name FROM users;
+            END;
+        "#;
+        let stmts = parse_pl(sql);
+        let block = extract_block(&stmts).unwrap();
+        let params = extract_params(&stmts);
+
+        let result = analyze_return_cursors(&block, &params, "get_cols", "Procedure", None);
+
+        assert_eq!(result.return_cursors.len(), 1);
+        let group = &result.return_cursors[0];
+        assert_eq!(group.branches.len(), 1);
+        let cols = &group.branches[0].result_columns;
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].name, "id");
+        assert_eq!(cols[1].name, "user_name");
+    }
+}

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -4758,4 +4758,40 @@ mod tests {
         let vars = extract_variables(sql);
         assert!(vars.contains("__SQL_RAW_VARCHAR2_v_sql__"), "got: {}", vars);
     }
+
+    #[test]
+    fn test_find_using_keyword_pos_chinese_aliases_no_panic() {
+        // Regression: byte-index slicing on multi-byte UTF-8 (Chinese) caused panic.
+        // "账号类型" starts at byte 110, char '账' occupies bytes 110..113.
+        // A byte-by-byte scan would land on byte 111 (mid-character) and panic on &str[..].
+        let sql = "select * from ( select decode ( t . if_inter_bank , '1' , '银行间资金结算账户' , '银行存款类' ) 账号类型 , t . fund_name 组合 , t . accno 账户 from t ) using p_min_amount, p_start_date";
+        let pos = find_using_keyword_pos(sql);
+        assert!(pos.is_some(), "should find USING keyword");
+        let p = pos.unwrap();
+        assert!(sql[p..].to_ascii_lowercase().starts_with("using "), "slice at pos must start with 'using '");
+    }
+
+    #[test]
+    fn test_find_using_keyword_pos_pure_chinese_no_using() {
+        let sql = "select 账号类型 , 组合 , 账户名称 from dual";
+        assert_eq!(find_using_keyword_pos(sql), None);
+    }
+
+    #[test]
+    fn test_find_using_keyword_pos_chinese_inside_string_skipped() {
+        // "using " inside a string literal must be ignored
+        let sql = "select 'using 中文测试' from dual using p_id";
+        let pos = find_using_keyword_pos(sql);
+        assert!(pos.is_some());
+        let p = pos.unwrap();
+        assert!(sql[p..].to_ascii_lowercase().starts_with("using "));
+    }
+
+    #[test]
+    fn test_find_using_keyword_pos_mixed_multibyte() {
+        // Mix of Chinese, Japanese, Korean with USING at end
+        let sql = "select 账号, データ, 데이터 from t using v_id";
+        let pos = find_using_keyword_pos(sql);
+        assert!(pos.is_some());
+    }
 }

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -1092,24 +1092,18 @@ fn find_using_keyword_pos(text: &str) -> Option<usize> {
     let lower = text.to_ascii_lowercase();
     let mut in_string_single = false;
     let mut in_string_double = false;
-    let mut i = 0;
-    let bytes = lower.as_bytes();
-    while i < bytes.len() {
-        let c = bytes[i];
-        if c == b'\'' && !in_string_double {
+    for (i, c) in lower.char_indices() {
+        if c == '\'' && !in_string_double {
             in_string_single = !in_string_single;
-            i += 1;
             continue;
         }
-        if c == b'"' && !in_string_single {
+        if c == '"' && !in_string_single {
             in_string_double = !in_string_double;
-            i += 1;
             continue;
         }
         if !in_string_single && !in_string_double && lower[i..].starts_with("using ") {
             return Some(i);
         }
-        i += 1;
     }
     None
 }

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -290,6 +290,83 @@ fn cmd_format(
     }
 }
 
+fn has_routine_return_cursors(stmt: &ogsql_parser::Statement) -> bool {
+    use ogsql_parser::Statement;
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            ogsql_parser::has_return_cursors(&p.parameters, None)
+        }
+        Statement::CreateFunction(f) => {
+            ogsql_parser::has_return_cursors(&f.parameters, f.return_type.as_deref())
+        }
+        Statement::CreatePackageBody(pkg) => {
+            pkg.items.iter().any(|item| match item {
+                ogsql_parser::ast::PackageItem::Procedure(p) =>
+                    ogsql_parser::has_return_cursors(&p.parameters, None),
+                ogsql_parser::ast::PackageItem::Function(f) =>
+                    ogsql_parser::has_return_cursors(&f.parameters, f.return_type.as_deref()),
+                _ => false,
+            })
+        }
+        _ => false,
+    }
+}
+
+fn compute_routine_analysis(stmt: &ogsql_parser::Statement) -> Option<serde_json::Value> {
+    use ogsql_parser::Statement;
+    match stmt {
+        Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref()?;
+            let analysis = ogsql_parser::analyze_return_cursors(
+                block, &p.parameters, &p.name.join("."), "Procedure", None,
+            );
+            if analysis.return_cursors.is_empty() { return None; }
+            Some(serde_json::json!(analysis))
+        }
+        Statement::CreateFunction(f) => {
+            let block = f.block.as_ref()?;
+            let analysis = ogsql_parser::analyze_return_cursors(
+                block, &f.parameters, &f.name.join("."), "Function",
+                f.return_type.as_deref(),
+            );
+            if analysis.return_cursors.is_empty() { return None; }
+            Some(serde_json::json!(analysis))
+        }
+        Statement::CreatePackageBody(pkg) => {
+            let mut analyses = Vec::new();
+            for item in &pkg.items {
+                match item {
+                    ogsql_parser::ast::PackageItem::Procedure(p) => {
+                        if let Some(ref block) = p.block {
+                            let analysis = ogsql_parser::analyze_return_cursors(
+                                block, &p.parameters, &p.name.join("."),
+                                "Procedure", None,
+                            );
+                            if !analysis.return_cursors.is_empty() {
+                                analyses.push(analysis);
+                            }
+                        }
+                    }
+                    ogsql_parser::ast::PackageItem::Function(f) => {
+                        if let Some(ref block) = f.block {
+                            let analysis = ogsql_parser::analyze_return_cursors(
+                                block, &f.parameters, &f.name.join("."),
+                                "Function", f.return_type.as_deref(),
+                            );
+                            if !analysis.return_cursors.is_empty() {
+                                analyses.push(analysis);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if analyses.is_empty() { None } else { Some(serde_json::json!(analyses)) }
+        }
+        _ => None,
+    }
+}
+
 fn cmd_parse(cli: &Cli, csv: bool) {
     let sql = read_input(cli.file.as_deref());
     let output = parse_input(&sql, cli.comments, cli.mybatis);
@@ -331,6 +408,14 @@ fn cmd_parse(cli: &Cli, csv: bool) {
                     }
                 }
                 annotate_builtin_functions(&mut obj);
+                if has_routine_return_cursors(&si.statement) {
+                    if let Some(analysis) = compute_routine_analysis(&si.statement) {
+                        obj.as_object_mut().unwrap().insert(
+                            "routine_analysis".to_string(),
+                            analysis,
+                        );
+                    }
+                }
                 obj
             })
             .collect();
@@ -598,7 +683,7 @@ fn read_file_path(path: &std::path::Path) -> String {
 }
 
 fn output_csv_parse_header() {
-    println!("file,directory,line,type,name,parent,parameters,return_type,sql,error,warning");
+    println!("file,directory,line,type,name,parent,parameters,return_type,sql,error,warning,branch_path,branch_condition");
 }
 
 struct ParseCsvRow {
@@ -609,6 +694,8 @@ struct ParseCsvRow {
     parameters: String,
     return_type: String,
     sql: String,
+    branch_path: String,
+    branch_condition: String,
 }
 
 fn format_params(params: &[ogsql_parser::ast::RoutineParam]) -> String {
@@ -1155,12 +1242,31 @@ fn resolve_dynamic_query_text(
     replace_pl_vars_in_sql(t, vars)
 }
 
+fn join_branch(parent: &str, segment: &str) -> String {
+    if parent.is_empty() { segment.to_string() } else { format!("{}.{}", parent, segment) }
+}
+
+fn extract_out_cursor_set(params: &[ogsql_parser::ast::RoutineParam]) -> std::collections::HashSet<String> {
+    params.iter()
+        .filter(|p| {
+            let is_out = p.mode.as_deref() == Some("OUT")
+                || p.mode.as_deref() == Some("INOUT")
+                || p.mode.as_deref() == Some("IN OUT");
+            let is_cursor = p.data_type.to_uppercase().contains("REFCURSOR");
+            is_out && is_cursor
+        })
+        .map(|p| p.name.to_lowercase())
+        .collect()
+}
+
 /// Recursively collect SQL rows from a PL/pgSQL block into individual CSV rows.
 fn collect_block_sql_rows(
     block: &ogsql_parser::ast::plpgsql::PlBlock,
     parent_name: &str,
     fallback_line: usize,
     vars: &std::collections::HashMap<String, Option<String>>,
+    out_cursors: &std::collections::HashSet<String>,
+    all_opens_are_returns: bool,
 ) -> Vec<ParseCsvRow> {
     use ogsql_parser::ast::plpgsql::PlDeclaration;
     let mut rows = Vec::new();
@@ -1176,12 +1282,12 @@ fn collect_block_sql_rows(
         }
     }
     for stmt in &block.body {
-        collect_pl_stmt_rows(stmt, parent_name, fallback_line, vars, &mut assigns, &mut rows);
+        collect_pl_stmt_rows(stmt, parent_name, fallback_line, vars, &mut assigns, &mut rows, out_cursors, all_opens_are_returns, "", "");
     }
     if let Some(ref exc) = block.exception_block {
         for handler in &exc.handlers {
             for stmt in &handler.statements {
-                collect_pl_stmt_rows(stmt, parent_name, fallback_line, vars, &mut assigns, &mut rows);
+                collect_pl_stmt_rows(stmt, parent_name, fallback_line, vars, &mut assigns, &mut rows, out_cursors, all_opens_are_returns, "", "");
             }
         }
     }
@@ -1260,6 +1366,10 @@ fn collect_pl_stmt_rows(
     vars: &std::collections::HashMap<String, Option<String>>,
     assigns: &mut std::collections::HashMap<String, Vec<ConcatPart>>,
     rows: &mut Vec<ParseCsvRow>,
+    out_cursors: &std::collections::HashSet<String>,
+    all_opens_are_returns: bool,
+    branch_path: &str,
+    branch_condition: &str,
 ) {
     use ogsql_parser::ast::plpgsql::PlStatement;
 
@@ -1302,6 +1412,8 @@ fn collect_pl_stmt_rows(
                 parameters: String::new(),
                 return_type: String::new(),
                 sql,
+                branch_path: branch_path.to_string(),
+                branch_condition: branch_condition.to_string(),
             });
         }
         PlStatement::Sql(text) => {
@@ -1325,6 +1437,8 @@ fn collect_pl_stmt_rows(
                     parameters: String::new(),
                     return_type: String::new(),
                     sql,
+                    branch_path: branch_path.to_string(),
+                    branch_condition: branch_condition.to_string(),
                 });
             }
         }
@@ -1339,6 +1453,8 @@ fn collect_pl_stmt_rows(
                 parameters: String::new(),
                 return_type: String::new(),
                 sql,
+                branch_path: branch_path.to_string(),
+                branch_condition: branch_condition.to_string(),
             });
         }
         PlStatement::Perform { span, query, .. } => {
@@ -1352,17 +1468,20 @@ fn collect_pl_stmt_rows(
                 parameters: String::new(),
                 return_type: String::new(),
                 sql,
+                branch_path: branch_path.to_string(),
+                branch_condition: branch_condition.to_string(),
             });
         }
         PlStatement::Block(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
+            let bp = join_branch(branch_path, "Block");
             for s in &spanned.node.body {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns, &bp, branch_condition);
             }
             if let Some(ref exc) = spanned.node.exception_block {
                 for handler in &exc.handlers {
                     for s in &handler.statements {
-                        collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                        collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns, &bp, branch_condition);
                     }
                 }
             }
@@ -1370,45 +1489,57 @@ fn collect_pl_stmt_rows(
         PlStatement::If(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
             let if_stmt = &spanned.node;
+            let cond_str = format_pl_expr(&if_stmt.condition);
             for s in &if_stmt.then_stmts {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns,
+                    &join_branch(branch_path, "IF.then"), &cond_str);
             }
-            for elsif in &if_stmt.elsifs {
+            for (i, elsif) in if_stmt.elsifs.iter().enumerate() {
+                let elsif_cond = format_pl_expr(&elsif.condition);
                 for s in &elsif.stmts {
-                    collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                    collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns,
+                        &join_branch(branch_path, &format!("IF.elsif#{}.then", i + 1)), &elsif_cond);
                 }
             }
             for s in &if_stmt.else_stmts {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns,
+                    &join_branch(branch_path, "IF.else"), &cond_str);
             }
         }
         PlStatement::Case(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
             let case_stmt = &spanned.node;
-            for when in &case_stmt.whens {
+            for (i, when) in case_stmt.whens.iter().enumerate() {
+                let when_cond = format_pl_expr(&when.condition);
                 for s in &when.stmts {
-                    collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                    collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns,
+                        &join_branch(branch_path, &format!("CASE.when#{}", i + 1)), &when_cond);
                 }
             }
             for s in &case_stmt.else_stmts {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns,
+                    &join_branch(branch_path, "CASE.else"), "");
             }
         }
         PlStatement::Loop(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
+            let bp = join_branch(branch_path, "LOOP");
             for s in &spanned.node.body {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns, &bp, branch_condition);
             }
         }
         PlStatement::While(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
+            let while_cond = format_pl_expr(&spanned.node.condition);
+            let bp = join_branch(branch_path, "WHILE");
             for s in &spanned.node.body {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns, &bp, &while_cond);
             }
         }
         PlStatement::For(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
             let for_stmt = &spanned.node;
+            let bp = join_branch(branch_path, "FOR");
             match &for_stmt.kind {
                 ogsql_parser::ast::plpgsql::PlForKind::Query { query, parsed_query, using_args: _ } => {
                     rows.push(ParseCsvRow {
@@ -1419,6 +1550,8 @@ fn collect_pl_stmt_rows(
                         parameters: String::new(),
                         return_type: String::new(),
                         sql: String::new(),
+                        branch_path: bp.clone(),
+                        branch_condition: branch_condition.to_string(),
                     });
                     if let Some(ref stmt) = parsed_query {
                         let formatter = ogsql_parser::SqlFormatter::new();
@@ -1432,6 +1565,8 @@ fn collect_pl_stmt_rows(
                             parameters: String::new(),
                             return_type: String::new(),
                             sql,
+                            branch_path: bp.clone(),
+                            branch_condition: branch_condition.to_string(),
                         });
                     } else {
                         let (embedded_type, sql) = resolve_for_query_text(query, vars, assigns);
@@ -1443,6 +1578,8 @@ fn collect_pl_stmt_rows(
                             parameters: String::new(),
                             return_type: String::new(),
                             sql,
+                            branch_path: bp.clone(),
+                            branch_condition: branch_condition.to_string(),
                         });
                     }
                 }
@@ -1456,18 +1593,21 @@ fn collect_pl_stmt_rows(
                         parameters: args_str.join(", "),
                         return_type: String::new(),
                         sql: String::new(),
+                        branch_path: bp.clone(),
+                        branch_condition: branch_condition.to_string(),
                     });
                 }
                 _ => {}
             }
             for s in &for_stmt.body {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns, &bp, branch_condition);
             }
         }
         PlStatement::ForEach(spanned) => {
             let line = spanned_line(&spanned.span).max(fallback_line);
+            let bp = join_branch(branch_path, "FOREACH");
             for s in &spanned.node.body {
-                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows);
+                collect_pl_stmt_rows(s, parent_name, line, vars, assigns, rows, out_cursors, all_opens_are_returns, &bp, branch_condition);
             }
         }
         PlStatement::ForAll(spanned) => {
@@ -1482,6 +1622,8 @@ fn collect_pl_stmt_rows(
                     parameters: String::new(),
                     return_type: String::new(),
                     sql: body.trim().to_string(),
+                    branch_path: branch_path.to_string(),
+                    branch_condition: branch_condition.to_string(),
                 });
             }
         }
@@ -1489,53 +1631,72 @@ fn collect_pl_stmt_rows(
             let line = spanned_line(&spanned.span).max(fallback_line);
             let open_stmt = &spanned.node;
             let cursor_name = format_pl_expr(&open_stmt.cursor);
+            let is_out = out_cursors.contains(&cursor_name.to_lowercase()) || all_opens_are_returns;
             match &open_stmt.kind {
                 ogsql_parser::ast::plpgsql::PlOpenKind::ForQuery { scroll: _, query, parsed_query } => {
-                    rows.push(ParseCsvRow {
-                        line,
-                        stmt_type: "Open/ForQuery".into(),
-                        name: cursor_name,
-                        parent: parent_name.to_string(),
-                        parameters: String::new(),
-                        return_type: String::new(),
-                        sql: String::new(),
-                    });
-                    if let Some(ref stmt) = parsed_query {
-                        let formatter = ogsql_parser::SqlFormatter::new();
-                        let formatted = formatter.format_statement(stmt);
-                        let sql = replace_pl_vars_in_sql(&formatted, vars);
+                    if is_out {
+                        let sql = if let Some(ref stmt) = parsed_query {
+                            let formatter = ogsql_parser::SqlFormatter::new();
+                            let formatted = formatter.format_statement(stmt);
+                            replace_pl_vars_in_sql(&formatted, vars)
+                        } else {
+                            replace_pl_vars_in_sql(query.trim(), vars)
+                        };
                         rows.push(ParseCsvRow {
                             line,
-                            stmt_type: "Embedded/Select".into(),
-                            name: String::new(),
+                            stmt_type: "ReturnCursorSQL".into(),
+                            name: cursor_name,
                             parent: parent_name.to_string(),
                             parameters: String::new(),
-                            return_type: String::new(),
+                            return_type: "REFCURSOR".into(),
                             sql,
+                            branch_path: branch_path.to_string(),
+                            branch_condition: branch_condition.to_string(),
                         });
                     } else {
-                        let (embedded_type, sql) = resolve_for_query_text(query, vars, assigns);
                         rows.push(ParseCsvRow {
                             line,
-                            stmt_type: embedded_type,
-                            name: String::new(),
+                            stmt_type: "Open/ForQuery".into(),
+                            name: cursor_name,
                             parent: parent_name.to_string(),
                             parameters: String::new(),
                             return_type: String::new(),
-                            sql,
+                            sql: String::new(),
+                            branch_path: branch_path.to_string(),
+                            branch_condition: branch_condition.to_string(),
                         });
+                        if let Some(ref stmt) = parsed_query {
+                            let formatter = ogsql_parser::SqlFormatter::new();
+                            let formatted = formatter.format_statement(stmt);
+                            let sql = replace_pl_vars_in_sql(&formatted, vars);
+                            rows.push(ParseCsvRow {
+                                line,
+                                stmt_type: "Embedded/Select".into(),
+                                name: String::new(),
+                                parent: parent_name.to_string(),
+                                parameters: String::new(),
+                                return_type: String::new(),
+                                sql,
+                                branch_path: branch_path.to_string(),
+                                branch_condition: branch_condition.to_string(),
+                            });
+                        } else {
+                            let (embedded_type, sql) = resolve_for_query_text(query, vars, assigns);
+                            rows.push(ParseCsvRow {
+                                line,
+                                stmt_type: embedded_type,
+                                name: String::new(),
+                                parent: parent_name.to_string(),
+                                parameters: String::new(),
+                                return_type: String::new(),
+                                sql,
+                                branch_path: branch_path.to_string(),
+                                branch_condition: branch_condition.to_string(),
+                            });
+                        }
                     }
                 }
                 ogsql_parser::ast::plpgsql::PlOpenKind::ForExecute { query, using_args } => {
-                    rows.push(ParseCsvRow {
-                        line,
-                        stmt_type: "Open/ForExecute".into(),
-                        name: cursor_name,
-                        parent: parent_name.to_string(),
-                        parameters: String::new(),
-                        return_type: String::new(),
-                        sql: String::new(),
-                    });
                     let dynamic_sql = build_dynamic_sql_from_expr(query, vars, assigns);
                     let using_suffix = format_using_args_exprs(using_args);
                     let full_sql = if using_suffix.is_empty() {
@@ -1543,15 +1704,42 @@ fn collect_pl_stmt_rows(
                     } else {
                         format!("{}\nUSING {}", dynamic_sql, using_suffix)
                     };
-                    rows.push(ParseCsvRow {
-                        line,
-                        stmt_type: "Embedded/Execute".into(),
-                        name: String::new(),
-                        parent: parent_name.to_string(),
-                        parameters: String::new(),
-                        return_type: String::new(),
-                        sql: full_sql,
-                    });
+                    if is_out {
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: "ReturnCursorSQL".into(),
+                            name: cursor_name,
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: "REFCURSOR".into(),
+                            sql: full_sql,
+                            branch_path: branch_path.to_string(),
+                            branch_condition: branch_condition.to_string(),
+                        });
+                    } else {
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: "Open/ForExecute".into(),
+                            name: cursor_name,
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: String::new(),
+                            sql: String::new(),
+                            branch_path: branch_path.to_string(),
+                            branch_condition: branch_condition.to_string(),
+                        });
+                        rows.push(ParseCsvRow {
+                            line,
+                            stmt_type: "Embedded/Execute".into(),
+                            name: String::new(),
+                            parent: parent_name.to_string(),
+                            parameters: String::new(),
+                            return_type: String::new(),
+                            sql: full_sql,
+                            branch_path: branch_path.to_string(),
+                            branch_condition: branch_condition.to_string(),
+                        });
+                    }
                 }
                 ogsql_parser::ast::plpgsql::PlOpenKind::ForUsing { expressions } => {
                     rows.push(ParseCsvRow {
@@ -1562,6 +1750,8 @@ fn collect_pl_stmt_rows(
                         parameters: String::new(),
                         return_type: String::new(),
                         sql: String::new(),
+                        branch_path: branch_path.to_string(),
+                        branch_condition: branch_condition.to_string(),
                     });
                     let exprs: Vec<String> = expressions.iter().map(|e| format_pl_expr(e)).collect();
                     rows.push(ParseCsvRow {
@@ -1572,6 +1762,8 @@ fn collect_pl_stmt_rows(
                         parameters: String::new(),
                         return_type: String::new(),
                         sql: exprs.join(", "),
+                        branch_path: branch_path.to_string(),
+                        branch_condition: branch_condition.to_string(),
                     });
                 }
                 ogsql_parser::ast::plpgsql::PlOpenKind::Simple { arguments } => {
@@ -1584,6 +1776,8 @@ fn collect_pl_stmt_rows(
                         parameters: args_str.join(", "),
                         return_type: String::new(),
                         sql: String::new(),
+                        branch_path: branch_path.to_string(),
+                        branch_condition: branch_condition.to_string(),
                     });
                 }
             }
@@ -1606,6 +1800,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: String::new(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
             for item in &s.items {
                 match item {
@@ -1618,14 +1814,19 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                             parameters: format_params(&p.parameters),
                             return_type: String::new(),
                             sql: String::new(),
+                            branch_path: String::new(),
+                            branch_condition: String::new(),
                         });
                         if let Some(ref block) = p.block {
                             let vars = if mybatis { collect_block_vars(block, &p.parameters) } else { std::collections::HashMap::new() };
+                            let out_cursors = extract_out_cursor_set(&p.parameters);
                             rows.extend(collect_block_sql_rows(
                                 block,
                                 &p.name.join("."),
                                 p.start_line.max(si.start_line),
                                 &vars,
+                                &out_cursors,
+                                false,
                             ));
                         }
                     }
@@ -1638,14 +1839,20 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                             parameters: format_params(&f.parameters),
                             return_type: f.return_type.clone().unwrap_or_default(),
                             sql: String::new(),
+                            branch_path: String::new(),
+                            branch_condition: String::new(),
                         });
                         if let Some(ref block) = f.block {
                             let vars = if mybatis { collect_block_vars(block, &f.parameters) } else { std::collections::HashMap::new() };
+                            let out_cursors = extract_out_cursor_set(&f.parameters);
+                            let is_return_cursor = f.return_type.as_ref().map_or(false, |rt| rt.to_uppercase().contains("REFCURSOR"));
                             rows.extend(collect_block_sql_rows(
                                 block,
                                 &f.name.join("."),
                                 f.start_line.max(si.start_line),
                                 &vars,
+                                &out_cursors,
+                                is_return_cursor,
                             ));
                         }
                     }
@@ -1662,6 +1869,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: String::new(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
             for item in &s.items {
                 match item {
@@ -1674,6 +1883,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                             parameters: format_params(&p.parameters),
                             return_type: String::new(),
                             sql: String::new(),
+                            branch_path: String::new(),
+                            branch_condition: String::new(),
                         });
                     }
                     ogsql_parser::ast::PackageItem::Function(f) => {
@@ -1685,6 +1896,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                             parameters: format_params(&f.parameters),
                             return_type: f.return_type.clone().unwrap_or_default(),
                             sql: String::new(),
+                            branch_path: String::new(),
+                            branch_condition: String::new(),
                         });
                     }
                     _ => {}
@@ -1701,10 +1914,13 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: format_params(&s.parameters),
                 return_type: String::new(),
                 sql: String::new(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
             if let Some(ref block) = s.block {
                 let vars = if mybatis { collect_block_vars(block, &s.parameters) } else { std::collections::HashMap::new() };
-                rows.extend(collect_block_sql_rows(block, &proc_name, si.start_line, &vars));
+                let out_cursors = extract_out_cursor_set(&s.parameters);
+                rows.extend(collect_block_sql_rows(block, &proc_name, si.start_line, &vars, &out_cursors, false));
             }
         }
         Statement::CreateFunction(s) => {
@@ -1717,10 +1933,14 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: format_params(&s.parameters),
                 return_type: s.return_type.clone().unwrap_or_default(),
                 sql: String::new(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
             if let Some(ref block) = s.block {
                 let vars = if mybatis { collect_block_vars(block, &s.parameters) } else { std::collections::HashMap::new() };
-                rows.extend(collect_block_sql_rows(block, &func_name, si.start_line, &vars));
+                let out_cursors = extract_out_cursor_set(&s.parameters);
+                let is_return_cursor = s.return_type.as_ref().map_or(false, |rt| rt.to_uppercase().contains("REFCURSOR"));
+                rows.extend(collect_block_sql_rows(block, &func_name, si.start_line, &vars, &out_cursors, is_return_cursor));
             }
         }
         Statement::Do(s) => {
@@ -1732,10 +1952,13 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: String::new(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
             if let Some(ref block) = s.block {
                 let vars = if mybatis { collect_block_vars(block, &[]) } else { std::collections::HashMap::new() };
-                rows.extend(collect_block_sql_rows(block, "", si.start_line, &vars));
+                let out_cursors = std::collections::HashSet::new();
+                rows.extend(collect_block_sql_rows(block, "", si.start_line, &vars, &out_cursors, false));
             }
         }
         Statement::AnonyBlock(s) => {
@@ -1747,9 +1970,12 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: String::new(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
             let vars = if mybatis { collect_block_vars(&s.block, &[]) } else { std::collections::HashMap::new() };
-            rows.extend(collect_block_sql_rows(&s.block, "", si.start_line, &vars));
+            let out_cursors = std::collections::HashSet::new();
+            rows.extend(collect_block_sql_rows(&s.block, "", si.start_line, &vars, &out_cursors, false));
         }
         Statement::Select(s) => {
             rows.push(ParseCsvRow {
@@ -1766,6 +1992,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
         Statement::Insert(s) => {
@@ -1777,6 +2005,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
         Statement::Update(s) => {
@@ -1794,6 +2024,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
         Statement::Delete(s) => {
@@ -1811,6 +2043,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
         Statement::Merge(s) => {
@@ -1825,6 +2059,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
         Statement::CreateTable(s) => {
@@ -1836,6 +2072,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
         _ => {
@@ -1857,6 +2095,8 @@ fn flatten_statement(si: &ogsql_parser::StatementInfo, mybatis: bool) -> Vec<Par
                 parameters: String::new(),
                 return_type: String::new(),
                 sql: si.sql_text.clone(),
+                branch_path: String::new(),
+                branch_condition: String::new(),
             });
         }
     }
@@ -1892,7 +2132,7 @@ fn output_csv_parse_rows(
 
             let sql = row.sql.trim().replace('\n', "\\n").replace('\r', "");
             println!(
-                "{},{},{},{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{},{},{},{},{}",
                 csv_escape(file_name),
                 csv_escape(rel_dir),
                 row.line,
@@ -1904,6 +2144,8 @@ fn output_csv_parse_rows(
                 csv_escape(&sql),
                 csv_escape(&row_err),
                 csv_escape(&row_warn),
+                csv_escape(&row.branch_path),
+                csv_escape(&row.branch_condition),
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@ pub mod parser;
 pub mod token;
 pub mod token_formatter;
 
+pub use analyzer::return_cursor::{
+    ReturnCursorAnnotation, RoutineReturnAnalysis, ReturnCursorGroup,
+    ReturnCursorBranch, ResultColumn, analyze_return_cursors, has_return_cursors,
+};
 pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_package_consistency, DynamicSqlReport, PackageConsistencyError, PackageConsistencyErrorKind, QueryFingerprint, TransactionReport};
 pub use analyzer::schema::{SchemaMap, SchemaResolutionReport, load_schema, resolve_schema};
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -114,8 +114,23 @@ impl OgsqlServer {
             .collect();
         let fingerprints = crate::compute_query_fingerprints(&all_stmts);
 
+        let stmt_values: Vec<serde_json::Value> = output
+            .statements
+            .iter()
+            .map(|si| {
+                let mut obj = serde_json::to_value(si).unwrap();
+                if let Some(analysis) = compute_routine_analysis(&si.statement) {
+                    obj.as_object_mut().unwrap().insert(
+                        "routine_analysis".to_string(),
+                        analysis,
+                    );
+                }
+                obj
+            })
+            .collect();
+
         let mut out = serde_json::json!({
-            "statements": output.statements,
+            "statements": stmt_values,
             "errors": output.errors,
         });
         if !fingerprints.is_empty() {
@@ -385,4 +400,59 @@ fn is_warning(e: &crate::ParserError) -> bool {
         crate::ParserError::Warning { .. }
             | crate::ParserError::ReservedKeywordAsIdentifier { .. }
     )
+}
+
+fn compute_routine_analysis(stmt: &crate::Statement) -> Option<serde_json::Value> {
+    use crate::ast::PackageItem;
+    match stmt {
+        crate::Statement::CreateProcedure(p) => {
+            let block = p.block.as_ref()?;
+            let analysis = crate::analyze_return_cursors(
+                block, &p.parameters, &p.name.join("."), "Procedure", None,
+            );
+            if analysis.return_cursors.is_empty() { return None; }
+            Some(serde_json::json!(analysis))
+        }
+        crate::Statement::CreateFunction(f) => {
+            let block = f.block.as_ref()?;
+            let analysis = crate::analyze_return_cursors(
+                block, &f.parameters, &f.name.join("."), "Function",
+                f.return_type.as_deref(),
+            );
+            if analysis.return_cursors.is_empty() { return None; }
+            Some(serde_json::json!(analysis))
+        }
+        crate::Statement::CreatePackageBody(pkg) => {
+            let mut analyses = Vec::new();
+            for item in &pkg.items {
+                match item {
+                    PackageItem::Procedure(p) => {
+                        if let Some(ref block) = p.block {
+                            let analysis = crate::analyze_return_cursors(
+                                block, &p.parameters, &p.name.join("."),
+                                "Procedure", None,
+                            );
+                            if !analysis.return_cursors.is_empty() {
+                                analyses.push(analysis);
+                            }
+                        }
+                    }
+                    PackageItem::Function(f) => {
+                        if let Some(ref block) = f.block {
+                            let analysis = crate::analyze_return_cursors(
+                                block, &f.parameters, &f.name.join("."),
+                                "Function", f.return_type.as_deref(),
+                            );
+                            if !analysis.return_cursors.is_empty() {
+                                analyses.push(analysis);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if analyses.is_empty() { None } else { Some(serde_json::json!(analyses)) }
+        }
+        _ => None,
+    }
 }


### PR DESCRIPTION
## Summary

- Add return cursor SQL annotation that identifies and marks SQL statements returned to callers via OUT REFCURSOR parameters or function RETURNS REFCURSOR
- New analyzer module `src/analyzer/return_cursor.rs` with branch-aware PL/pgSQL traversal tracking IF/ELSIF/ELSE, CASE, LOOP, WHILE, FOR paths
- CSV output: new `ReturnCursorSQL` row type with `branch_path` and `branch_condition` columns
- JSON output: `routine_analysis` section injected with structured metadata (out_param, position, jdbc_type, result_columns, branch details)
- MCP server: `routine_analysis` injection in parse tool output

## Test plan

- [x] 8 new unit tests in `return_cursor.rs` covering static OPEN FOR, conditional branches, IN cursor exclusion, function returns, dynamic EXECUTE, result column extraction
- [x] All 1312 existing tests pass (1161 lib + MCP tests)
- [x] Integration test with full package body (4 procedures/functions, conditional branches, dynamic SQL)
- [x] CSV output verified with `--csv` flag
- [x] JSON output verified with `-j` flag
- [x] MCP binary builds successfully with `--features mcp`