### PR TITLE
fix: reject unsupported ON CONFLICT syntax (issue #165)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1526,7 +1526,7 @@ pub struct InsertStatement {
     pub partition: Option<DmlPartitionClause>,
     pub columns: Vec<String>,
     pub source: InsertSource,
-    pub on_conflict: Option<OnConflictAction>,
+    pub on_duplicate_key: Option<OnDuplicateKeyUpdate>,
     pub returning: Vec<SelectTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -1536,21 +1536,9 @@ pub struct InsertStatement {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum OnConflictAction {
-    Nothing {
-        target: Option<OnConflictTarget>,
-    },
-    Update {
-        target: Option<OnConflictTarget>,
-        assignments: Vec<UpdateAssignment>,
-        where_clause: Option<Expr>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub enum OnConflictTarget {
-    Columns(Vec<String>),
-    OnConstraint(String),
+pub struct OnDuplicateKeyUpdate {
+    pub assignments: Vec<UpdateAssignment>,
+    pub where_clause: Option<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1691,66 +1691,25 @@ impl SqlFormatter {
             }
         }
 
-        if let Some(ref conflict) = stmt.on_conflict {
-            match conflict {
-                OnConflictAction::Nothing { target } => {
-                    let mut conflict_parts = vec![self.kw("ON"), self.kw("CONFLICT")];
-                    if let Some(t) = target {
-                        match t {
-                            OnConflictTarget::Columns(cols) => {
-                                conflict_parts.push(format!("({})", cols.join(", ")));
-                            }
-                            OnConflictTarget::OnConstraint(name) => {
-                                conflict_parts.push(self.kw("ON"));
-                                conflict_parts.push(self.kw("CONSTRAINT"));
-                                conflict_parts.push(self.quote_identifier(name));
-                            }
-                        }
-                    }
-                    conflict_parts.push(self.kw("DO"));
-                    conflict_parts.push(self.kw("NOTHING"));
-                    parts.push(conflict_parts.join(" "));
-                }
-                OnConflictAction::Update {
-                    target,
-                    assignments,
-                    where_clause,
-                } => {
-                    let mut conflict_parts = vec![self.kw("ON")];
-                    conflict_parts.push(self.kw("CONFLICT"));
-                    if let Some(t) = target {
-                        match t {
-                            OnConflictTarget::Columns(cols) => {
-                                conflict_parts.push(format!("({})", cols.join(", ")));
-                            }
-                            OnConflictTarget::OnConstraint(name) => {
-                                conflict_parts.push(self.kw("ON"));
-                                conflict_parts.push(self.kw("CONSTRAINT"));
-                                conflict_parts.push(self.quote_identifier(name));
-                            }
-                        }
-                    }
-                    conflict_parts.push(self.kw("DO"));
-                    conflict_parts.push(self.kw("UPDATE"));
-                    conflict_parts.push(self.kw("SET"));
-                    let assign_strs: Vec<String> = assignments
-                        .iter()
-                        .map(|a| {
-                            format!(
-                                "{} = {}",
-                                self.format_object_name(&a.columns[0]),
-                                self.format_expr(&a.value)
-                            )
-                        })
-                        .collect();
-                    conflict_parts.push(assign_strs.join(", "));
-                    if let Some(w) = where_clause {
-                        conflict_parts.push(self.kw("WHERE"));
-                        conflict_parts.push(self.format_expr(w));
-                    }
-                    parts.push(conflict_parts.join(" "));
-                }
+        if let Some(ref dup_key) = stmt.on_duplicate_key {
+            let mut dup_parts = vec![self.kw("ON"), self.kw("DUPLICATE"), self.kw("KEY"), self.kw("UPDATE")];
+            let assign_strs: Vec<String> = dup_key
+                .assignments
+                .iter()
+                .map(|a| {
+                    format!(
+                        "{} = {}",
+                        self.format_object_name(&a.columns[0]),
+                        self.format_expr(&a.value)
+                    )
+                })
+                .collect();
+            dup_parts.push(assign_strs.join(", "));
+            if let Some(w) = &dup_key.where_clause {
+                dup_parts.push(self.kw("WHERE"));
+                dup_parts.push(self.format_expr(w));
             }
+            parts.push(dup_parts.join(" "));
         }
 
         if !stmt.returning.is_empty() {

--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     DeleteStatement, DmlPartitionClause, InsertAllCondition, InsertAllStatement, InsertAllTarget,
     InsertFirstStatement, InsertSource, InsertStatement, MergeAction, MergeStatement,
-    MergeWhenClause, OnConflictAction, OnConflictTarget, SelectTarget, TablePartitionRef, TableRef,
+    MergeWhenClause, OnDuplicateKeyUpdate, TablePartitionRef, TableRef,
     UpdateAssignment, UpdateStatement,
 };
 use crate::parser::{Parser, ParserError};
@@ -163,7 +163,7 @@ impl Parser {
                 got: format!("{:?}", self.peek()),
             });
         };
-        let on_conflict = if self.match_keyword(Keyword::ON) {
+        let on_duplicate_key = if self.match_keyword(Keyword::ON) {
             self.advance();
             if self.match_keyword(Keyword::DUPLICATE) {
                 self.advance();
@@ -186,66 +186,16 @@ impl Parser {
                 } else {
                     None
                 };
-                Some(OnConflictAction::Update {
-                    target: None,
+                Some(OnDuplicateKeyUpdate {
                     assignments,
                     where_clause,
                 })
             } else if self.match_keyword(Keyword::CONFLICT) {
-                self.advance();
-                let target = if self.match_keyword(Keyword::ON) {
-                    self.advance();
-                    self.expect_keyword(Keyword::CONSTRAINT)?;
-                    let name = self.parse_identifier()?;
-                    Some(OnConflictTarget::OnConstraint(name))
-                } else if self.match_token(&Token::LParen) {
-                    self.advance();
-                    let mut cols = vec![self.parse_identifier()?];
-                    while self.match_token(&Token::Comma) {
-                        self.advance();
-                        cols.push(self.parse_identifier()?);
-                    }
-                    self.expect_token(&Token::RParen)?;
-                    Some(OnConflictTarget::Columns(cols))
-                } else {
-                    None
-                };
-                self.expect_keyword(Keyword::DO)?;
-                if self.match_keyword(Keyword::NOTHING) {
-                    self.advance();
-                    Some(OnConflictAction::Nothing { target })
-                } else if self.match_keyword(Keyword::UPDATE) {
-                    self.advance();
-                    self.expect_keyword(Keyword::SET)?;
-                    let mut assignments = Vec::new();
-                    loop {
-                        let column = self.parse_object_name()?;
-                        self.expect_token(&Token::Eq)?;
-                        let value = self.parse_expr()?;
-                        assignments.push(UpdateAssignment { columns: vec![column], value });
-                        if !self.match_token(&Token::Comma) {
-                            break;
-                        }
-                        self.advance();
-                    }
-                    let where_clause = if self.match_keyword(Keyword::WHERE) {
-                        self.advance();
-                        Some(self.parse_expr()?)
-                    } else {
-                        None
-                    };
-                    Some(OnConflictAction::Update {
-                        target,
-                        assignments,
-                        where_clause,
-                    })
-                } else {
-                    return Err(ParserError::UnexpectedToken {
-                        location: self.current_location(),
-                        expected: "NOTHING or UPDATE".to_string(),
-                        got: format!("{:?}", self.peek()),
-                    });
-                }
+                return Err(ParserError::UnsupportedSyntax {
+                    location: self.current_location(),
+                    syntax: "ON CONFLICT".to_string(),
+                    hint: "openGauss does not support ON CONFLICT. Use ON DUPLICATE KEY UPDATE instead.".to_string(),
+                });
             } else {
                 self.pos -= 1;
                 None
@@ -283,7 +233,7 @@ impl Parser {
             partition,
             columns,
             source,
-            on_conflict,
+            on_duplicate_key,
             returning,
             into_targets,
             bulk_collect,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -37,6 +37,12 @@ pub enum ParserError {
     },
     #[error("{0}")]
     TokenizerError(#[from] crate::token::tokenizer::TokenizerError),
+    #[error("unsupported syntax at line {}, column {}: {} ({})", .location.line, .location.column, .syntax, .hint)]
+    UnsupportedSyntax {
+        location: SourceLocation,
+        syntax: String,
+        hint: String,
+    },
 }
 
 pub struct Parser {
@@ -936,7 +942,7 @@ impl Parser {
     /// Try to consume an optional column alias: [AS] identifier
     /// Unlike parse_optional_alias, also accepts non-reserved keywords as implicit aliases.
     /// Uses 1-token lookahead to avoid consuming keywords that start subsequent clauses
-    /// (e.g., LOOP in PL/pgSQL, CONNECT in hierarchical queries, ON CONFLICT in INSERT).
+    /// (e.g., LOOP in PL/pgSQL, CONNECT in hierarchical queries, ON DUPLICATE KEY UPDATE in INSERT).
     fn parse_optional_column_alias(&mut self) -> Result<Option<String>, ParserError> {
         if self.match_keyword(Keyword::AS) {
             self.advance();

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -6920,57 +6920,72 @@ END;"#;
 }
 
 #[test]
-fn test_on_conflict_do_nothing() {
-    let stmt = parse_one("INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING");
+fn test_on_conflict_rejected() {
+    let sql = "INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let errors = parser.errors();
+    assert!(!errors.is_empty(), "ON CONFLICT should produce an error");
+    let msg = format!("{:?}", errors);
+    assert!(
+        msg.contains("unsupported syntax") || msg.contains("ON CONFLICT"),
+        "error should mention ON CONFLICT: {}",
+        msg
+    );
+    assert!(
+        matches!(stmts[0], Statement::Empty),
+        "ON CONFLICT should produce Empty statement"
+    );
+}
+
+#[test]
+fn test_on_conflict_with_columns_rejected() {
+    let sql = "INSERT INTO t VALUES (1) ON CONFLICT (id) DO UPDATE SET name = 'x'";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let errors = parser.errors();
+    assert!(!errors.is_empty(), "ON CONFLICT (columns) should produce an error");
+    assert!(
+        matches!(stmts[0], Statement::Empty),
+        "ON CONFLICT should produce Empty statement"
+    );
+}
+
+#[test]
+fn test_on_conflict_on_constraint_rejected() {
+    let sql = "INSERT INTO t VALUES (1) ON CONFLICT ON CONSTRAINT pk DO NOTHING";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let errors = parser.errors();
+    assert!(!errors.is_empty(), "ON CONFLICT ON CONSTRAINT should produce an error");
+    assert!(
+        matches!(stmts[0], Statement::Empty),
+        "ON CONFLICT should produce Empty statement"
+    );
+}
+
+#[test]
+fn test_on_duplicate_key_update() {
+    let stmt = parse_one("INSERT INTO t (a, b) VALUES (1, 2) ON DUPLICATE KEY UPDATE b = EXCLUDED.b");
     match stmt {
         Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.expect("expected on_conflict");
-            assert!(matches!(oc, OnConflictAction::Nothing { target: None }));
+            let dk = ins.node.on_duplicate_key.expect("expected on_duplicate_key");
+            assert_eq!(dk.assignments.len(), 1);
         }
         _ => panic!("expected Insert"),
     }
 }
 
 #[test]
-fn test_on_conflict_columns() {
-    let stmt = parse_one("INSERT INTO t VALUES (1) ON CONFLICT (id) DO UPDATE SET name = 'x'");
+fn test_on_duplicate_key_update_multiple() {
+    let stmt = parse_one("INSERT INTO t (a, b, c) VALUES (1, 2, 3) ON DUPLICATE KEY UPDATE b = EXCLUDED.b, c = 5");
     match stmt {
         Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.expect("expected on_conflict");
-            match oc {
-                OnConflictAction::Update {
-                    target,
-                    assignments,
-                    ..
-                } => {
-                    assert!(
-                        matches!(target, Some(OnConflictTarget::Columns(cols)) if cols == vec!["id"])
-                    );
-                    assert_eq!(assignments.len(), 1);
-                }
-                _ => panic!("expected Update action"),
-            }
-        }
-        _ => panic!("expected Insert"),
-    }
-}
-
-#[test]
-fn test_on_conflict_on_constraint() {
-    let stmt = parse_one("INSERT INTO t VALUES (1) ON CONFLICT ON CONSTRAINT pk DO NOTHING");
-    match stmt {
-        Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.expect("expected on_conflict");
-            match oc {
-                OnConflictAction::Nothing { target } => {
-                    assert!(
-                        matches!(target, Some(OnConflictTarget::OnConstraint(ref name)) if name == "pk"),
-                        "expected OnConstraint(pk), got {:?}",
-                        target
-                    );
-                }
-                other => panic!("expected Nothing, got {:?}", other),
-            }
+            let dk = ins.node.on_duplicate_key.expect("expected on_duplicate_key");
+            assert_eq!(dk.assignments.len(), 2);
         }
         _ => panic!("expected Insert"),
     }


### PR DESCRIPTION
## Summary

`ON CONFLICT ... DO UPDATE SET` is PostgreSQL syntax that openGauss does not support. The parser was silently accepting it and the formatter was incorrectly converting `ON DUPLICATE KEY UPDATE` input to `ON CONFLICT` output.

## Changes

- **AST**: Replace `OnConflictAction` enum with `OnDuplicateKeyUpdate` struct; remove `OnConflictTarget` enum
- **Parser**: Remove `ON CONFLICT` parsing branch; return `ParserError::UnsupportedSyntax` with hint to use `ON DUPLICATE KEY UPDATE`
- **Formatter**: Output `ON DUPLICATE KEY UPDATE` instead of `ON CONFLICT`
- **Tests**: Convert 3 `test_on_conflict_*` to expect errors; add 2 `test_on_duplicate_key_update` tests

## Behavior

```sql
-- Before: silently accepted → VALID
-- After: error "unsupported syntax: ON CONFLICT ... Use ON DUPLICATE KEY UPDATE instead."
INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING;

-- Continues to work correctly
INSERT INTO t (a,b) VALUES (1,2) ON DUPLICATE KEY UPDATE b = EXCLUDED.b;
```

Closes #165