### PR TITLE
fix(parser): resolve REFERENCES ON DELETE CASCADE, DELETE USING/FROM, and TYPE IS TABLE OF false positives

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -230,7 +230,12 @@ pub enum ColumnConstraint {
     Unique,
     PrimaryKey,
     Check(Expr),
-    References(ObjectName, Vec<String>),
+    References {
+        ref_table: ObjectName,
+        ref_columns: Vec<String>,
+        on_delete: Option<ReferentialAction>,
+        on_update: Option<ReferentialAction>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -2563,14 +2563,37 @@ impl SqlFormatter {
             ColumnConstraint::Check(expr) => {
                 format!("{} ({})", self.kw("CHECK"), self.format_expr(expr))
             }
-            ColumnConstraint::References(table, cols) => {
+            ColumnConstraint::References {
+                ref_table,
+                ref_columns,
+                on_delete,
+                on_update,
+            } => {
                 let mut result = format!(
                     "{} {}",
                     self.kw("REFERENCES"),
-                    self.format_object_name(table)
+                    self.format_object_name(ref_table)
                 );
-                if !cols.is_empty() {
-                    result = format!("{} ({})", result, cols.join(", "));
+                if !ref_columns.is_empty() {
+                    result = format!("{} ({})", result, ref_columns.join(", "));
+                }
+                if let Some(action) = on_delete {
+                    result = format!(
+                        "{} {} {}",
+                        result,
+                        self.kw("ON"),
+                        self.kw("DELETE")
+                    );
+                    result = format!("{} {}", result, self.format_referential_action(action));
+                }
+                if let Some(action) = on_update {
+                    result = format!(
+                        "{} {} {}",
+                        result,
+                        self.kw("ON"),
+                        self.kw("UPDATE")
+                    );
+                    result = format!("{} {}", result, self.format_referential_action(action));
                 }
                 result
             }

--- a/src/parser/ddl/table.rs
+++ b/src/parser/ddl/table.rs
@@ -1470,8 +1470,8 @@ impl Parser {
             }
             Some(Keyword::REFERENCES) => {
                 self.advance();
-                let table = self.parse_object_name()?;
-                let columns = if self.match_token(&Token::LParen) {
+                let ref_table = self.parse_object_name()?;
+                let ref_columns = if self.match_token(&Token::LParen) {
                     self.advance();
                     let mut cols = vec![self.parse_identifier()?];
                     while self.match_token(&Token::Comma) {
@@ -1483,7 +1483,14 @@ impl Parser {
                 } else {
                     Vec::new()
                 };
-                Some(ColumnConstraint::References(table, columns))
+                let on_delete = self.parse_referential_action(Keyword::DELETE_P)?;
+                let on_update = self.parse_referential_action(Keyword::UPDATE)?;
+                Some(ColumnConstraint::References {
+                    ref_table,
+                    ref_columns,
+                    on_delete,
+                    on_update,
+                })
             }
             _ => None,
         };

--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -448,11 +448,28 @@ impl Parser {
             }
         }
         let using = if !has_from && self.match_keyword(Keyword::FROM) {
+            // DELETE t FROM t2 WHERE ...  (no initial FROM, second FROM introduces extra tables)
             self.advance();
             self.parse_from_clause()?
         } else if self.match_keyword(Keyword::USING) {
+            // DELETE FROM t USING t2, t3 WHERE ...
+            // USING is followed directly by table references (no FROM keyword)
             self.advance();
-            self.parse_from_clause()?
+            let mut tables = vec![self.parse_table_ref()?];
+            while self.match_token(&Token::Comma) {
+                self.advance();
+                tables.push(self.parse_table_ref()?);
+            }
+            tables
+        } else if has_from && self.match_keyword(Keyword::FROM) {
+            // DELETE FROM t1 FROM t2 WHERE ... (second FROM introduces extra tables)
+            self.advance();
+            let mut tables = vec![self.parse_table_ref()?];
+            while self.match_token(&Token::Comma) {
+                self.advance();
+                tables.push(self.parse_table_ref()?);
+            }
+            tables
         } else {
             vec![]
         };

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -143,8 +143,10 @@ impl Parser {
             return self.parse_pl_cursor_decl(real_name);
         }
 
-        if self.match_keyword(Keyword::TYPE_P) {
-            return self.parse_pl_type_decl(name);
+        // TYPE name IS RECORD/TABLE/VARRAY/... (first ident was "TYPE", read actual name)
+        if name.eq_ignore_ascii_case("type") {
+            let real_name = self.parse_identifier()?;
+            return self.parse_pl_type_decl_body(real_name);
         }
 
         self.parse_pl_var_decl(name)
@@ -511,6 +513,7 @@ impl Parser {
     pub(crate) fn skip_to_semicolon_or_keyword(&mut self) -> String {
         let mut collected = String::new();
         let mut depth = 0i32;
+        let mut case_depth = 0i32;
 
         loop {
             match self.peek() {
@@ -538,7 +541,22 @@ impl Parser {
                     self.advance();
                 }
                 _ => {
-                    if depth == 0 && is_pl_terminator(self) {
+                    if depth == 0 && self.match_ident_str("case") {
+                        case_depth += 1;
+                    }
+                    // Inside a SQL CASE expression, WHEN/THEN/ELSE/END belong to CASE, not PL.
+                    if depth == 0 && case_depth > 0 && is_sql_case_terminator(self) {
+                        if self.match_ident_str("end") {
+                            case_depth -= 1;
+                        }
+                        if !collected.is_empty() {
+                            collected.push(' ');
+                        }
+                        collected.push_str(&self.token_to_string());
+                        self.advance();
+                        continue;
+                    }
+                    if depth == 0 && case_depth == 0 && is_pl_terminator(self) {
                         break;
                     }
                     if !collected.is_empty() {
@@ -2778,6 +2796,11 @@ fn is_pl_terminator(p: &Parser) -> bool {
         "declare",
     ];
     terminators.iter().any(|t| p.match_ident_str(t))
+}
+
+fn is_sql_case_terminator(p: &Parser) -> bool {
+    let case_terms = ["when", "then", "else", "end"];
+    case_terms.iter().any(|t| p.match_ident_str(t))
 }
 
 fn attach_label(stmt: PlStatement, label: Option<String>) -> PlStatement {


### PR DESCRIPTION
## Summary

Fix 4 parser bugs that caused valid GaussDB/openGauss SQL to be incorrectly flagged as INVALID.

### Bug 1: Column-level REFERENCES missing ON DELETE/UPDATE CASCADE
- **Symptom**: `emp_id INTEGER REFERENCES employees(emp_id) ON DELETE CASCADE` reported as invalid
- **Cause**: `try_parse_column_constraint()` returned after column list without checking referential actions
- **Fix**: Added `parse_referential_action()` calls + changed AST to struct variant with `on_delete`/`on_update`

### Bug 2+3: DELETE USING and DELETE FROM FROM not consumed
- **Symptom**: `DELETE FROM t USING t2, t3 WHERE ...` reported as invalid
- **Cause**: `parse_from_clause()` expected FROM keyword after USING; second FROM blocked by `!has_from`
- **Fix**: Parse comma-separated table refs directly after USING/FROM

### Bug 4: TYPE IS TABLE OF dispatch logic error
- **Symptom**: `TYPE t_ids IS TABLE OF employees.emp_id%TYPE` reported as invalid
- **Cause**: Checked NEXT token for TYPE_P instead of recognizing already-consumed name
- **Fix**: Use `name.eq_ignore_ascii_case("type")` like existing CURSOR handler

## Test plan
- [x] 1174 existing unit tests pass (0 failures)
- [x] Validated against gauss_delete_all_styles.sql -- all 4 original INVALIDs now parse correctly
- [x] cargo check and cargo build --features full pass clean