### PR TITLE
fix: cursor attribute % priority and TRIM direction keyword false positives

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1459,6 +1459,7 @@ const PL_BUILTIN_VALUES: &[&str] = &[
     "EPOCH", "DOW", "DOY", "ISODOW", "ISOYEAR", "QUARTER", "WEEK",
     "CENTURY", "DECADE", "MILLISECONDS", "MICROSECONDS",
     "TIMEZONE", "TIMEZONE_HOUR", "TIMEZONE_MINUTE",
+    "BOTH", "LEADING", "TRAILING",
 ];
 
 fn is_pl_builtin(name: &str) -> bool {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -81,16 +81,6 @@ impl Parser {
                 continue;
             }
 
-            if op_str == "%" && !self.scope_stack.is_empty() {
-                if let Some(attr) = self.try_parse_cursor_attribute() {
-                    left = Expr::CursorAttribute {
-                        cursor: Box::new(left),
-                        attribute: attr,
-                    };
-                    continue;
-                }
-            }
-
             if matches!(op_str.as_str(), "=" | "<" | ">" | "<=" | ">=" | "<>" | "!=")
                 && matches!(
                     self.peek(),
@@ -637,6 +627,20 @@ impl Parser {
                         };
                     }
                     return Ok(true);
+                }
+                Ok(false)
+            }
+            Token::Percent => {
+                if !self.scope_stack.is_empty() {
+                    self.advance();
+                    if let Some(attr) = self.try_parse_cursor_attribute() {
+                        *left = Expr::CursorAttribute {
+                            cursor: Box::new(std::mem::replace(left, Expr::Default)),
+                            attribute: attr,
+                        };
+                        return Ok(true);
+                    }
+                    self.pos -= 1;
                 }
                 Ok(false)
             }


### PR DESCRIPTION
## Summary

- **Cursor attribute `%` priority**: `SQL%ROWCOUNT` in expressions like `'a' || SQL%ROWCOUNT` was incorrectly parsed as `('a' || SQL) % ROWCOUNT` because `%` was an infix operator (precedence 50) equal to `||`. Move `%` cursor attribute handling to the postfix stage so it binds tighter than any infix operator.
- **TRIM direction keywords**: Add `BOTH`, `LEADING`, `TRAILING` to `PL_BUILTIN_VALUES` so `trim(BOTH 'x' FROM expr)` no longer reports `undefined variable 'both'` in package body procedures.

## Test plan

- [x] All 1174 unit tests pass (`cargo test --lib`)
- [x] Build clean (`cargo build --features full --bin ogsql`)
- [x] `gauss_update_select.sql` validates with 0 INVALID (was 12)
- [x] `SQL%ROWCOUNT` in anonymous blocks and package bodies both parse correctly