### PR TITLE
fix(parser): support 5 GaussDB syntax gaps + improve unclosed BEGIN error

### DIFF
--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -54,14 +54,25 @@ impl Parser {
         let alias = self.parse_optional_alias()?;
         let partition = self.parse_dml_partition()?;
         let columns = if self.match_token(&Token::LParen) {
-            self.advance();
-            let mut cols = vec![self.parse_identifier()?];
-            while self.match_token(&Token::Comma) {
+            // Look ahead: if (SELECT or (WITH, this is NOT a column list
+            // but a parenthesized INSERT source — skip and let source parsing handle it
+            let is_parenthesized_source = self
+                .tokens
+                .get(self.pos + 1)
+                .map(|tws| matches!(&tws.token, Token::Keyword(kw) if *kw == Keyword::SELECT || *kw == Keyword::WITH))
+                .unwrap_or(false);
+            if is_parenthesized_source {
+                vec![]
+            } else {
                 self.advance();
-                cols.push(self.parse_identifier()?);
+                let mut cols = vec![self.parse_identifier()?];
+                while self.match_token(&Token::Comma) {
+                    self.advance();
+                    cols.push(self.parse_identifier()?);
+                }
+                self.expect_token(&Token::RParen)?;
+                cols
             }
-            self.expect_token(&Token::RParen)?;
-            cols
         } else {
             vec![]
         };
@@ -115,16 +126,23 @@ impl Parser {
         } else if self.match_keyword(Keyword::SELECT) || self.match_keyword(Keyword::WITH) {
             InsertSource::Select(Box::new(self.parse_select_statement()?))
         } else if self.match_token(&Token::LParen) {
-            if let Some(Token::Keyword(kw)) = self.tokens.get(self.pos + 1).map(|tws| &tws.token) {
-                if *kw == Keyword::SELECT || *kw == Keyword::WITH {
+            let save_pos = self.pos;
+            let save_err_len = self.errors.len();
+            let paren_loc = self.current_location();
+            self.advance();
+            if let Ok(mut select) = self.parse_select_statement() {
+                if self.match_token(&Token::RParen) {
                     self.advance();
-                    let paren_loc = self.current_location();
-                    let mut select = self.parse_select_statement()?;
-                    self.expect_token(&Token::RParen)?;
-                    // Detect pattern: INSERT INTO ... (SELECT ...) UNION ALL (SELECT ...)
-                    // GaussDB/openGauss supports this syntax; emit a compatibility warning.
-                    if let Some(Token::Keyword(kw)) = self.tokens.get(self.pos).map(|tws| &tws.token) {
-                        if matches!(kw, Keyword::UNION | Keyword::INTERSECT | Keyword::EXCEPT | Keyword::MINUS_P) {
+                    if let Some(Token::Keyword(kw)) =
+                        self.tokens.get(self.pos).map(|tws| &tws.token)
+                    {
+                        if matches!(
+                            kw,
+                            Keyword::UNION
+                                | Keyword::INTERSECT
+                                | Keyword::EXCEPT
+                                | Keyword::MINUS_P
+                        ) {
                             self.add_error(ParserError::Warning {
                                 message: format!(
                                     "bracketed INSERT ... (SELECT ...) {} — consider removing parentheses around each SELECT branch for clarity",
@@ -143,6 +161,8 @@ impl Parser {
                     }
                     InsertSource::Select(Box::new(select))
                 } else {
+                    self.pos = save_pos;
+                    self.errors.truncate(save_err_len);
                     return Err(ParserError::UnexpectedToken {
                         location: self.current_location(),
                         expected: "VALUES, SELECT, DEFAULT VALUES".to_string(),
@@ -150,6 +170,8 @@ impl Parser {
                     });
                 }
             } else {
+                self.pos = save_pos;
+                self.errors.truncate(save_err_len);
                 return Err(ParserError::UnexpectedToken {
                     location: self.current_location(),
                     expected: "VALUES, SELECT, DEFAULT VALUES".to_string(),

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -98,6 +98,47 @@ impl Parser {
                 self.advance();
                 self.expect_token(&Token::LParen)?;
                 self.consume_hints();
+                if self.match_keyword(Keyword::VALUES) {
+                    self.advance();
+                    let values_stmt = self.parse_values_statement()?;
+                    self.expect_token(&Token::RParen)?;
+                    let targets = values_stmt
+                        .rows
+                        .into_iter()
+                        .filter_map(|mut row| row.pop())
+                        .map(|expr| crate::ast::SelectTarget::Expr(expr, None))
+                        .collect();
+                    left = Expr::ScalarSublink {
+                        expr: Box::new(left),
+                        op: op_str,
+                        sublink_type,
+                        subquery: Box::new(crate::ast::SelectStatement {
+                            targets,
+                            hints: vec![],
+                            with: None,
+                            distinct: false,
+                            distinct_on: vec![],
+                            into_targets: None,
+                            bulk_collect: false,
+                            into_table: None,
+                            from: vec![],
+                            where_clause: None,
+                            connect_by: None,
+                            group_by: vec![],
+                            having: None,
+                            order_by: vec![],
+                            order_siblings: false,
+                            limit: None,
+                            offset: None,
+                            fetch: None,
+                            lock_clause: None,
+                            window_clause: vec![],
+                            set_operation: None,
+                            raw_body: None,
+                        }),
+                    };
+                    continue;
+                }
                 let saved_pos = self.pos;
                 let saved_err_len = self.errors.len();
                 if let Ok(subquery) = self.parse_select_statement() {
@@ -659,6 +700,23 @@ impl Parser {
                 negated,
             });
         }
+        // Handle IN ((SELECT...) UNION (SELECT...)) — parenthesized subquery with set operations
+        if self.match_token(&Token::LParen) {
+            let save_pos = self.pos;
+            let save_err_len = self.errors.len();
+            if let Ok(subquery) = self.parse_select_statement() {
+                if self.match_token(&Token::RParen) {
+                    self.advance();
+                    return Ok(Expr::InSubquery {
+                        expr: Box::new(left),
+                        subquery: Box::new(subquery),
+                        negated,
+                    });
+                }
+            }
+            self.pos = save_pos;
+            self.errors.truncate(save_err_len);
+        }
         let mut list = vec![self.parse_expr()?];
         while self.match_token(&Token::Comma) {
             self.advance();
@@ -1171,6 +1229,21 @@ impl Parser {
                     });
                 }
                 if self.match_token(&Token::LParen) {
+                    if self.tokens.len() > self.pos + 2 {
+                        let next = &self.tokens[self.pos + 1].token;
+                        let next2 = &self.tokens[self.pos + 2].token;
+                        if matches!(next, Token::Plus) && matches!(next2, Token::RParen) {
+                            let loc = self.current_location();
+                            self.advance();
+                            self.advance();
+                            self.advance();
+                            self.add_error(ParserError::Warning {
+                                message: "Oracle-style outer join operator '(+)' is deprecated, use standard JOIN syntax instead".to_string(),
+                                location: loc,
+                            });
+                            return Ok(Expr::ColumnRef(name));
+                        }
+                    }
                     return self.parse_function_call(name);
                 }
                 if name.len() >= 2 {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1821,7 +1821,8 @@ impl Parser {
                 if !self.is_declare_cursor_at(self.pos) && self.has_begin_after_declare(self.pos) {
                     self.advance();
                     let declarations = self.parse_pl_declarations_until_begin()?;
-                    let block = self.parse_pl_block_body(None, declarations)?;
+                    let begin_location = self.current_location();
+                    let block = self.parse_pl_block_body(None, declarations, begin_location)?;
                     self.try_consume_semicolon();
                     crate::ast::Statement::AnonyBlock(crate::ast::Spanned::new(crate::ast::AnonyBlockStatement { block }, Some(crate::ast::SourceSpan { start, end: self.prev_location() })))
                 } else if self.is_declare_cursor_at(self.pos) {

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -15,9 +15,10 @@ impl Parser {
             Vec::new()
         };
 
+        let begin_location = self.current_location();
         self.expect_keyword(Keyword::BEGIN_P)?;
 
-        self.parse_pl_block_body(label, declarations)
+        self.parse_pl_block_body(label, declarations, begin_location)
     }
 
     fn declaration_name(&self, decl: &PlDeclaration) -> Option<String> {
@@ -36,6 +37,7 @@ impl Parser {
         &mut self,
         label: Option<String>,
         declarations: Vec<PlDeclaration>,
+        begin_location: crate::token::SourceLocation,
     ) -> Result<PlBlock, ParserError> {
         self.enter_scope()?;
         self.push_scope();
@@ -44,7 +46,7 @@ impl Parser {
                 self.declare_var(&name);
             }
         }
-        let result = self.parse_pl_block_body_inner(label, declarations);
+        let result = self.parse_pl_block_body_inner(label, declarations, begin_location);
         self.pop_scope();
         self.leave_scope();
         result
@@ -54,6 +56,7 @@ impl Parser {
         &mut self,
         label: Option<String>,
         declarations: Vec<PlDeclaration>,
+        begin_location: crate::token::SourceLocation,
     ) -> Result<PlBlock, ParserError> {
         let mut body = Vec::new();
         let mut exception_block = None;
@@ -62,7 +65,7 @@ impl Parser {
             if matches!(self.peek(), Token::Eof) {
                 return Err(ParserError::UnexpectedToken {
                     location: self.current_location(),
-                    expected: "END".to_string(),
+                    expected: format!("END (to close BEGIN at line {})", begin_location.line),
                     got: "EOF".to_string(),
                 });
             }

--- a/src/parser/select.rs
+++ b/src/parser/select.rs
@@ -750,7 +750,11 @@ impl Parser {
                 self.leave_scope();
                 let query = query?;
                 self.expect_token(&Token::RParen)?;
-                let alias = self.parse_optional_alias()?;
+                let alias = if self.match_ident_str("PIVOT") || self.match_ident_str("UNPIVOT") {
+                    None
+                } else {
+                    self.parse_optional_alias()?
+                };
                 return Ok(TableRef::Subquery {
                     query: Box::new(query),
                     alias,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -3102,11 +3102,377 @@ fn test_cursor_decl_with_parsed_select() {
                         other => panic!("expected Select, got {:?}", other),
                     }
                 }
-                other => panic!("expected Cursor, got {:?}", other),
+                other => panic!("expected cursor declaration, got {:?}", other),
             }
         }
-        other => panic!("expected Do, got {:?}", other),
+        other => panic!("expected DO statement, got {:?}", other),
     }
+}
+
+fn parse_valid(sql: &str) -> Vec<Statement> {
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let hard_errors: Vec<_> = parser
+        .errors()
+        .iter()
+        .filter(|e| !matches!(e, ParserError::Warning { .. }))
+        .collect();
+    assert!(
+        hard_errors.is_empty(),
+        "SQL should parse without errors:\n  SQL: {}\n  Errors: {:?}",
+        sql,
+        hard_errors
+    );
+    assert!(
+        !stmts.is_empty(),
+        "SQL should produce at least one statement:\n  SQL: {}",
+        sql
+    );
+    stmts
+}
+
+fn assert_valid(sql: &str) {
+    parse_valid(sql);
+}
+
+// ============================================================
+// GaussDB Syntax Gap Tests (error-5.txt regression)
+// ============================================================
+
+// --- Category A: INSERT INTO table (SELECT ...) ---
+
+#[test]
+fn test_gaussdb_insert_select_no_columns() {
+    let stmts = parse_valid("INSERT INTO t1 (SELECT * FROM t2)");
+    match &stmts[0] {
+        Statement::Insert(ins) => {
+            assert!(ins.columns.is_empty(), "no column list expected");
+            match &ins.source {
+                InsertSource::Select(_) => {}
+                other => panic!("expected Select source, got {:?}", other),
+            }
+        }
+        other => panic!("expected Insert, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_insert_select_with_columns() {
+    let stmts = parse_valid("INSERT INTO t1 (a, b) (SELECT x, y FROM t2)");
+    match &stmts[0] {
+        Statement::Insert(ins) => {
+            assert_eq!(ins.columns.len(), 2);
+            match &ins.source {
+                InsertSource::Select(_) => {}
+                other => panic!("expected Select source, got {:?}", other),
+            }
+        }
+        other => panic!("expected Insert, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_insert_double_paren_select() {
+    let stmts = parse_valid("INSERT INTO t1 (a, b) ((SELECT x, y FROM t2))");
+    match &stmts[0] {
+        Statement::Insert(ins) => {
+            assert_eq!(ins.columns.len(), 2);
+            match &ins.source {
+                InsertSource::Select(_) => {}
+                other => panic!("expected Select source, got {:?}", other),
+            }
+        }
+        other => panic!("expected Insert, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_insert_select_no_columns_complex() {
+    let sql = "INSERT INTO par_fund_accnt_relation (SELECT v_row.seq_id, v_row.fund_code, v_row.accnt_book_code FROM sys_dummy)";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_insert_double_paren_select_complex() {
+    let sql = "INSERT INTO dat_fax_receive_info (col1, col2) ((SELECT v_fax_seq, t.fax_type FROM dat_fax_receive_info t WHERE t.fax_seq = p_fax_seq))";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_insert_select_nextval() {
+    let sql = "INSERT INTO dat_zl_accountinfo (SELECT seq_external_no.nextval, t.facctcode, t.facctname FROM dat_zl_accountinfo_temp t WHERE t.fund_id = v_fund_template)";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_insert_plain_select_still_works() {
+    let stmts = parse_valid("INSERT INTO t1 SELECT * FROM t2");
+    match &stmts[0] {
+        Statement::Insert(ins) => {
+            assert!(ins.columns.is_empty());
+            match &ins.source {
+                InsertSource::Select(_) => {}
+                other => panic!("expected Select source, got {:?}", other),
+            }
+        }
+        other => panic!("expected Insert, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_insert_values_still_works() {
+    let stmts = parse_valid("INSERT INTO t1 (a, b) VALUES (1, 2)");
+    match &stmts[0] {
+        Statement::Insert(ins) => {
+            assert_eq!(ins.columns.len(), 2);
+            match &ins.source {
+                InsertSource::Values(rows) => {
+                    assert_eq!(rows.len(), 1);
+                    assert_eq!(rows[0].len(), 2);
+                }
+                other => panic!("expected Values source, got {:?}", other),
+            }
+        }
+        other => panic!("expected Insert, got {:?}", other),
+    }
+}
+
+// --- Category B: Oracle (+) outer join ---
+
+#[test]
+fn test_gaussdb_oracle_plus_identifier() {
+    let sql = "SELECT * FROM t1, t2 WHERE t1.id = t2.id(+)";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let hard_errors: Vec<_> = parser
+        .errors()
+        .iter()
+        .filter(|e| !matches!(e, ParserError::Warning { .. }))
+        .collect();
+    assert!(hard_errors.is_empty(), "should have no hard errors: {:?}", hard_errors);
+    assert!(!stmts.is_empty());
+}
+
+#[test]
+fn test_gaussdb_oracle_plus_keyword_column() {
+    let sql = "SELECT * FROM t1, t2 WHERE LANGUAGE(+) = '02'";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let hard_errors: Vec<_> = parser
+        .errors()
+        .iter()
+        .filter(|e| !matches!(e, ParserError::Warning { .. }))
+        .collect();
+    assert!(hard_errors.is_empty(), "should have no hard errors: {:?}", hard_errors);
+    assert!(!stmts.is_empty());
+}
+
+#[test]
+fn test_gaussdb_oracle_plus_qualified_column() {
+    let sql = "SELECT * FROM t1, t2 WHERE t.code = exchange.coin_code(+)";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+    let hard_errors: Vec<_> = parser
+        .errors()
+        .iter()
+        .filter(|e| !matches!(e, ParserError::Warning { .. }))
+        .collect();
+    assert!(hard_errors.is_empty(), "should have no hard errors: {:?}", hard_errors);
+    assert!(!stmts.is_empty());
+}
+
+#[test]
+fn test_gaussdb_oracle_plus_emits_warning() {
+    let sql = "SELECT * FROM t1, t2 WHERE t1.id = t2.id(+)";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let _stmts = parser.parse();
+    let warnings: Vec<_> = parser
+        .errors()
+        .iter()
+        .filter(|e| matches!(e, ParserError::Warning { .. }))
+        .collect();
+    assert!(
+        warnings.iter().any(|w| w.to_string().contains("(+)")),
+        "should emit a warning mentioning (+): {:?}",
+        warnings
+    );
+}
+
+// --- Category C: PIVOT / UNPIVOT after subquery ---
+
+#[test]
+fn test_gaussdb_pivot_after_subquery() {
+    let sql = "SELECT * FROM (SELECT a, b FROM t) PIVOT(MAX(b) FOR a IN ('x', 'y'))";
+    let stmts = parse_valid(sql);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            match &sel.from[0] {
+                TableRef::Pivot { source, .. } => {
+                    match source.as_ref() {
+                        TableRef::Subquery { .. } => {}
+                        other => panic!("expected Subquery source, got {:?}", other),
+                    }
+                }
+                other => panic!("expected Pivot table ref, got {:?}", other),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_unpivot_after_subquery() {
+    let sql = "SELECT * FROM (SELECT * FROM t1 WHERE rownum = 1) UNPIVOT(val FOR name IN(col1, col2))";
+    let stmts = parse_valid(sql);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            match &sel.from[0] {
+                TableRef::Unpivot { source, .. } => {
+                    match source.as_ref() {
+                        TableRef::Subquery { .. } => {}
+                        other => panic!("expected Subquery source, got {:?}", other),
+                    }
+                }
+                other => panic!("expected Unpivot table ref, got {:?}", other),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_pivot_subquery_with_alias() {
+    let sql = "SELECT * FROM (SELECT a, b FROM t) s PIVOT(MAX(b) FOR a IN ('x'))";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_pivot_plain_table_still_works() {
+    let sql = "SELECT * FROM t PIVOT(MAX(b) FOR a IN ('x', 'y'))";
+    assert_valid(sql);
+}
+
+// --- Category D: IN ((SELECT...) UNION (SELECT...)) ---
+
+#[test]
+fn test_gaussdb_in_union_subquery() {
+    let sql = "SELECT * FROM t WHERE code IN ((SELECT code FROM t1) UNION (SELECT code FROM t2))";
+    let stmts = parse_valid(sql);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            match &sel.where_clause {
+                Some(Expr::InSubquery { negated, .. }) => {
+                    assert!(!negated);
+                }
+                Some(other) => panic!("expected InSubquery, got {:?}", other),
+                None => panic!("expected WHERE clause"),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_not_in_union_subquery() {
+    let sql = "SELECT * FROM t WHERE code NOT IN ((SELECT code FROM t1) UNION (SELECT code FROM t2))";
+    let stmts = parse_valid(sql);
+    match &stmts[0] {
+        Statement::Select(sel) => {
+            match &sel.where_clause {
+                Some(Expr::InSubquery { negated, .. }) => {
+                    assert!(negated);
+                }
+                Some(other) => panic!("expected InSubquery, got {:?}", other),
+                None => panic!("expected WHERE clause"),
+            }
+        }
+        other => panic!("expected Select, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gaussdb_in_plain_select_still_works() {
+    let sql = "SELECT * FROM t WHERE id IN (SELECT id FROM t1)";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_in_list_still_works() {
+    let sql = "SELECT * FROM t WHERE id IN (1, 2, 3)";
+    assert_valid(sql);
+}
+
+// --- Category E: ANY(VALUES(...)) ---
+
+#[test]
+fn test_gaussdb_any_values() {
+    let sql = "SELECT * FROM t WHERE 0 <> ANY(VALUES(1), (2), (3))";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_all_values() {
+    let sql = "SELECT * FROM t WHERE x > ALL(VALUES(10), (20))";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_any_values_complex_expr() {
+    let sql = "SELECT * FROM vv WHERE (0 <> ANY(VALUES(to_number(REPLACE(vv.deal_amount1, ',', ''))), (to_number(REPLACE(vv.deal_amount2, ',', '')))))";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_any_select_still_works() {
+    let sql = "SELECT * FROM t WHERE x = ANY(SELECT id FROM t1)";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_some_values() {
+    let sql = "SELECT * FROM t WHERE x > SOME(VALUES(1), (2))";
+    assert_valid(sql);
+}
+
+// --- Cross-category regression: error-5.txt representative cases ---
+
+#[test]
+fn test_gaussdb_error5_category_a_insert_parenthesized_select() {
+    assert_valid("INSERT INTO FUNDCODE_PRIV_FUNDKIND (SELECT p_targetuser_id, role_id FROM sys_dummy)");
+    assert_valid("INSERT INTO par_fund_accnt_relation (SELECT v_row.seq_id, v_row.fund_code, v_row.accnt_book_code FROM sys_dummy)");
+}
+
+#[test]
+fn test_gaussdb_error5_category_b_oracle_plus() {
+    let sql1 = "SELECT * FROM t1, t2 WHERE t.coin_code = exchange.coin_code(+)";
+    let sql2 = "SELECT * FROM t1, t2 WHERE LANGUAGE(+) = '02'";
+    assert_valid(sql1);
+    assert_valid(sql2);
+}
+
+#[test]
+fn test_gaussdb_error5_category_c_pivot_unpivot() {
+    let sql1 = "SELECT * FROM (SELECT * FROM t WHERE user_code = p_code) PIVOT(MIN(remark12) FOR remark11 IN ('1','2'))";
+    let sql2 = "SELECT * FROM (SELECT * FROM t1 WHERE rownum = 1) UNPIVOT(val FOR name IN(col1, col2))";
+    assert_valid(sql1);
+    assert_valid(sql2);
+}
+
+#[test]
+fn test_gaussdb_error5_category_d_union_in() {
+    let sql = "SELECT * FROM t WHERE code IN ((SELECT code FROM t1) UNION (SELECT code FROM t2))";
+    assert_valid(sql);
+}
+
+#[test]
+fn test_gaussdb_error5_category_e_any_values() {
+    let sql = "SELECT * FROM t WHERE 0 <> ANY(VALUES(1), (2), (3))";
+    assert_valid(sql);
 }
 
 #[test]

--- a/src/parser/utility/statements.rs
+++ b/src/parser/utility/statements.rs
@@ -789,7 +789,8 @@ impl Parser {
             }
         }
 
-        let block = self.parse_pl_block_body(None, Vec::new())?;
+        let begin_location = self.current_location();
+        let block = self.parse_pl_block_body(None, Vec::new(), begin_location)?;
         Ok(crate::ast::AnonyBlockStatement { block })
     }
 


### PR DESCRIPTION
## Summary

Eliminates all 15 errors from `error-5.txt` by adding parser support for 5 categories of GaussDB SQL syntax, and improves error messages for unclosed PL/pgSQL blocks.

### 5 GaussDB Syntax Gap Fixes

| # | Syntax | Error Count | Fix |
|---|--------|-------------|-----|
| A | `INSERT INTO t (SELECT...)` / `((SELECT...))` | 5 errors | Lookahead before column list + try-parse for double-paren |
| B | Oracle `(+)` outer join on keyword columns | 2 errors | Detect `(+)` in keyword-as-identifier handler |
| C | PIVOT/UNPIVOT after subquery in FROM | 4 errors | Guard before `parse_optional_alias` |
| D | `IN ((SELECT...) UNION (SELECT...))` | 1 error | Delegate to `parse_select_statement` for set operations |
| E | `ANY(VALUES(1),(2),(3))` | 2 errors | VALUES recognition via `parse_values_statement` |

### Error Message Improvement

Before: `expected END, got EOF`
After: `expected END (to close BEGIN at line 1735), got EOF`

### Commits

1. `fix(parser): support 5 GaussDB syntax gaps` — dml.rs, expr.rs, select.rs
2. `fix(parser): show BEGIN line number in unclosed PL/pgSQL block error messages` — plpgsql.rs, mod.rs, utility/statements.rs
3. `test(parser): add 30 tests for GaussDB syntax gap fixes and regression` — tests.rs

### Verification

- 1234 tests pass (30 new), 0 failures
- All 15 original errors from error-5.txt resolved
- Backward compatibility preserved (INSERT VALUES, INSERT plain SELECT, IN list, etc.)