### PR TITLE
fix(parser): handle non-reserved keywords as table aliases and qualified star

### DIFF
--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1141,7 +1141,26 @@ impl Parser {
                 }
                 self.pos = saved;
                 self.errors.truncate(saved_err_len);
-                let name = self.parse_object_name()?;
+                // Parse first identifier (keyword-as-identifier),
+                // then check for qualified star (e.g. temp.*) before
+                // continuing with dotted name resolution.
+                let first = self.parse_identifier()?;
+                let name = if self.match_token(&Token::Dot) {
+                    self.advance();
+                    if self.match_token(&Token::Star) {
+                        self.advance();
+                        return Ok(Expr::QualifiedStar(first));
+                    }
+                    let mut parts = vec![first];
+                    parts.push(self.parse_identifier()?);
+                    while self.match_token(&Token::Dot) {
+                        self.advance();
+                        parts.push(self.parse_identifier()?);
+                    }
+                    parts
+                } else {
+                    vec![first]
+                };
                 if let Token::StringLiteral(s) = self.peek().clone() {
                     self.advance();
                     return Ok(Expr::TypeCast {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1059,6 +1059,7 @@ impl Parser {
                     | Keyword::MINUS_P
                     | Keyword::FOR
                     | Keyword::INTO
+                    | Keyword::ON
                     | Keyword::END_P
                     | Keyword::THEN
                     | Keyword::ELSE
@@ -1066,6 +1067,8 @@ impl Parser {
                     | Keyword::AND
                     | Keyword::OR
                     | Keyword::AS
+                    | Keyword::SET
+                    | Keyword::USING
                     // JOIN keywords — a table alias can be followed by any join clause
                     | Keyword::LEFT
                     | Keyword::RIGHT


### PR DESCRIPTION
## Summary

- **fix qualified star after keyword-as-identifier**: `SELECT temp.* FROM ...` crashed because `temp` is tokenized as `Keyword(TEMP)`, and the keyword branch in `parse_primary_expr` called `parse_object_name()` which cannot handle `.*`. Inlined the parsing with explicit `.*` detection, mirroring `parse_column_ref_or_qualified_star`.
- **fix alias detection for ON/SET/USING**: `MERGE INTO t USING staging source ON (...)` failed with "expected on, got Keyword(SOURCE_P)" because `looks_like_alias()` did not include `ON`, `SET`, `USING` as tokens that terminate a table alias.

## Test plan

- [x] 1174 existing tests pass
- [x] `SELECT temp.* FROM salary_update_log temp` parses correctly
- [x] `MERGE INTO t USING staging source ON (...)` parses correctly
- [x] gauss_update_select.sql proc_rollback_to_date: INVALID -> VALID
- [x] pkg_merge_fix1.sql proc_merge_sales_data: 2 errors -> 1 (remaining error is a bug in the SQL file itself - missing EXECUTE IMMEDIATE)