### PR TITLE
fix(validate): add SQLERRM and SQLCODE to PL built-in values

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1452,6 +1452,8 @@ const PL_BUILTIN_VALUES: &[&str] = &[
     "FOUND",
     "NOT_FOUND",
     "ROW_COUNT",
+    "SQLCODE",
+    "SQLERRM",
 ];
 
 fn is_pl_builtin(name: &str) -> bool {


### PR DESCRIPTION
## Summary
- Add `SQLERRM` and `SQLCODE` to `PL_BUILTIN_VALUES` in the analyzer undefined variable validator
- These are standard PL/SQL exception variables available in EXCEPTION WHEN OTHERS handlers

## Problem
The validator incorrectly reported `SQLERRM` as an undefined variable in assignment expressions like `p_out_msg := msg || SQLERRM`, producing false-positive warnings.

## Fix
Added `"SQLCODE"` and `"SQLERRM"` to the `PL_BUILTIN_VALUES` constant in `src/analyzer/mod.rs`.

## Verification
```
$ ogsql validate -f GaussDB-2.23.07.210/sql/errsp1.sql
VALID
```
Previously showed 2 warnings, now clean.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)