### PR TITLE
feat(parser): support INSERT INTO ... VALUES record_variable for %ROWTYPE

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1538,6 +1538,9 @@ pub enum InsertSource {
     Select(Box<SelectStatement>),
     DefaultValues,
     Set(Vec<UpdateAssignment>),
+    /// INSERT INTO t VALUES record_variable — GaussDB/openGauss Oracle-compatible
+    /// syntax where a %ROWTYPE or RECORD variable is used without parentheses.
+    RecordVariable(Expr),
 }
 
 // INSERT ALL / INSERT FIRST multi-table insert types

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -751,6 +751,11 @@ fn walk_insert(visitor: &mut dyn Visitor, insert: &InsertStatement) -> VisitorRe
             }
         }
         InsertSource::DefaultValues => {}
+        InsertSource::RecordVariable(expr) => {
+            if walk_expr(visitor, expr) == VisitorResult::Stop {
+                return VisitorResult::Stop;
+            }
+        }
         InsertSource::Set(assignments) => {
             for a in assignments {
                 if walk_expr(visitor, &a.value) == VisitorResult::Stop {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1650,6 +1650,9 @@ impl SqlFormatter {
             InsertSource::DefaultValues => {
                 parts.push(self.kw("DEFAULT VALUES"));
             }
+            InsertSource::RecordVariable(expr) => {
+                parts.push(format!("{} {}", self.kw("VALUES"), self.format_expr(expr)));
+            }
             InsertSource::Set(assignments) => {
                 parts.push(self.kw("SET"));
                 let assign_strs: Vec<String> = assignments

--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -86,25 +86,30 @@ impl Parser {
             InsertSource::Set(assignments)
         } else if self.match_keyword(Keyword::VALUES) {
             self.advance();
-            let mut rows = Vec::new();
-            loop {
-                self.expect_token(&Token::LParen)?;
-                let mut row = Vec::new();
-                if !self.match_token(&Token::RParen) {
-                    row.push(self.parse_expr()?);
-                    while self.match_token(&Token::Comma) {
-                        self.advance();
-                        row.push(self.parse_expr()?);
-                    }
-                }
-                self.expect_token(&Token::RParen)?;
-                rows.push(row);
-                if !self.match_token(&Token::Comma) {
-                    break;
-                }
+            if self.match_token(&Token::LParen) {
                 self.advance();
+                let mut rows = Vec::new();
+                loop {
+                    let mut row = Vec::new();
+                    if !self.match_token(&Token::RParen) {
+                        row.push(self.parse_expr()?);
+                        while self.match_token(&Token::Comma) {
+                            self.advance();
+                            row.push(self.parse_expr()?);
+                        }
+                    }
+                    self.expect_token(&Token::RParen)?;
+                    rows.push(row);
+                    if !self.match_token(&Token::Comma) {
+                        break;
+                    }
+                    self.advance();
+                    self.expect_token(&Token::LParen)?;
+                }
+                InsertSource::Values(rows)
+            } else {
+                InsertSource::RecordVariable(self.parse_expr()?)
             }
-            InsertSource::Values(rows)
         } else if self.match_keyword(Keyword::SELECT) || self.match_keyword(Keyword::WITH) {
             InsertSource::Select(Box::new(self.parse_select_statement()?))
         } else if self.match_token(&Token::LParen) {

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -786,7 +786,7 @@ impl Parser {
                 self.add_error(ParserError::UnexpectedToken {
                     location: err_loc,
                     expected: "valid DML statement".to_string(),
-                    got: "unparseable DML (dynamic table name requires EXECUTE IMMEDIATE)".to_string(),
+                    got: "unparseable DML".to_string(),
                 });
                 if sql.is_empty() {
                     Ok(PlStatement::Null)
@@ -1593,7 +1593,7 @@ impl Parser {
                                 self.add_error(ParserError::UnexpectedToken {
                                     location: err_loc,
                                     expected: "valid query in FOR-IN-SELECT".to_string(),
-                                    got: "unparseable query (dynamic table name requires EXECUTE IMMEDIATE)".to_string(),
+                                    got: "unparseable query".to_string(),
                                 });
                                 return Ok(PlForKind::Query {
                                     query: raw,


### PR DESCRIPTION
## Summary

- Add `InsertSource::RecordVariable(Expr)` variant to support GaussDB/openGauss Oracle-compatible syntax `INSERT INTO table VALUES record_variable` where the variable is a `%ROWTYPE` or `RECORD` type used without parentheses
- Remove misleading "dynamic table name requires EXECUTE IMMEDIATE" hardcoded hint from DML parse error messages

## Root Cause

The parser VALUES clause handler unconditionally expected `(` after `VALUES`, but GaussDB supports `INSERT INTO t VALUES v_row` (no parens) for ROWTYPE/RECORD variables. The parse failure was then masked by an inaccurate error message.

## Changes

| File | Change |
|------|--------|
| `src/ast/mod.rs` | Add `RecordVariable(Expr)` to `InsertSource` enum |
| `src/parser/dml.rs` | Peek for `(` after VALUES - if absent, parse as record variable |
| `src/formatter.rs` | Format `InsertSource::RecordVariable` as `VALUES expr` |
| `src/ast/visitor.rs` | Walk expr inside `RecordVariable` variant |
| `src/parser/plpgsql.rs` | Simplify DML parse error messages (2 locations) |

## Verification

- `gauss_insert_all_styles.sql`: all procedures now VALID (was 3 INVALID -> 0)
- 1174 unit tests: all passing
- Zero regressions on existing INSERT VALUES / INSERT SELECT patterns