### PR TITLE
feat: add GaussDB MERGE semantic validation (v0.5.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -6,7 +6,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use crate::ast::plpgsql::{PlBlock, PlDeclaration, PlOpenKind, PlStatement};
-use crate::ast::{Expr, Literal, SourceSpan, Statement};
+use crate::ast::{Expr, Literal, SourceSpan, Statement, StatementInfo};
 
 // ── 报告类型 ──
 
@@ -2029,6 +2029,353 @@ impl PlVariableValidator {
             }
             _ => {}
         }
+    }
+}
+
+// ── MERGE Semantic Validation for GaussDB ──
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MergeSemanticError {
+    pub kind: MergeSemanticErrorKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default)]
+    pub location: crate::token::SourceLocation,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum MergeSemanticErrorKind {
+    /// GaussDB does not support WHEN MATCHED THEN DELETE
+    DeleteNotSupported,
+    /// Columns referenced in ON clause cannot be updated
+    OnColumnUpdated,
+    /// DUAL table does not exist in GaussDB
+    DualTableNotSupported,
+}
+
+/// Validate MERGE statements against GaussDB semantic restrictions.
+///
+/// Returns a list of errors for each violation found across all MERGE statements
+/// in the provided statement list (including MERGE inside PL/pgSQL blocks).
+pub fn validate_merge_semantics(stmts: &[StatementInfo]) -> Vec<MergeSemanticError> {
+    let mut errors = Vec::new();
+    for si in stmts {
+        let loc = crate::token::SourceLocation {
+            line: si.start_line,
+            column: si.start_col,
+            offset: 0,
+        };
+        collect_merge_errors(&si.statement, &mut errors, loc);
+    }
+    errors
+}
+
+fn span_to_location(span: Option<&crate::ast::SourceSpan>) -> crate::token::SourceLocation {
+    span.map(|s| s.start.clone())
+        .unwrap_or_default()
+}
+
+fn collect_merge_errors(
+    stmt: &Statement,
+    errors: &mut Vec<MergeSemanticError>,
+    fallback_loc: crate::token::SourceLocation,
+) {
+    match stmt {
+        Statement::Merge(ref merge_stmt) => {
+            let loc = if merge_stmt.span.is_some() {
+                span_to_location(merge_stmt.span.as_ref())
+            } else {
+                fallback_loc
+            };
+            errors.extend(validate_single_merge(&merge_stmt.node, loc));
+        }
+        Statement::CreateProcedure(ref proc) => {
+            if let Some(ref block) = proc.block {
+                scan_pl_block(block, errors);
+            }
+        }
+        Statement::CreateFunction(ref func) => {
+            if let Some(ref block) = func.block {
+                scan_pl_block(block, errors);
+            }
+        }
+        Statement::Do(ref do_stmt) => {
+            if let Some(ref block) = do_stmt.block {
+                scan_pl_block(block, errors);
+            }
+        }
+        Statement::AnonyBlock(ref ab) => {
+            scan_pl_block(&ab.block, errors);
+        }
+        Statement::CreatePackageBody(ref body) => {
+            for item in &body.items {
+                match item {
+                    crate::ast::PackageItem::Procedure(ref p) => {
+                        if let Some(ref block) = p.block {
+                            scan_pl_block(block, errors);
+                        }
+                    }
+                    crate::ast::PackageItem::Function(ref f) => {
+                        if let Some(ref block) = f.block {
+                            scan_pl_block(block, errors);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scan_pl_block(block: &crate::ast::plpgsql::PlBlock, errors: &mut Vec<MergeSemanticError>) {
+    for stmt in &block.body {
+        scan_pl_stmt(stmt, errors);
+    }
+    if let Some(ref exc) = block.exception_block {
+        for handler in &exc.handlers {
+            for stmt in &handler.statements {
+                scan_pl_stmt(stmt, errors);
+            }
+        }
+    }
+}
+
+fn scan_pl_stmt(stmt: &crate::ast::plpgsql::PlStatement, errors: &mut Vec<MergeSemanticError>) {
+    use crate::ast::plpgsql::PlStatement as Ps;
+    match stmt {
+        Ps::SqlStatement { statement, span, .. } => {
+            let loc = if let Some(ref sp) = span {
+                sp.start.clone()
+            } else if let Statement::Merge(ref ms) = statement.as_ref() {
+                span_to_location(ms.span.as_ref())
+            } else {
+                crate::token::SourceLocation::default()
+            };
+            collect_merge_errors(statement, errors, loc);
+        }
+        Ps::Block(ref inner) => {
+            scan_pl_block(&inner.node, errors);
+        }
+        Ps::If(ref if_stmt) => {
+            for s in &if_stmt.node.then_stmts {
+                scan_pl_stmt(s, errors);
+            }
+            for elsif in &if_stmt.node.elsifs {
+                for s in &elsif.stmts {
+                    scan_pl_stmt(s, errors);
+                }
+            }
+            for s in &if_stmt.node.else_stmts {
+                scan_pl_stmt(s, errors);
+            }
+        }
+        Ps::Case(ref case_stmt) => {
+            for when in &case_stmt.node.whens {
+                for s in &when.stmts {
+                    scan_pl_stmt(s, errors);
+                }
+            }
+            for s in &case_stmt.node.else_stmts {
+                scan_pl_stmt(s, errors);
+            }
+        }
+        Ps::Loop(ref loop_stmt) => {
+            for s in &loop_stmt.node.body {
+                scan_pl_stmt(s, errors);
+            }
+        }
+        Ps::While(ref while_stmt) => {
+            for s in &while_stmt.node.body {
+                scan_pl_stmt(s, errors);
+            }
+        }
+        Ps::For(ref for_stmt) => {
+            for s in &for_stmt.node.body {
+                scan_pl_stmt(s, errors);
+            }
+        }
+        Ps::ForEach(ref foreach_stmt) => {
+            for s in &foreach_stmt.node.body {
+                scan_pl_stmt(s, errors);
+            }
+        }
+        Ps::ForAll(ref _forall_stmt) => {
+            // ForAll body is a String (raw SQL), not structured PlStatement
+        }
+        _ => {}
+    }
+}
+
+fn validate_single_merge(stmt: &crate::ast::MergeStatement, loc: crate::token::SourceLocation) -> Vec<MergeSemanticError> {
+    let mut errors = Vec::new();
+
+    for clause in &stmt.when_clauses {
+        // Check 1: WHEN MATCHED THEN DELETE is not supported
+        if clause.matched && matches!(clause.action, crate::ast::MergeAction::Delete) {
+            errors.push(MergeSemanticError {
+                kind: MergeSemanticErrorKind::DeleteNotSupported,
+                detail: Some("GaussDB does not support MERGE ... WHEN MATCHED THEN DELETE".to_string()),
+                location: loc.clone(),
+            });
+        }
+
+        // Check 2: Columns referenced in ON clause cannot be updated
+        if let crate::ast::MergeAction::Update(ref assignments) = clause.action {
+            let on_columns = extract_target_columns_from_expr(&stmt.on_condition, &stmt.target);
+            if !on_columns.is_empty() {
+                let mut conflicting = Vec::new();
+                for assign in assignments {
+                    for col_name in &assign.columns {
+                        let col_lower = col_name.last().map(|s| s.to_lowercase());
+                        if let Some(ref col) = col_lower {
+                            if on_columns.contains(col) {
+                                if !conflicting.contains(col) {
+                                    conflicting.push(col.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+                if !conflicting.is_empty() {
+                    errors.push(MergeSemanticError {
+                        kind: MergeSemanticErrorKind::OnColumnUpdated,
+                        detail: Some(format!(
+                            "Columns referenced in the ON clause cannot be updated: {}",
+                            conflicting.join(", ")
+                        )),
+                        location: loc.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    // Check 3: DUAL table does not exist in GaussDB
+    if uses_dual_table(&stmt.source) {
+        errors.push(MergeSemanticError {
+            kind: MergeSemanticErrorKind::DualTableNotSupported,
+            detail: Some("GaussDB does not have a DUAL table; use a VALUES clause or bare SELECT instead".to_string()),
+            location: loc.clone(),
+        });
+    }
+
+    errors
+}
+
+/// Extract column names from an expression that belong to the target table.
+///
+/// The target table is identified by its alias (if present) or its unqualified name.
+/// Column names are returned in lowercase for case-insensitive comparison.
+fn extract_target_columns_from_expr(
+    expr: &Expr,
+    target: &crate::ast::TableRef,
+) -> std::collections::HashSet<String> {
+    let target_id = match target {
+        crate::ast::TableRef::Table { name, alias, .. } => {
+            if let Some(ref a) = alias {
+                a.to_lowercase()
+            } else {
+                name.last().map(|s| s.to_lowercase()).unwrap_or_default()
+            }
+        }
+        _ => return std::collections::HashSet::new(),
+    };
+
+    let mut cols = std::collections::HashSet::new();
+    collect_target_columns(expr, &target_id, &mut cols);
+    cols
+}
+
+fn collect_target_columns(
+    expr: &Expr,
+    target_id: &str,
+    cols: &mut std::collections::HashSet<String>,
+) {
+    match expr {
+        Expr::ColumnRef(parts) => {
+            if parts.len() == 2 && parts[0].to_lowercase() == target_id {
+                cols.insert(parts[1].to_lowercase());
+            } else if parts.len() == 1 {
+                // Unqualified column — conservatively include as potential target column
+                cols.insert(parts[0].to_lowercase());
+            }
+        }
+        Expr::BinaryOp { left, right, .. } => {
+            collect_target_columns(left, target_id, cols);
+            collect_target_columns(right, target_id, cols);
+        }
+        Expr::Parenthesized(inner) => {
+            collect_target_columns(inner, target_id, cols);
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_target_columns(arg, target_id, cols);
+            }
+        }
+        Expr::Like { expr: e, pattern, .. } => {
+            collect_target_columns(e, target_id, cols);
+            collect_target_columns(pattern, target_id, cols);
+        }
+        Expr::Between { expr: e, low, high, .. } => {
+            collect_target_columns(e, target_id, cols);
+            collect_target_columns(low, target_id, cols);
+            collect_target_columns(high, target_id, cols);
+        }
+        Expr::InList { expr: e, list, .. } => {
+            collect_target_columns(e, target_id, cols);
+            for item in list {
+                collect_target_columns(item, target_id, cols);
+            }
+        }
+        Expr::IsNull { expr: e, .. } => {
+            collect_target_columns(e, target_id, cols);
+        }
+        Expr::IsBoolean { expr: e, .. } => {
+            collect_target_columns(e, target_id, cols);
+        }
+        Expr::UnaryOp { expr: e, .. } => {
+            collect_target_columns(e, target_id, cols);
+        }
+        Expr::TypeCast { expr: e, .. } => {
+            collect_target_columns(e, target_id, cols);
+        }
+        Expr::Case { operand, whens, else_expr } => {
+            if let Some(ref op) = operand {
+                collect_target_columns(op, target_id, cols);
+            }
+            for when in whens {
+                collect_target_columns(&when.condition, target_id, cols);
+                collect_target_columns(&when.result, target_id, cols);
+            }
+            if let Some(ref el) = else_expr {
+                collect_target_columns(el, target_id, cols);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Check if a TableRef (or its nested subqueries) references the DUAL table.
+fn uses_dual_table(table_ref: &crate::ast::TableRef) -> bool {
+    match table_ref {
+        crate::ast::TableRef::Table { name, .. } => {
+            name.last().map_or(false, |n| n.eq_ignore_ascii_case("dual"))
+        }
+        crate::ast::TableRef::Subquery { query, .. } => {
+            for tr in &query.from {
+                if uses_dual_table(tr) {
+                    return true;
+                }
+            }
+            false
+        }
+        crate::ast::TableRef::Join { left, right, .. } => {
+            uses_dual_table(left) || uses_dual_table(right)
+        }
+        crate::ast::TableRef::Pivot { source, .. } => uses_dual_table(source),
+        crate::ast::TableRef::Unpivot { source, .. } => uses_dual_table(source),
+        _ => false,
     }
 }
 

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -896,3 +896,109 @@ fn test_no_warning_for_perform_sql() {
     let warnings = validate_pl_variables(&block, &params);
     assert!(warnings.is_empty(), "PERFORM SQL columns should not be flagged, got: {:?}", warnings);
 }
+
+// ── MERGE Semantic Validation Tests ──
+
+fn parse_merge_stmts(sql: &str) -> Vec<crate::ast::StatementInfo> {
+    let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
+    let stmts = Parser::new(tokens).parse();
+    stmts.iter().map(|s| crate::ast::StatementInfo {
+        sql_text: sql.to_string(),
+        start_line: 1,
+        start_col: 1,
+        end_line: 1,
+        end_col: sql.len(),
+        statement: s.clone(),
+    }).collect()
+}
+
+#[test]
+fn test_merge_delete_not_supported() {
+    let sql = "MERGE INTO emp_performance tgt USING (SELECT emp_id FROM employees WHERE base_salary < 7000) src ON (tgt.emp_id = src.emp_id) WHEN MATCHED THEN DELETE";
+    let infos = parse_merge_stmts(sql);
+    let errors = super::validate_merge_semantics(&infos);
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].kind, super::MergeSemanticErrorKind::DeleteNotSupported);
+}
+
+#[test]
+fn test_merge_on_column_updated() {
+    let sql = "MERGE INTO emp_bonus tgt USING (SELECT emp_id, base_salary FROM employees) src ON (tgt.emp_id = src.emp_id AND tgt.calc_method = 'MERGE_UPDATE') WHEN MATCHED THEN UPDATE SET bonus_amount = src.base_salary, calc_method = 'UPDATED' WHEN NOT MATCHED THEN INSERT (bonus_id, emp_id) VALUES (nextval('seq_bonus'), src.emp_id)";
+    let infos = parse_merge_stmts(sql);
+    let errors = super::validate_merge_semantics(&infos);
+    assert!(errors.iter().any(|e| e.kind == super::MergeSemanticErrorKind::OnColumnUpdated),
+        "Expected OnColumnUpdated error, got: {:?}", errors);
+}
+
+#[test]
+fn test_merge_dual_table_not_supported() {
+    let sql = "MERGE INTO employees tgt USING (SELECT 1070 AS emp_id, 'MergeNew' AS name FROM DUAL) src ON (tgt.emp_id = src.emp_id) WHEN NOT MATCHED THEN INSERT (emp_id, emp_name) VALUES (src.emp_id, src.name)";
+    let infos = parse_merge_stmts(sql);
+    let errors = super::validate_merge_semantics(&infos);
+    assert!(errors.iter().any(|e| e.kind == super::MergeSemanticErrorKind::DualTableNotSupported),
+        "Expected DualTableNotSupported error, got: {:?}", errors);
+}
+
+#[test]
+fn test_merge_valid_no_errors() {
+    let sql = "MERGE INTO products p USING newproducts np ON (p.product_id = np.product_id) WHEN MATCHED THEN UPDATE SET p.product_name = np.product_name WHEN NOT MATCHED THEN INSERT VALUES (np.product_id, np.product_name)";
+    let infos = parse_merge_stmts(sql);
+    let errors = super::validate_merge_semantics(&infos);
+    assert!(errors.is_empty(), "Expected no errors for valid MERGE, got: {:?}", errors);
+}
+
+#[test]
+fn test_merge_on_column_updated_unqualified() {
+    let sql = "MERGE INTO salary_history h USING (SELECT emp_id, base_salary FROM employees) e ON (h.emp_id = e.emp_id AND h.change_date >= CURRENT_DATE) WHEN MATCHED THEN UPDATE SET old_salary = h.new_salary, new_salary = e.base_salary, change_date = CURRENT_TIMESTAMP";
+    let infos = parse_merge_stmts(sql);
+    let errors = super::validate_merge_semantics(&infos);
+    assert!(errors.iter().any(|e| e.kind == super::MergeSemanticErrorKind::OnColumnUpdated),
+        "Expected OnColumnUpdated for change_date, got: {:?}", errors);
+}
+
+#[test]
+fn test_merge_dual_case_insensitive() {
+    let sql = "MERGE INTO t1 tgt USING (SELECT 1 AS id FROM dual) src ON (tgt.id = src.id) WHEN NOT MATCHED THEN INSERT (id) VALUES (src.id)";
+    let infos = parse_merge_stmts(sql);
+    let errors = super::validate_merge_semantics(&infos);
+    assert!(errors.iter().any(|e| e.kind == super::MergeSemanticErrorKind::DualTableNotSupported),
+        "Expected DualTableNotSupported for lowercase 'dual', got: {:?}", errors);
+}
+
+#[test]
+fn test_merge_delete_inside_procedure() {
+    let sql = "CREATE OR REPLACE PROCEDURE test_merge IS BEGIN MERGE INTO emp_performance tgt USING (SELECT emp_id FROM employees WHERE base_salary < 7000) src ON (tgt.emp_id = src.emp_id) WHEN MATCHED THEN DELETE; END;";
+    let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
+    let stmts = Parser::new(tokens).parse();
+    let infos: Vec<crate::ast::StatementInfo> = stmts.iter().map(|s| crate::ast::StatementInfo {
+        sql_text: sql.to_string(),
+        start_line: 1, start_col: 1, end_line: 1, end_col: sql.len(),
+        statement: s.clone(),
+    }).collect();
+    let errors = super::validate_merge_semantics(&infos);
+    assert_eq!(errors.len(), 1, "Expected 1 DeleteNotSupported error for MERGE inside procedure, got: {:?}", errors);
+    assert_eq!(errors[0].kind, super::MergeSemanticErrorKind::DeleteNotSupported);
+}
+
+#[test]
+fn test_merge_delete_inside_package_body() {
+    let sql = r#"CREATE OR REPLACE PACKAGE BODY pkg_test AS
+        PROCEDURE do_merge IS
+        BEGIN
+            MERGE INTO emp_performance tgt
+            USING (SELECT emp_id FROM employees WHERE base_salary < 7000) src
+            ON (tgt.emp_id = src.emp_id)
+            WHEN MATCHED THEN DELETE;
+        END do_merge;
+    END pkg_test;"#;
+    let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
+    let stmts = Parser::new(tokens).parse();
+    let infos: Vec<crate::ast::StatementInfo> = stmts.iter().map(|s| crate::ast::StatementInfo {
+        sql_text: sql.to_string(),
+        start_line: 1, start_col: 1, end_line: 1, end_col: sql.len(),
+        statement: s.clone(),
+    }).collect();
+    let errors = super::validate_merge_semantics(&infos);
+    assert_eq!(errors.len(), 1, "Expected 1 DeleteNotSupported error for MERGE inside package body, got: {:?}", errors);
+    assert_eq!(errors[0].kind, super::MergeSemanticErrorKind::DeleteNotSupported);
+}

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -2844,6 +2844,23 @@ fn is_warning(e: &ogsql_parser::ParserError) -> bool {
     )
 }
 
+fn merge_error_detail(err: &ogsql_parser::MergeSemanticError) -> String {
+    match &err.detail {
+        Some(d) => d.clone(),
+        None => match err.kind {
+            ogsql_parser::MergeSemanticErrorKind::DeleteNotSupported => {
+                "GaussDB does not support MERGE ... WHEN MATCHED THEN DELETE".to_string()
+            }
+            ogsql_parser::MergeSemanticErrorKind::OnColumnUpdated => {
+                "GaussDB does not allow updating columns referenced in the ON clause".to_string()
+            }
+            ogsql_parser::MergeSemanticErrorKind::DualTableNotSupported => {
+                "GaussDB does not have a DUAL table".to_string()
+            }
+        },
+    }
+}
+
 fn collect_defined_routine_names(stmts: &[ogsql_parser::StatementInfo]) -> Vec<String> {
     use ogsql_parser::ast::Statement;
     let mut names = Vec::new();
@@ -2920,6 +2937,17 @@ fn validate_sql(
             errors.push(ogsql_parser::ParserError::Warning {
                 message: msg,
                 location: ogsql_parser::SourceLocation::default(),
+            });
+        }
+    }
+
+    let merge_errors = ogsql_parser::validate_merge_semantics(&stmts);
+    if !merge_errors.is_empty() {
+        for me in &merge_errors {
+            errors.push(ogsql_parser::ParserError::UnsupportedSyntax {
+                location: me.location.clone(),
+                syntax: "MERGE".to_string(),
+                hint: merge_error_detail(me),
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use analyzer::return_cursor::{
     ReturnCursorAnnotation, RoutineReturnAnalysis, ReturnCursorGroup,
     ReturnCursorBranch, ResultColumn, analyze_return_cursors, has_return_cursors,
 };
-pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars, validate_pl_variables_with_extra_vars_and_funcs, DynamicSqlReport, PackageConsistencyError, PackageConsistencyErrorKind, QueryFingerprint, TransactionReport, UndefinedVariableError};
+pub use analyzer::{analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_merge_semantics, validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars, validate_pl_variables_with_extra_vars_and_funcs, DynamicSqlReport, MergeSemanticError, MergeSemanticErrorKind, PackageConsistencyError, PackageConsistencyErrorKind, QueryFingerprint, TransactionReport, UndefinedVariableError};
 pub use analyzer::schema::{SchemaMap, SchemaResolutionReport, load_schema, resolve_schema};
 
 pub use ast::visitor::{

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -248,6 +248,16 @@ impl OgsqlServer {
                 });
             }
         }
+        let merge_errors = crate::validate_merge_semantics(&output.statements);
+        if !merge_errors.is_empty() {
+            for me in &merge_errors {
+                errors.push(crate::ParserError::UnsupportedSyntax {
+                    location: me.location.clone(),
+                    syntax: "MERGE".to_string(),
+                    hint: merge_error_detail(me),
+                });
+            }
+        }
         let has_real_errors = errors.iter().any(|e| !is_warning(e));
         let mut result = serde_json::json!({
             "valid": !has_real_errors,
@@ -259,6 +269,12 @@ impl OgsqlServer {
             result.as_object_mut().unwrap().insert(
                 "package_consistency_errors".to_string(),
                 serde_json::json!(pkg_errors),
+            );
+        }
+        if !merge_errors.is_empty() {
+            result.as_object_mut().unwrap().insert(
+                "merge_semantic_errors".to_string(),
+                serde_json::json!(merge_errors),
             );
         }
         serde_json::to_string_pretty(&result)
@@ -400,6 +416,23 @@ fn is_warning(e: &crate::ParserError) -> bool {
         crate::ParserError::Warning { .. }
             | crate::ParserError::ReservedKeywordAsIdentifier { .. }
     )
+}
+
+fn merge_error_detail(err: &crate::MergeSemanticError) -> String {
+    match &err.detail {
+        Some(d) => d.clone(),
+        None => match err.kind {
+            crate::MergeSemanticErrorKind::DeleteNotSupported => {
+                "GaussDB does not support MERGE ... WHEN MATCHED THEN DELETE".to_string()
+            }
+            crate::MergeSemanticErrorKind::OnColumnUpdated => {
+                "GaussDB does not allow updating columns referenced in the ON clause".to_string()
+            }
+            crate::MergeSemanticErrorKind::DualTableNotSupported => {
+                "GaussDB does not have a DUAL table".to_string()
+            }
+        },
+    }
 }
 
 fn compute_routine_analysis(stmt: &crate::Statement) -> Option<serde_json::Value> {


### PR DESCRIPTION
## Summary

Add static validation for 3 GaussDB MERGE runtime errors that can be caught at parse time:

| Check | Error Kind | Description |
|-------|-----------|-------------|
| `WHEN MATCHED THEN DELETE` | `DeleteNotSupported` | GaussDB does not support DELETE in MERGE |
| ON clause columns updated | `OnColumnUpdated` | Columns referenced in ON cannot be updated |
| `FROM DUAL` | `DualTableNotSupported` | GaussDB has no DUAL table |

### Key features
- Recursively scans PL/pgSQL blocks (procedures, functions, packages, DO blocks) for embedded MERGE statements
- Reports errors with accurate source location (line/column) from AST span
- Integrated into both CLI `validate` command and MCP validate endpoint
- 8 new unit tests covering all checks + nested PL scenarios

### Files changed
- `src/analyzer/mod.rs` — Core validation logic (`validate_merge_semantics`, column extraction, DUAL detection)
- `src/analyzer/tests.rs` — 8 tests for all 3 checks + PL nesting
- `src/lib.rs` — Public API export
- `src/mcp/mod.rs` — MCP validate integration
- `src/bin/ogsql.rs` — CLI validate integration
- `Cargo.toml` — Version bump to 0.5.0