### PR TITLE
fix: resolve parser false positives and add GaussDB syntax support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1455,6 +1455,10 @@ const PL_BUILTIN_VALUES: &[&str] = &[
     "SQLCODE",
     "SQLERRM",
     "SQLSTATE",
+    "YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND",
+    "EPOCH", "DOW", "DOY", "ISODOW", "ISOYEAR", "QUARTER", "WEEK",
+    "CENTURY", "DECADE", "MILLISECONDS", "MICROSECONDS",
+    "TIMEZONE", "TIMEZONE_HOUR", "TIMEZONE_MINUTE",
 ];
 
 fn is_pl_builtin(name: &str) -> bool {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1600,6 +1600,9 @@ pub struct DeleteStatement {
     pub tables: Vec<TableRef>,
     pub using: Vec<TableRef>,
     pub where_clause: Option<Expr>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub limit: Option<Expr>,
     pub returning: Vec<SelectTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -2691,12 +2691,26 @@ fn validate_pl_variables_from_stmts(stmts: &[ogsql_parser::StatementInfo]) -> Ve
                 }
             }
             Statement::CreatePackageBody(body) => {
-                let pkg_vars: Vec<&str> = body.items.iter()
+                let body_name: String = body.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
+                let mut pkg_vars: Vec<&str> = body.items.iter()
                     .filter_map(|item| match item {
                         ogsql_parser::ast::PackageItem::Variable(v) => Some(v.name.as_str()),
                         _ => None,
                     })
                     .collect();
+                // Also collect variables/constants from the matching package spec
+                for other_si in stmts {
+                    if let Statement::CreatePackage(spec) = &other_si.statement {
+                        let spec_name: String = spec.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
+                        if spec_name == body_name {
+                            for item in &spec.items {
+                                if let ogsql_parser::ast::PackageItem::Variable(v) = item {
+                                    pkg_vars.push(v.name.as_str());
+                                }
+                            }
+                        }
+                    }
+                }
                 for item in &body.items {
                     match item {
                         ogsql_parser::ast::PackageItem::Procedure(proc) => {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1887,6 +1887,10 @@ impl SqlFormatter {
             ));
         }
 
+        if let Some(limit) = &stmt.limit {
+            parts.push(format!("{} {}", self.kw("LIMIT"), self.format_expr(limit)));
+        }
+
         if !stmt.returning.is_empty() {
             parts.push(format!(
                 "{} {}",

--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -441,6 +441,17 @@ impl Parser {
         } else {
             None
         };
+        let limit = if self.match_keyword(Keyword::LIMIT) {
+            self.advance();
+            if self.match_keyword(Keyword::ALL) {
+                self.advance();
+                None
+            } else {
+                Some(self.parse_expr()?)
+            }
+        } else {
+            None
+        };
         let (returning, into_targets, bulk_collect) = if self.match_keyword(Keyword::RETURNING) {
             self.advance();
             let returning = self.parse_target_list()?;
@@ -469,6 +480,7 @@ impl Parser {
             tables,
             using,
             where_clause,
+            limit,
             returning,
             into_targets,
             bulk_collect,

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1364,6 +1364,10 @@ impl Parser {
             self.advance();
             let value = self.parse_expr()?;
             Ok((value, has_variadic))
+        } else if self.match_keyword(Keyword::VALUE_P) {
+            self.advance();
+            let value = self.parse_expr()?;
+            Ok((value, has_variadic))
         } else {
             Ok((first, has_variadic))
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -375,12 +375,19 @@ impl Parser {
                     case_depth += 1;
                 }
                 Token::Keyword(Keyword::BEGIN_P) => {
-                    begin_depth += 1;
-                    if in_routine_decl && begin_depth == 1 {
-                        in_routine_decl = false;
-                    }
-                    if in_declare_section && begin_depth == 1 {
-                        in_declare_section = false;
+                    // At top level (depth=0, begin_depth=0, subprog_depth=0), BEGIN is
+                    // transactional unless we're inside a routine declaration or declare section.
+                    // Inside a package subprogram or already-nested block, BEGIN is a PL block.
+                    let is_pl_block_begin = begin_depth > 0 || depth > 0 || subprog_depth > 0
+                        || in_routine_decl || in_declare_section;
+                    if is_pl_block_begin {
+                        begin_depth += 1;
+                        if in_routine_decl && begin_depth == 1 {
+                            in_routine_decl = false;
+                        }
+                        if in_declare_section && begin_depth == 1 {
+                            in_declare_section = false;
+                        }
                     }
                 }
                 Token::Keyword(Keyword::END_P) => {

--- a/src/parser/utility/functions.rs
+++ b/src/parser/utility/functions.rs
@@ -85,6 +85,36 @@ impl Parser {
     }
 
     fn parse_function_parameter(&mut self) -> Result<RoutineParam, ParserError> {
+        // Try mode-first syntax: OUT result INT, IN name VARCHAR2, INOUT val INT, IN OUT val INT
+        let saved_pos = self.pos;
+        let saved_error_count = self.errors.len();
+        if let Some(mode) = self.parse_param_mode() {
+            // Mode-first: MODE name type [DEFAULT expr]
+            // Check that the next token looks like an identifier/name (not a comma/paren/EOF)
+            match self.peek() {
+                Token::Ident(_) | Token::QuotedIdent(_) | Token::Keyword(_) => {
+                    let name = self.parse_identifier()?;
+                    let data_type = self.parse_param_data_type()?;
+                    let default_value = self.parse_param_default()?;
+                    return Ok(RoutineParam {
+                        name,
+                        mode: Some(mode),
+                        data_type,
+                        default_value,
+                    });
+                }
+                _ => {
+                    // Not a name after mode keyword — restore and try name-first
+                    self.pos = saved_pos;
+                    self.errors.truncate(saved_error_count);
+                }
+            }
+        } else {
+            // No mode found — restore position for name-first attempt
+            self.pos = saved_pos;
+        }
+
+        // Name-first syntax: name [MODE] type [DEFAULT expr]
         let name = self.parse_identifier()?;
         let mode = self.parse_param_mode();
         let data_type = self.parse_param_data_type()?;


### PR DESCRIPTION
## Summary

- **DELETE ... LIMIT**: Add LIMIT clause support for DELETE statements (GaussDB/openGauss syntax)
- **Mode-first parameters**: Support `OUT result INT` parameter syntax in function/procedure definitions
- **json_object VALUE**: Accept `VALUE` keyword as named argument separator in `json_object()`
- **BEGIN disambiguation**: Correctly distinguish transactional BEGIN from PL block BEGIN inside package subprograms
- **EXTRACT fields**: Add EXTRACT datetime fields (YEAR, MONTH, DAY, etc.) to PL_BUILTIN_VALUES
- **Package spec variables**: Collect variables from matching package spec when validating package body procedures
- **Version bump**: 0.4.6 → 0.4.7

## Test plan

- [x] All 1174 unit tests pass (`cargo test --lib`)
- [x] Build clean (`cargo build --features full --bin ogsql`)
- [x] Validated against GaussDB SQL files — false positives resolved