### PR TITLE
feat(cli): generate error.log for parse/validate --dir --verbose

### DIFF
--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -659,6 +659,9 @@ fn cmd_parse_dir(
                     for e in &real_errors {
                         eprintln!("  {}", e);
                     }
+                    if cli.verbose {
+                        write_error_log(&sql, Some(file_name), &output.statements, &real_errors);
+                    }
                 }
                 if !warnings.is_empty() {
                     eprintln!("[{}] {} warning(s):", file_name, warnings.len());
@@ -3062,6 +3065,9 @@ fn cmd_validate_dir(cli: &Cli, dir_paths: &[String], exts: &[String], csv: bool,
                 }
                 for w in &warnings {
                     eprintln!("  warning: {}", w);
+                }
+                if cli.verbose {
+                    write_error_log(&sql, Some(&format!("{}/{}", rel_dir, file_name)), &stmts, &real_errors);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add `write_error_log` calls in `cmd_validate_dir` and `cmd_parse_dir` (text mode) when `--verbose` is set, so that `parse --dir --verbose` and `validate --dir --verbose` produce an `error.log` file in CWD — matching the existing single-file `-f --verbose` behavior.
- The error.log includes full statement-level context with source line excerpts and `> |` markers for error lines, identical to what `-f --verbose` generates.

## Changes

| Command | Before | After |
|---|---|---|
| `ogsql validate --dir ... --verbose` | No error.log | Writes `error.log` to CWD |
| `ogsql parse --dir ... --verbose` | No error.log | Writes `error.log` to CWD |

No behavior change without `--verbose` flag.