### PR TITLE
fix(validate): resolve false positives for SQL cursor attributes and package-level variables

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1454,6 +1454,7 @@ const PL_BUILTIN_VALUES: &[&str] = &[
     "ROW_COUNT",
     "SQLCODE",
     "SQLERRM",
+    "SQLSTATE",
 ];
 
 fn is_pl_builtin(name: &str) -> bool {
@@ -1476,9 +1477,20 @@ pub fn validate_pl_variables(
     block: &PlBlock,
     params: &[crate::ast::RoutineParam],
 ) -> Vec<UndefinedVariableError> {
+    validate_pl_variables_with_extra_vars(block, params, &[])
+}
+
+pub fn validate_pl_variables_with_extra_vars(
+    block: &PlBlock,
+    params: &[crate::ast::RoutineParam],
+    extra_vars: &[&str],
+) -> Vec<UndefinedVariableError> {
     let mut validator = PlVariableValidator::new();
     for p in params {
         validator.declare(&p.name);
+    }
+    for v in extra_vars {
+        validator.declare(v);
     }
     validator.process_block(block);
     validator.errors
@@ -1887,6 +1899,11 @@ impl PlVariableValidator {
                 self.check_expr(inner, context);
             }
             Expr::CursorAttribute { cursor, .. } => {
+                if let Expr::ColumnRef(names) | Expr::PlVariable(names) = cursor.as_ref() {
+                    if names.len() == 1 && names[0].eq_ignore_ascii_case("SQL") {
+                        return;
+                    }
+                }
                 self.check_expr(cursor, context);
             }
             Expr::XmlElement { evalname, content, .. } => {

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -2691,17 +2691,23 @@ fn validate_pl_variables_from_stmts(stmts: &[ogsql_parser::StatementInfo]) -> Ve
                 }
             }
             Statement::CreatePackageBody(body) => {
+                let pkg_vars: Vec<&str> = body.items.iter()
+                    .filter_map(|item| match item {
+                        ogsql_parser::ast::PackageItem::Variable(v) => Some(v.name.as_str()),
+                        _ => None,
+                    })
+                    .collect();
                 for item in &body.items {
                     match item {
                         ogsql_parser::ast::PackageItem::Procedure(proc) => {
                             if let Some(ref block) = proc.block {
-                                let vars = ogsql_parser::validate_pl_variables(block, &proc.parameters);
+                                let vars = ogsql_parser::validate_pl_variables_with_extra_vars(block, &proc.parameters, &pkg_vars);
                                 warnings.extend(vars);
                             }
                         }
                         ogsql_parser::ast::PackageItem::Function(func) => {
                             if let Some(ref block) = func.block {
-                                let vars = ogsql_parser::validate_pl_variables(block, &func.parameters);
+                                let vars = ogsql_parser::validate_pl_variables_with_extra_vars(block, &func.parameters, &pkg_vars);
                                 warnings.extend(vars);
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use analyzer::return_cursor::{
     ReturnCursorAnnotation, RoutineReturnAnalysis, ReturnCursorGroup,
     ReturnCursorBranch, ResultColumn, analyze_return_cursors, has_return_cursors,
 };
-pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_package_consistency, validate_pl_variables, DynamicSqlReport, PackageConsistencyError, PackageConsistencyErrorKind, QueryFingerprint, TransactionReport, UndefinedVariableError};
+pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars, DynamicSqlReport, PackageConsistencyError, PackageConsistencyErrorKind, QueryFingerprint, TransactionReport, UndefinedVariableError};
 pub use analyzer::schema::{SchemaMap, SchemaResolutionReport, load_schema, resolve_schema};
 
 pub use ast::visitor::{


### PR DESCRIPTION
## Summary
- Fix `SQL%FOUND`/`SQL%NOTFOUND`/`SQL%ROWCOUNT`/`SQL%ISOPEN` incorrectly flagged as undefined variables — SQL is the implicit cursor and should not be checked
- Add `SQLSTATE` to `PL_BUILTIN_VALUES` (GaussDB-compatible alias for `SQLCODE`)
- Fix package-level variables (e.g. `v_max_amount` declared in `PACKAGE BODY`) not visible to child procedures/functions — new `validate_pl_variables_with_extra_vars()` API collects `PackageItem::Variable` names and passes them into scope

## Test
```
SQL%FOUND / SQL%NOTFOUND / SQL%ROWCOUNT / SQL%ISOPEN → VALID (was INVALID)
SQLSTATE → VALID (was undefined variable)
pkg_package_vars_test.sql → all 4 rows VALID (was 2 INVALID for v_max_amount, v_threshold)
```