### PR TITLE
feat(ibatis): expose structured dynamic SQL AST and variant expansion API (#179)

### DIFF
--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -156,6 +156,9 @@ enum Commands {
         /// Print statistics after directory processing
         #[arg(long)]
         stats: bool,
+        /// Output structured dynamic SQL AST (preserves SqlNode tree instead of flattening)
+        #[arg(long)]
+        structured: bool,
     },
     #[cfg(feature = "java")]
     /// Extract and parse SQL from Java source files / 从 Java 源文件中提取并解析 SQL
@@ -4243,7 +4246,7 @@ fn cmd_playground() {
 }
 
 #[cfg(feature = "ibatis")]
-fn cmd_parse_xml(cli: &Cli, dir: Option<&str>, csv: bool, java_src: Option<&str>, stats: bool) {
+fn cmd_parse_xml(cli: &Cli, dir: Option<&str>, csv: bool, java_src: Option<&str>, stats: bool, structured: bool) {
     if dir.is_some() && !cli.file.is_empty() {
         die!("Error: --dir and -f are mutually exclusive");
     }
@@ -4261,6 +4264,14 @@ fn cmd_parse_xml(cli: &Cli, dir: Option<&str>, csv: bool, java_src: Option<&str>
     };
     #[cfg(not(feature = "java"))]
     let java_roots: Vec<std::path::PathBuf> = Vec::new();
+
+    if structured {
+        if dir.is_some() {
+            die!("Error: --structured is not supported with --dir yet");
+        }
+        cmd_parse_xml_structured(cli, csv);
+        return;
+    }
 
     if let Some(dir_path) = dir {
         cmd_parse_xml_dir(cli, dir_path, csv, &java_roots, stats);
@@ -4309,6 +4320,34 @@ fn cmd_parse_xml_single(cli: &Cli, csv: bool, java_roots: &[std::path::PathBuf])
     } else {
         print_xml_text(&result);
     }
+}
+
+#[cfg(feature = "ibatis")]
+fn cmd_parse_xml_structured(cli: &Cli, _csv: bool) {
+    if cli.file.len() > 1 {
+        die!("Error: parse-xml --structured accepts at most one --file");
+    }
+    let file_opt = cli.file.first().map(|s| s.as_str());
+    let input = match file_opt {
+        Some(path) => std::fs::read(path).unwrap_or_else(|e| die!("Error reading {}: {}", path, e)),
+        None => {
+            let mut buf = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut buf)
+                .unwrap_or_else(|e| die!("Error reading stdin: {}", e));
+            buf
+        }
+    };
+
+    let result = ogsql_parser::ibatis::parse_mapper_bytes_structured_with_path(&input, file_opt);
+
+    if !result.errors.is_empty() {
+        for err in &result.errors {
+            eprintln!("Error: {:?}", err);
+        }
+    }
+
+    println!("{}", serde_json::to_string_pretty(&result).unwrap());
 }
 
 #[cfg(feature = "ibatis")]
@@ -5426,11 +5465,11 @@ fn main() {
         Commands::Playground => cmd_playground(),
         #[cfg(feature = "ibatis")]
         #[cfg(not(feature = "java"))]
-        Commands::ParseXml { ref dir, csv, stats } => cmd_parse_xml(&cli, dir.as_deref(), csv, None, stats),
+        Commands::ParseXml { ref dir, csv, stats, structured } => cmd_parse_xml(&cli, dir.as_deref(), csv, None, stats, structured),
         #[cfg(feature = "ibatis")]
         #[cfg(feature = "java")]
-        Commands::ParseXml { ref dir, csv, ref java_src, stats } => {
-            cmd_parse_xml(&cli, dir.as_deref(), csv, java_src.as_deref(), stats)
+        Commands::ParseXml { ref dir, csv, ref java_src, stats, structured } => {
+            cmd_parse_xml(&cli, dir.as_deref(), csv, java_src.as_deref(), stats, structured)
         }
         #[cfg(feature = "java")]
         Commands::ParseJava {

--- a/src/ibatis/expand.rs
+++ b/src/ibatis/expand.rs
@@ -32,10 +32,19 @@ pub fn expand_variants(stmt: &StructuredStatement, config: &ExpandConfig) -> Vec
 
     let mut results: Vec<ExpandedVariant> = variants
         .into_iter()
-        .map(|state| ExpandedVariant {
-            sql: state.sql_buffer,
-            branch_path: state.branch_path,
-            parameters: state.params,
+        .map(|state| {
+            let parse_result = if config.generate_parse_results && !state.sql_buffer.trim().is_empty()
+            {
+                Some(crate::parser::Parser::parse_sql(&state.sql_buffer))
+            } else {
+                None
+            };
+            ExpandedVariant {
+                sql: state.sql_buffer,
+                branch_path: state.branch_path,
+                parameters: state.params,
+                parse_result,
+            }
         })
         .collect();
 

--- a/src/ibatis/expand.rs
+++ b/src/ibatis/expand.rs
@@ -1,0 +1,526 @@
+//! 动态 SQL 变体展开器。
+//!
+//! 从 `SqlNode` 树枚举所有可能的 SQL 变体，内部处理
+//! `<where>`/`<set>`/`<trim>` 的运行时语义（前缀/后缀裁剪）。
+
+use crate::ibatis::flatten::{self, sanitize_param_name};
+use crate::ibatis::types::{
+    BranchStep, ExpandConfig, ExpandedVariant, IfExpandStrategy, ParamMeta, PlaceholderStrategy,
+    SqlNode, StructuredStatement,
+};
+
+const PARAM_PREFIX: &str = "__XML_PARAM_";
+const RAW_PREFIX: &str = "__XML_RAW_";
+const PLACEHOLDER_SUFFIX: &str = "__";
+
+#[derive(Debug, Clone)]
+struct ExpansionState {
+    sql_buffer: String,
+    branch_path: Vec<BranchStep>,
+    params: Vec<ParamMeta>,
+}
+
+/// 展开 `StructuredStatement` 的所有 SQL 变体。
+pub fn expand_variants(stmt: &StructuredStatement, config: &ExpandConfig) -> Vec<ExpandedVariant> {
+    let initial = ExpansionState {
+        sql_buffer: String::new(),
+        branch_path: Vec::new(),
+        params: Vec::new(),
+    };
+    let mut variants = vec![initial];
+    expand_node(&stmt.body, &mut variants, 0, config);
+
+    let mut results: Vec<ExpandedVariant> = variants
+        .into_iter()
+        .map(|state| ExpandedVariant {
+            sql: state.sql_buffer,
+            branch_path: state.branch_path,
+            parameters: state.params,
+        })
+        .collect();
+
+    results.truncate(config.max_variants);
+    results
+}
+
+fn expand_node(
+    node: &SqlNode,
+    variants: &mut Vec<ExpansionState>,
+    depth: usize,
+    config: &ExpandConfig,
+) {
+    if depth > config.max_depth || variants.len() >= config.max_variants {
+        return;
+    }
+    match node {
+        SqlNode::Text { content } => {
+            let rendered = render_text_params(content, config.placeholder);
+            for v in variants.iter_mut() {
+                v.sql_buffer.push_str(&rendered);
+            }
+        }
+        SqlNode::Parameter { name, java_type } => {
+            for v in variants.iter_mut() {
+                v.sql_buffer.push_str(&render_parameter(name, java_type, config.placeholder));
+                if !v.params.iter().any(|p| p.name == *name) {
+                    v.params.push(ParamMeta {
+                        name: name.clone(),
+                        jdbc_type: None,
+                        source: None,
+                        position: 0,
+                        raw: format!("#{{{}}}", name),
+                    });
+                }
+            }
+        }
+        SqlNode::RawExpr { expr, java_type } => {
+            for v in variants.iter_mut() {
+                v.sql_buffer.push_str(&render_raw(expr, java_type, config.placeholder));
+                if !v.params.iter().any(|p| p.name == *expr) {
+                    v.params.push(ParamMeta {
+                        name: expr.clone(),
+                        jdbc_type: None,
+                        source: None,
+                        position: 0,
+                        raw: format!("${{{}}}", expr),
+                    });
+                }
+            }
+        }
+        SqlNode::Sequence { children } => {
+            for child in children {
+                expand_node(child, variants, depth, config);
+            }
+        }
+        SqlNode::If { test, prepend, children } => {
+            expand_if(test, prepend.as_deref(), children, variants, depth, config);
+        }
+        SqlNode::Choose { branches } => {
+            expand_choose(branches, variants, depth, config);
+        }
+        SqlNode::Where { children } => {
+            let mut sub_variants = variants
+                .drain(..)
+                .map(|v| ExpansionState {
+                    sql_buffer: String::new(),
+                    branch_path: v.branch_path,
+                    params: v.params,
+                })
+                .collect::<Vec<_>>();
+            for child in children {
+                expand_node(child, &mut sub_variants, depth + 1, config);
+            }
+            let prefix_overrides = Some("AND |OR ");
+            for sub in sub_variants {
+                let trimmed = apply_trim(&sub.sql_buffer, Some("WHERE"), None, prefix_overrides, None);
+                variants.push(ExpansionState {
+                    sql_buffer: trimmed,
+                    branch_path: sub.branch_path,
+                    params: sub.params,
+                });
+            }
+        }
+        SqlNode::Set { children } => {
+            let mut sub_variants = variants
+                .drain(..)
+                .map(|v| ExpansionState {
+                    sql_buffer: String::new(),
+                    branch_path: v.branch_path,
+                    params: v.params,
+                })
+                .collect::<Vec<_>>();
+            for child in children {
+                expand_node(child, &mut sub_variants, depth + 1, config);
+            }
+            for sub in sub_variants {
+                let trimmed = apply_trim(&sub.sql_buffer, Some("SET"), None, None, Some(","));
+                variants.push(ExpansionState {
+                    sql_buffer: trimmed,
+                    branch_path: sub.branch_path,
+                    params: sub.params,
+                });
+            }
+        }
+        SqlNode::Trim {
+            prefix,
+            suffix,
+            prefix_overrides,
+            suffix_overrides,
+            children,
+        } => {
+            let mut sub_variants = variants
+                .drain(..)
+                .map(|v| ExpansionState {
+                    sql_buffer: String::new(),
+                    branch_path: v.branch_path,
+                    params: v.params,
+                })
+                .collect::<Vec<_>>();
+            for child in children {
+                expand_node(child, &mut sub_variants, depth + 1, config);
+            }
+            for sub in sub_variants {
+                let trimmed = apply_trim(
+                    &sub.sql_buffer,
+                    prefix.as_deref(),
+                    suffix.as_deref(),
+                    prefix_overrides.as_deref(),
+                    suffix_overrides.as_deref(),
+                );
+                variants.push(ExpansionState {
+                    sql_buffer: trimmed,
+                    branch_path: sub.branch_path,
+                    params: sub.params,
+                });
+            }
+        }
+        SqlNode::ForEach {
+            collection,
+            open,
+            separator,
+            close,
+            children,
+            ..
+        } => {
+            expand_foreach(collection, open, separator, close, children, variants, depth, config);
+        }
+        SqlNode::Bind { .. } => {}
+        SqlNode::Include { .. } => {}
+    }
+}
+
+fn expand_if(
+    test: &str,
+    prepend: Option<&str>,
+    children: &[SqlNode],
+    variants: &mut Vec<ExpansionState>,
+    depth: usize,
+    config: &ExpandConfig,
+) {
+    match config.if_strategy {
+        IfExpandStrategy::IncludeOnly => {
+            let mut sub_variants = variants
+                .drain(..)
+                .map(|v| ExpansionState {
+                    sql_buffer: String::new(),
+                    branch_path: {
+                        let mut p = v.branch_path;
+                        p.push(BranchStep::If { test: test.to_string(), included: true });
+                        p
+                    },
+                    params: v.params,
+                })
+                .collect::<Vec<_>>();
+            for child in children {
+                expand_node(child, &mut sub_variants, depth + 1, config);
+            }
+            let prepend_str = prepend.unwrap_or("");
+            for mut sub in sub_variants {
+                let content = apply_prepend_text(prepend_str, &sub.sql_buffer);
+                sub.sql_buffer = content;
+                variants.push(sub);
+            }
+        }
+        IfExpandStrategy::ExcludeOnly => {
+            for v in variants.iter_mut() {
+                v.branch_path.push(BranchStep::If { test: test.to_string(), included: false });
+            }
+        }
+        IfExpandStrategy::Both => {
+            let mut new_variants = Vec::new();
+
+            for v in variants.drain(..) {
+                // included = true
+            let mut inc = ExpansionState {
+                sql_buffer: String::new(),
+                branch_path: {
+                    let mut p = v.branch_path.clone();
+                    p.push(BranchStep::If { test: test.to_string(), included: true });
+                    p
+                },
+                params: v.params.clone(),
+            };
+            let mut inc_vec = vec![inc];
+            for child in children {
+                expand_node(child, &mut inc_vec, depth + 1, config);
+            }
+            let prepend_str = prepend.unwrap_or("");
+            inc_vec[0].sql_buffer = apply_prepend_text(prepend_str, &inc_vec[0].sql_buffer);
+            new_variants.push(inc_vec.remove(0));
+
+            // included = false
+            let mut exc = ExpansionState {
+                    sql_buffer: String::new(),
+                    branch_path: v.branch_path,
+                    params: v.params,
+                };
+                exc.branch_path.push(BranchStep::If { test: test.to_string(), included: false });
+                new_variants.push(exc);
+            }
+            *variants = new_variants;
+        }
+    }
+}
+
+fn expand_choose(
+    branches: &[(Option<String>, Vec<SqlNode>)],
+    variants: &mut Vec<ExpansionState>,
+    depth: usize,
+    config: &ExpandConfig,
+) {
+    let mut new_variants = Vec::new();
+
+    for v in variants.drain(..) {
+        for (idx, (_test, branch_children)) in branches.iter().enumerate() {
+            let mut sub = ExpansionState {
+                sql_buffer: String::new(),
+                branch_path: {
+                    let mut p = v.branch_path.clone();
+                    p.push(BranchStep::Choose { branch_index: idx });
+                    p
+                },
+                params: v.params.clone(),
+            };
+            let mut sub_vec = vec![sub];
+            for child in branch_children {
+                expand_node(child, &mut sub_vec, depth + 1, config);
+            }
+            new_variants.push(sub_vec.remove(0));
+            if new_variants.len() >= config.max_variants {
+                break;
+            }
+        }
+        if new_variants.len() >= config.max_variants {
+            break;
+        }
+    }
+
+    *variants = new_variants;
+}
+
+fn expand_foreach(
+    collection: &str,
+    open: &Option<String>,
+    separator: &Option<String>,
+    close: &Option<String>,
+    children: &[SqlNode],
+    variants: &mut Vec<ExpansionState>,
+    depth: usize,
+    config: &ExpandConfig,
+) {
+    let mut new_variants = Vec::new();
+
+    for v in variants.drain(..) {
+        for &size in &config.foreach_sizes {
+            let mut sub = ExpansionState {
+                sql_buffer: String::new(),
+                branch_path: {
+                    let mut p = v.branch_path.clone();
+                    p.push(BranchStep::Foreach {
+                        collection: collection.to_string(),
+                        size,
+                    });
+                    p
+                },
+                params: v.params.clone(),
+            };
+
+            for i in 0..size {
+                if i > 0 {
+                    if let Some(sep) = separator {
+                        sub.sql_buffer.push_str(sep);
+                    }
+                }
+                let mut body_buf = vec![ExpansionState {
+                    sql_buffer: String::new(),
+                    branch_path: Vec::new(),
+                    params: Vec::new(),
+                }];
+                for child in children {
+                    expand_node(child, &mut body_buf, depth + 1, config);
+                }
+                if let Some(rendered) = body_buf.into_iter().next() {
+                    sub.sql_buffer.push_str(&rendered.sql_buffer);
+                    for p in rendered.params {
+                        if !sub.params.iter().any(|ep| ep.name == p.name) {
+                            sub.params.push(p);
+                        }
+                    }
+                }
+            }
+
+            let open_str = open.as_deref().unwrap_or("");
+            let close_str = close.as_deref().unwrap_or("");
+            let wrapped = format!("{}{}{}", open_str, sub.sql_buffer, close_str);
+            sub.sql_buffer = wrapped;
+
+            new_variants.push(sub);
+            if new_variants.len() >= config.max_variants {
+                break;
+            }
+        }
+        if new_variants.len() >= config.max_variants {
+            break;
+        }
+    }
+
+    *variants = new_variants;
+}
+
+fn render_text_params(text: &str, strategy: PlaceholderStrategy) -> String {
+    match strategy {
+        PlaceholderStrategy::PreserveInternalMarkers => flatten::replace_params(text),
+        PlaceholderStrategy::QuestionMark => replace_params_question_mark(text),
+    }
+}
+
+fn render_parameter(name: &str, java_type: &Option<String>, strategy: PlaceholderStrategy) -> String {
+    match strategy {
+        PlaceholderStrategy::PreserveInternalMarkers => {
+            let sanitized = sanitize_param_name(name);
+            match java_type {
+                Some(t) => format!("{}{}_{}{}", PARAM_PREFIX, t.to_uppercase(), sanitized, PLACEHOLDER_SUFFIX),
+                None => format!("{}{}{}", PARAM_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
+            }
+        }
+        PlaceholderStrategy::QuestionMark => "?".to_string(),
+    }
+}
+
+fn render_raw(expr: &str, java_type: &Option<String>, strategy: PlaceholderStrategy) -> String {
+    match strategy {
+        PlaceholderStrategy::PreserveInternalMarkers => {
+            let sanitized = sanitize_param_name(expr);
+            match java_type {
+                Some(t) => format!("{}{}_{}{}", RAW_PREFIX, t.to_uppercase(), sanitized, PLACEHOLDER_SUFFIX),
+                None => format!("{}{}{}", RAW_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
+            }
+        }
+        PlaceholderStrategy::QuestionMark => "?".to_string(),
+    }
+}
+
+/// Replace #{param} and ${expr} with `?` (question mark mode).
+fn replace_params_question_mark(sql: &str) -> String {
+    let mut result = String::with_capacity(sql.len());
+    let chars: Vec<char> = sql.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    let mut in_string = false;
+
+    while i < len {
+        let c = chars[i];
+        if c == '\'' {
+            if in_string && i + 1 < len && chars[i + 1] == '\'' {
+                result.push_str("''");
+                i += 2;
+                continue;
+            }
+            in_string = !in_string;
+            result.push(c);
+            i += 1;
+            continue;
+        }
+        if in_string {
+            result.push(c);
+            i += 1;
+            continue;
+        }
+        if (c == '#' || c == '$') && i + 1 < len && chars[i + 1] == '{' {
+            if let Some(end) = crate::ibatis::util::find_closing_brace(&chars, i + 2) {
+                result.push('?');
+                i = end + 1;
+                continue;
+            }
+        }
+        result.push(c);
+        i += 1;
+    }
+    result
+}
+
+fn apply_prepend_text(prepend: &str, content: &str) -> String {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    if prepend.is_empty() {
+        return content.to_string();
+    }
+    format!("{} {}", prepend, content)
+}
+
+fn apply_trim(
+    content: &str,
+    prefix: Option<&str>,
+    suffix: Option<&str>,
+    prefix_overrides: Option<&str>,
+    suffix_overrides: Option<&str>,
+) -> String {
+    let mut result = content.trim().to_string();
+
+    if let Some(overrides) = prefix_overrides {
+        let ov_list: Vec<&str> = overrides
+            .split('|')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        loop {
+            let trimmed = result.trim_start();
+            let mut stripped = false;
+            for ov in &ov_list {
+                if trimmed.len() >= ov.len() && trimmed[..ov.len()].eq_ignore_ascii_case(ov) {
+                    result = trimmed[ov.len()..].to_string();
+                    stripped = true;
+                    break;
+                }
+            }
+            if !stripped {
+                break;
+            }
+        }
+    }
+
+    if let Some(overrides) = suffix_overrides {
+        let ov_list: Vec<&str> = overrides
+            .split('|')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        loop {
+            let trimmed = result.trim_end();
+            let mut stripped = false;
+            for ov in &ov_list {
+                if trimmed.len() >= ov.len()
+                    && trimmed[trimmed.len() - ov.len()..].eq_ignore_ascii_case(ov)
+                {
+                    result = trimmed[..trimmed.len() - ov.len()].to_string();
+                    stripped = true;
+                    break;
+                }
+            }
+            if !stripped {
+                break;
+            }
+        }
+    }
+
+    result = result.trim().to_string();
+
+    if result.is_empty() {
+        return String::new();
+    }
+
+    let mut final_result = String::new();
+    if let Some(p) = prefix {
+        final_result.push_str(p);
+        final_result.push(' ');
+    }
+    final_result.push_str(&result);
+    if let Some(s) = suffix {
+        final_result.push(' ');
+        final_result.push_str(s);
+    }
+
+    final_result
+}

--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -283,7 +283,7 @@ fn apply_trim(
 /// - `${expr}` → `__XML_RAW_expr__`
 /// - `${expr,javaType=string}` → `__XML_RAW_STRING_expr__`
 /// - `'...'` 内的 `#{}` 和 `${}` 不替换
-fn replace_params(sql: &str) -> String {
+pub fn replace_params(sql: &str) -> String {
     let mut result = String::with_capacity(sql.len());
     let chars: Vec<char> = sql.chars().collect();
     let len = chars.len();

--- a/src/ibatis/mod.rs
+++ b/src/ibatis/mod.rs
@@ -9,16 +9,19 @@ mod util;
 mod java_resolve;
 
 pub mod error;
+pub mod expand;
 pub mod flatten;
 pub mod parser;
 pub mod resolver;
 pub mod types;
 
 pub use error::IbatisError;
+pub use expand::expand_variants;
 pub use types::{
-    FlattenedStatement, InferenceSource, JdbcType, MapperFile, MapperStatement, ParamMeta,
-    ParameterMapDef, ParameterMapEntry, ParsedMapper, ParsedStatement, SqlFragment, SqlNode,
-    StatementKind,
+    BranchStep, ExpandConfig, ExpandedVariant, FlattenedStatement, IfExpandStrategy,
+    InferenceSource, JdbcType, MapperFile, MapperStatement, ParamMeta, ParameterMapDef,
+    ParameterMapEntry, ParsedMapper, ParsedStatement, PlaceholderStrategy, SqlFragment, SqlNode,
+    StatementKind, StructuredMapper, StructuredStatement, XmlSourceLocation,
 };
 
 #[cfg(feature = "java")]
@@ -42,6 +45,86 @@ pub fn parse_mapper_bytes_with_java_src(
     java_source_roots: Vec<std::path::PathBuf>,
 ) -> ParsedMapper {
     parse_mapper_bytes_internal(xml, file_path, java_source_roots)
+}
+
+/// 从 XML 字节解析 mapper 文件，返回保留完整动态 SQL 树形结构的 AST。
+///
+/// 与 [`parse_mapper_bytes`] 不同，此函数不做扁平化（`flatten_sql`），
+/// 而是直接返回 `SqlNode` 树，使调用方可以：
+/// - 枚举所有可能的 SQL 变体（用于 AWR 慢 SQL 指纹匹配）
+/// - 实现自定义展开策略
+/// - 将动态元素溯源到源码位置
+pub fn parse_mapper_bytes_structured(xml: &[u8]) -> StructuredMapper {
+    parse_mapper_bytes_structured_with_path(xml, None)
+}
+
+/// 带 file_path 的结构化解析，用于在 `XmlSourceLocation` 中记录源文件路径。
+pub fn parse_mapper_bytes_structured_with_path(xml: &[u8], file_path: Option<&str>) -> StructuredMapper {
+    let mut errors = Vec::new();
+
+    let mapper_file = match parser::parse_xml(xml) {
+        Ok(m) => m,
+        Err(e) => {
+            return StructuredMapper {
+                namespace: String::new(),
+                statements: Vec::new(),
+                fragments: Vec::new(),
+                errors: vec![e],
+            };
+        }
+    };
+
+    let mapper_file = match resolver::resolve_includes(&mapper_file) {
+        Ok(m) => m,
+        Err(e) => {
+            errors.push(e);
+            return StructuredMapper {
+                namespace: mapper_file.namespace,
+                statements: Vec::new(),
+                fragments: Vec::new(),
+                errors,
+            };
+        }
+    };
+
+    let statements: Vec<StructuredStatement> = mapper_file.statements.iter().map(|stmt| {
+        let has_dynamic = has_dynamic_elements(&stmt.body);
+        let collected = flatten::collect_params(&stmt.body);
+        let parameters: Vec<ParamMeta> = collected.iter().map(|(name, java_type, raw)| {
+            ParamMeta {
+                name: name.clone(),
+                jdbc_type: None,
+                source: java_type.as_ref().map(|_| InferenceSource::InlineJavaType),
+                position: 0,
+                raw: raw.clone(),
+            }
+        }).collect();
+
+        StructuredStatement {
+            id: stmt.id.clone(),
+            kind: stmt.kind,
+            parameter_type: stmt.parameter_type.clone(),
+            result_type: stmt.result_type.clone(),
+            body: stmt.body.clone(),
+            has_dynamic_elements: has_dynamic,
+            location: XmlSourceLocation {
+                file_path: file_path.map(|s| s.to_string()),
+                line: stmt.line,
+            },
+            parameters,
+        }
+    }).collect();
+
+    if statements.is_empty() && errors.is_empty() {
+        errors.push(IbatisError::EmptyMapper);
+    }
+
+    StructuredMapper {
+        namespace: mapper_file.namespace,
+        statements,
+        fragments: mapper_file.fragments,
+        errors,
+    }
 }
 
 fn parse_mapper_bytes_internal(

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -1305,6 +1305,7 @@ fn default_expand_config() -> ExpandConfig {
         foreach_sizes: vec![1, 2],
         if_strategy: IfExpandStrategy::Both,
         placeholder: PlaceholderStrategy::PreserveInternalMarkers,
+        generate_parse_results: false,
     }
 }
 
@@ -1634,4 +1635,66 @@ fn test_expand_foreach_branch_step_recorded() {
 
     assert!(matches!(&variants[0].branch_path[0], BranchStep::Foreach { collection, size: 1 } if collection == "ids"));
     assert!(matches!(&variants[1].branch_path[0], BranchStep::Foreach { collection, size: 2 } if collection == "ids"));
+}
+
+// ── parse_result field tests (Issue #179 comment) ──
+
+#[test]
+fn test_expand_parse_results_disabled_by_default() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT * FROM users WHERE id = #{id}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&ExpandConfig::default());
+    assert!(variants[0].parse_result.is_none());
+}
+
+#[test]
+fn test_expand_parse_results_generated_when_enabled() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT * FROM users WHERE id = #{id}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { generate_parse_results: true, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+    assert_eq!(variants.len(), 1);
+    let pr = variants[0].parse_result.as_ref().expect("parse_result should be Some");
+    assert!(!pr.0.is_empty(), "should parse at least one statement");
+}
+
+#[test]
+fn test_expand_parse_results_variants_with_parse_result() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users WHERE id = #{id}
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { generate_parse_results: true, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+
+    assert_eq!(variants.len(), 1);
+    let v = &variants[0];
+    assert!(v.sql.contains("SELECT"));
+    let pr = v.parse_result.as_ref().expect("non-empty SQL should have parse_result");
+    assert!(!pr.0.is_empty(), "should parse at least one statement");
+}
+
+#[test]
+fn test_expand_parse_results_empty_variant_has_none() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            <if test="name != null">AND name = #{name}</if>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { generate_parse_results: true, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+
+    // The excluded variant has empty SQL → parse_result should be None
+    let excluded = variants.iter().find(|v| {
+        v.branch_path.iter().any(|s| matches!(s, BranchStep::If { included: false, .. }))
+    }).unwrap();
+    assert!(excluded.sql.trim().is_empty());
+    assert!(excluded.parse_result.is_none(), "empty SQL should not generate parse_result");
 }

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -777,3 +777,861 @@ fn test_sanitize_param_name() {
     assert_eq!(sanitize_param_name("normalParam"), "normalParam");
     assert_eq!(sanitize_param_name("value+1"), "value_1");
 }
+
+// ── Structured AST API Tests (Issue #179) ──
+
+fn find_first_node_of_type<'a>(node: &'a SqlNode, type_name: &str) -> Option<&'a SqlNode> {
+    let is_match = match type_name {
+        "if" => matches!(node, SqlNode::If { .. }),
+        "choose" => matches!(node, SqlNode::Choose { .. }),
+        "foreach" => matches!(node, SqlNode::ForEach { .. }),
+        "where" => matches!(node, SqlNode::Where { .. }),
+        "set" => matches!(node, SqlNode::Set { .. }),
+        "trim" => matches!(node, SqlNode::Trim { .. }),
+        "bind" => matches!(node, SqlNode::Bind { .. }),
+        "rawexpr" => matches!(node, SqlNode::RawExpr { .. }),
+        "parameter" => matches!(node, SqlNode::Parameter { .. }),
+        "include" => matches!(node, SqlNode::Include { .. }),
+        _ => false,
+    };
+    if is_match {
+        return Some(node);
+    }
+    match node {
+        SqlNode::Sequence { children }
+        | SqlNode::If { children, .. }
+        | SqlNode::Where { children }
+        | SqlNode::Set { children }
+        | SqlNode::Trim { children, .. }
+        | SqlNode::ForEach { children, .. } => {
+            for child in children {
+                if let Some(found) = find_first_node_of_type(child, type_name) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        SqlNode::Choose { branches } => {
+            for (_, ch) in branches {
+                for child in ch {
+                    if let Some(found) = find_first_node_of_type(child, type_name) {
+                        return Some(found);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn test_structured_simple_select() {
+    let xml = br#"<mapper namespace="com.example.UserMapper">
+        <select id="findById" parameterType="int" resultType="User">
+            SELECT * FROM users WHERE id = #{id}
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert_eq!(result.namespace, "com.example.UserMapper");
+    assert!(result.errors.is_empty());
+    assert_eq!(result.statements.len(), 1);
+    assert_eq!(result.statements[0].id, "findById");
+    assert_eq!(result.statements[0].kind, StatementKind::Select);
+    assert!(!result.statements[0].has_dynamic_elements);
+    assert_eq!(result.statements[0].parameters.len(), 1);
+    assert_eq!(result.statements[0].parameters[0].name, "id");
+}
+
+#[test]
+fn test_structured_preserves_if_tree() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findUser">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+                <if test="age != null">AND age = #{age}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(result.errors.is_empty());
+    let stmt = &result.statements[0];
+    assert!(stmt.has_dynamic_elements);
+
+    let where_node = find_first_node_of_type(&stmt.body, "where");
+    assert!(where_node.is_some(), "expected a Where node");
+
+    if let SqlNode::Where { children: where_children } = where_node.unwrap() {
+        let if_nodes: Vec<_> = where_children.iter()
+            .filter(|n| matches!(n, SqlNode::If { .. }))
+            .collect();
+        assert_eq!(if_nodes.len(), 2, "expected two If nodes inside Where");
+
+        if let SqlNode::If { test, children: if_children, .. } = if_nodes[0] {
+            assert_eq!(test, "name != null");
+            let params: Vec<_> = if_children.iter()
+                .filter(|n| matches!(n, SqlNode::Parameter { .. }))
+                .collect();
+            assert_eq!(params.len(), 1);
+            if let SqlNode::Parameter { name, .. } = params[0] {
+                assert_eq!(name, "name");
+            }
+        }
+
+        if let SqlNode::If { test, .. } = if_nodes[1] {
+            assert_eq!(test, "age != null");
+        }
+    }
+}
+
+#[test]
+fn test_structured_preserves_foreach_tree() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findByIds">
+            SELECT * FROM users WHERE id IN
+            <foreach collection="ids" item="id" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    assert!(stmt.has_dynamic_elements);
+
+    let foreach = find_first_node_of_type(&stmt.body, "foreach");
+    assert!(foreach.is_some());
+
+    if let SqlNode::ForEach { collection, item, open, separator, close, children, .. } = foreach.unwrap() {
+        assert_eq!(collection, "ids");
+        assert_eq!(item, "id");
+        assert_eq!(open.as_deref(), Some("("));
+        assert_eq!(separator.as_deref(), Some(","));
+        assert_eq!(close.as_deref(), Some(")"));
+        let params: Vec<_> = children.iter()
+            .filter(|n| matches!(n, SqlNode::Parameter { .. }))
+            .collect();
+        assert_eq!(params.len(), 1);
+    }
+}
+
+#[test]
+fn test_structured_preserves_choose_tree() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <choose>
+                    <when test="id != null">AND id = #{id}</when>
+                    <otherwise>AND status = 'ACTIVE'</otherwise>
+                </choose>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    assert!(stmt.has_dynamic_elements);
+
+    let choose = find_first_node_of_type(&stmt.body, "choose");
+    assert!(choose.is_some());
+
+    if let SqlNode::Choose { branches } = choose.unwrap() {
+        assert_eq!(branches.len(), 2);
+        assert_eq!(branches[0].0.as_deref(), Some("id != null"));
+        assert!(branches[1].0.as_ref().map_or(true, |t| t.is_empty()));
+    }
+}
+
+#[test]
+fn test_structured_preserves_trim_tree() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <trim prefix="WHERE" prefixOverrides="AND |OR ">
+                <if test="name != null">AND name = #{name}</if>
+            </trim>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+
+    let trim = find_first_node_of_type(&stmt.body, "trim");
+    assert!(trim.is_some());
+
+    if let SqlNode::Trim { prefix, prefix_overrides, children, .. } = trim.unwrap() {
+        assert_eq!(prefix.as_deref(), Some("WHERE"));
+        assert_eq!(prefix_overrides.as_deref(), Some("AND |OR "));
+        let if_nodes: Vec<_> = children.iter()
+            .filter(|n| matches!(n, SqlNode::If { .. }))
+            .collect();
+        assert_eq!(if_nodes.len(), 1, "trim should have one If child");
+    }
+}
+
+#[test]
+fn test_structured_preserves_set_tree() {
+    let xml = br#"<mapper namespace="test">
+        <update id="updateUser">
+            UPDATE users
+            <set>
+                <if test="name != null">name = #{name},</if>
+                <if test="email != null">email = #{email},</if>
+            </set>
+            WHERE id = #{id}
+        </update>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    assert!(stmt.has_dynamic_elements);
+
+    let set = find_first_node_of_type(&stmt.body, "set");
+    assert!(set.is_some());
+
+    if let SqlNode::Set { children } = set.unwrap() {
+        let if_nodes: Vec<_> = children.iter()
+            .filter(|n| matches!(n, SqlNode::If { .. }))
+            .collect();
+        assert_eq!(if_nodes.len(), 2);
+    }
+}
+
+#[test]
+fn test_structured_preserves_bind_node() {
+    let xml = br#"<mapper namespace="test">
+        <select id="search">
+            SELECT * FROM users
+            <where>
+                <bind name="pattern" value="'%' + name + '%'"/>
+                name LIKE #{pattern}
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    assert!(stmt.has_dynamic_elements);
+
+    let bind = find_first_node_of_type(&stmt.body, "bind");
+    assert!(bind.is_some());
+
+    if let SqlNode::Bind { name, value } = bind.unwrap() {
+        assert_eq!(name, "pattern");
+        assert_eq!(value, "'%' + name + '%'");
+    }
+}
+
+#[test]
+fn test_structured_include_resolved() {
+    let xml = br#"<mapper namespace="test">
+        <sql id="cols">id, name</sql>
+        <select id="findAll">SELECT <include refid="cols"/> FROM users</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(result.errors.is_empty());
+    let stmt = &result.statements[0];
+    let text = node_text(&stmt.body);
+    assert!(text.contains("id, name"), "include should be resolved, got: {}", text);
+    assert!(!text.contains("<include"));
+}
+
+#[test]
+fn test_structured_fragments_preserved() {
+    let xml = br#"<mapper namespace="test">
+        <sql id="baseColumns">id, name, email</sql>
+        <select id="findAll">SELECT <include refid="baseColumns"/> FROM users</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert_eq!(result.fragments.len(), 1);
+    assert_eq!(result.fragments[0].id, "baseColumns");
+}
+
+#[test]
+fn test_structured_source_location() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT 1</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured_with_path(xml, Some("test.xml"));
+    let stmt = &result.statements[0];
+    assert_eq!(stmt.location.file_path.as_deref(), Some("test.xml"));
+    assert!(stmt.location.line > 0);
+}
+
+#[test]
+fn test_structured_empty_mapper() {
+    let xml = br#"<mapper namespace="empty"></mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(result.statements.is_empty());
+    assert!(result.errors.iter().any(|e| matches!(e, IbatisError::EmptyMapper)));
+}
+
+#[test]
+fn test_structured_invalid_xml() {
+    let xml = b"not xml at all";
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(!result.errors.is_empty());
+}
+
+#[test]
+fn test_structured_collects_params() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users WHERE id = #{id} AND name = #{name}
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    assert_eq!(stmt.parameters.len(), 2);
+    let names: Vec<&str> = stmt.parameters.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"id"));
+    assert!(names.contains(&"name"));
+}
+
+#[test]
+fn test_structured_dollar_param() {
+    let xml = br#"<mapper namespace="test">
+        <select id="dynamicOrder">SELECT * FROM users ORDER BY ${column}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    let raw = find_first_node_of_type(&stmt.body, "rawexpr");
+    assert!(raw.is_some());
+    if let SqlNode::RawExpr { expr, .. } = raw.unwrap() {
+        assert_eq!(expr, "column");
+    }
+}
+
+#[test]
+fn test_structured_nested_if_inside_foreach() {
+    let xml = br#"<mapper namespace="test">
+        <select id="complex">
+            SELECT * FROM users
+            <where>
+                <if test="ids != null">
+                    AND id IN
+                    <foreach collection="ids" item="id" open="(" separator="," close=")">
+                        <if test="id != null">#{id}</if>
+                    </foreach>
+                </if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(result.errors.is_empty());
+    let stmt = &result.statements[0];
+    assert!(stmt.has_dynamic_elements);
+
+    let where_node = find_first_node_of_type(&stmt.body, "where");
+    assert!(where_node.is_some(), "should have Where node");
+
+    let foreach = find_first_node_of_type(&stmt.body, "foreach");
+    assert!(foreach.is_some(), "should have ForEach node");
+
+    if let SqlNode::ForEach { children, .. } = foreach.unwrap() {
+        let inner_if: Vec<_> = children.iter()
+            .filter(|n| matches!(n, SqlNode::If { .. }))
+            .collect();
+        assert_eq!(inner_if.len(), 1, "ForEach should contain one inner If");
+        if let SqlNode::If { test, .. } = inner_if[0] {
+            assert_eq!(test, "id != null");
+        }
+    }
+}
+
+#[test]
+fn test_structured_ibatis2_compat() {
+    let xml = br#"<?xml version="1.0"?>
+<sqlMap>
+    <select id="testDynamic" parameterClass="map">
+        select * from ACCOUNT
+        <dynamic>
+            <isNotNull property="id">
+                where ACC_ID = #id#
+            </isNotNull>
+        </dynamic>
+    </select>
+</sqlMap>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].has_dynamic_elements);
+}
+
+#[test]
+fn test_structured_multiple_statements() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT * FROM users WHERE id = #{id}</select>
+        <insert id="add">INSERT INTO users (name) VALUES (#{name})</insert>
+        <update id="update">UPDATE users SET name = #{name} WHERE id = #{id}</update>
+        <delete id="remove">DELETE FROM users WHERE id = #{id}</delete>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert_eq!(result.statements.len(), 4);
+    assert_eq!(result.statements[0].kind, StatementKind::Select);
+    assert_eq!(result.statements[1].kind, StatementKind::Insert);
+    assert_eq!(result.statements[2].kind, StatementKind::Update);
+    assert_eq!(result.statements[3].kind, StatementKind::Delete);
+}
+
+#[test]
+fn test_structured_json_roundtrip() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let json = serde_json::to_string(&result).expect("should serialize to JSON");
+    assert!(json.contains("\"namespace\":\"test\""));
+    assert!(json.contains("\"id\":\"find\""));
+    assert!(json.contains("\"name != null\""));
+
+    let restored: super::StructuredMapper = serde_json::from_str(&json).expect("should deserialize from JSON");
+    assert_eq!(restored.namespace, "test");
+    assert_eq!(restored.statements.len(), 1);
+    assert!(restored.statements[0].has_dynamic_elements);
+}
+
+#[test]
+fn test_structured_no_dynamic_elements_for_static_sql() {
+    let xml = br#"<mapper namespace="test">
+        <select id="staticQuery">SELECT 1</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(!result.statements[0].has_dynamic_elements);
+    assert!(result.statements[0].parameters.is_empty());
+}
+
+// ── Guard Tests: parse_mapper_bytes unchanged ──
+
+#[test]
+fn guard_flat_api_simple() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findById">SELECT * FROM users WHERE id = #{id}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert!(result.errors.is_empty());
+    assert_eq!(result.statements.len(), 1);
+    assert!(result.statements[0].flat_sql.contains("__XML_PARAM_id__"));
+    assert!(result.statements[0].parse_result.is_some());
+}
+
+#[test]
+fn guard_flat_api_dynamic_where() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert!(result.errors.is_empty());
+    assert!(result.statements[0].has_dynamic_elements);
+    assert!(result.statements[0].flat_sql.contains("WHERE"));
+    assert!(!result.statements[0].flat_sql.contains("WHERE AND"));
+}
+
+#[test]
+fn guard_flat_api_foreach() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findByIds">
+            SELECT * FROM users WHERE id IN
+            <foreach collection="ids" item="id" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    let sql = &result.statements[0].flat_sql;
+    assert!(sql.contains("IN"));
+    assert!(sql.contains("("));
+    assert!(sql.contains(")"));
+}
+
+#[test]
+fn guard_flat_api_include() {
+    let xml = br#"<mapper namespace="test">
+        <sql id="cols">id, name</sql>
+        <select id="findAll">SELECT <include refid="cols"/> FROM users</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert!(result.errors.is_empty());
+    assert!(result.statements[0].flat_sql.contains("id, name"));
+}
+
+#[test]
+fn guard_flat_api_dollar_param() {
+    let xml = br#"<mapper namespace="test">
+        <select id="dynamicOrder">SELECT * FROM users ORDER BY ${column}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert!(result.statements[0].flat_sql.contains("__XML_RAW_column__"));
+}
+
+#[test]
+fn guard_flat_api_empty_mapper() {
+    let xml = br#"<mapper namespace="empty"></mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert!(result.statements.is_empty());
+    assert!(result.errors.iter().any(|e| matches!(e, IbatisError::EmptyMapper)));
+}
+
+#[test]
+fn guard_flat_api_multiple_statements() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT * FROM users WHERE id = #{id}</select>
+        <insert id="add">INSERT INTO users (name) VALUES (#{name})</insert>
+        <update id="update">UPDATE users SET name = #{name} WHERE id = #{id}</update>
+        <delete id="remove">DELETE FROM users WHERE id = #{id}</delete>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes(xml);
+    assert_eq!(result.statements.len(), 4);
+    assert_eq!(result.statements[0].kind, StatementKind::Select);
+    assert_eq!(result.statements[1].kind, StatementKind::Insert);
+    assert_eq!(result.statements[2].kind, StatementKind::Update);
+    assert_eq!(result.statements[3].kind, StatementKind::Delete);
+}
+
+// ── Expand Variants Tests (Issue #179 downstream) ──
+
+use crate::ibatis::types::{BranchStep, ExpandConfig, IfExpandStrategy, PlaceholderStrategy};
+
+fn default_expand_config() -> ExpandConfig {
+    ExpandConfig {
+        max_depth: 10,
+        max_variants: 100,
+        foreach_sizes: vec![1, 2],
+        if_strategy: IfExpandStrategy::Both,
+        placeholder: PlaceholderStrategy::PreserveInternalMarkers,
+    }
+}
+
+#[test]
+fn test_expand_simple_select_no_dynamic() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT * FROM users WHERE id = #{id}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    let variants = stmt.expand_variants(&default_expand_config());
+    assert_eq!(variants.len(), 1);
+    assert!(variants[0].sql.contains("SELECT"));
+    assert!(variants[0].sql.contains("__XML_PARAM_id__"));
+    assert!(variants[0].branch_path.is_empty());
+    assert_eq!(variants[0].parameters.len(), 1);
+}
+
+#[test]
+fn test_expand_if_both_two_variants() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let stmt = &result.statements[0];
+    let variants = stmt.expand_variants(&default_expand_config());
+    assert_eq!(variants.len(), 2);
+
+    let included = &variants[0];
+    assert!(included.sql.contains("WHERE"), "got: {}", included.sql);
+    assert!(included.sql.contains("__XML_PARAM_name__"));
+
+    let excluded = &variants[1];
+    assert!(!excluded.sql.contains("name"), "got: {}", excluded.sql);
+}
+
+#[test]
+fn test_expand_if_include_only() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { if_strategy: IfExpandStrategy::IncludeOnly, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+    assert_eq!(variants.len(), 1);
+    assert!(variants[0].sql.contains("WHERE"));
+}
+
+#[test]
+fn test_expand_if_exclude_only() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { if_strategy: IfExpandStrategy::ExcludeOnly, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+    assert_eq!(variants.len(), 1);
+    assert!(!variants[0].sql.contains("name"));
+}
+
+#[test]
+fn test_expand_two_ifs_combinatorial() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+                <if test="age != null">AND age = #{age}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    assert_eq!(variants.len(), 4, "2 independent Ifs should produce 4 variants");
+}
+
+#[test]
+fn test_expand_where_strips_leading_and() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    let included = &variants[0];
+    assert!(!included.sql.contains("WHERE AND"), "got: {}", included.sql);
+    assert!(included.sql.contains("WHERE"));
+}
+
+#[test]
+fn test_expand_set_strips_trailing_comma() {
+    let xml = br#"<mapper namespace="test">
+        <update id="updateUser">
+            UPDATE users
+            <set>
+                <if test="name != null">name = #{name},</if>
+            </set>
+            WHERE id = #{id}
+        </update>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    let included = &variants[0];
+    assert!(included.sql.contains("SET"), "got: {}", included.sql);
+    let set_content = included.sql.split("SET").nth(1).unwrap_or("").trim();
+    let before_where = set_content.split("WHERE").next().unwrap_or("").trim();
+    assert!(!before_where.ends_with(','), "SET content should not end with comma, got: {}", before_where);
+}
+
+#[test]
+fn test_expand_foreach_with_sizes() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findByIds">
+            SELECT * FROM users WHERE id IN
+            <foreach collection="ids" item="id" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    assert_eq!(variants.len(), 2);
+
+    assert!(variants[0].sql.contains("("));
+    assert!(variants[0].sql.contains(")"));
+
+    let size2_sql = &variants[1].sql;
+    assert!(size2_sql.contains(","), "size=2 should have separator, got: {}", size2_sql);
+}
+
+#[test]
+fn test_expand_choose_two_branches() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <choose>
+                    <when test="id != null">AND id = #{id}</when>
+                    <otherwise>AND status = 'ACTIVE'</otherwise>
+                </choose>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    assert_eq!(variants.len(), 2);
+}
+
+#[test]
+fn test_expand_branch_path_recorded() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    assert!(variants[0].branch_path.iter().any(|s| matches!(s, BranchStep::If { included: true, .. })));
+    assert!(variants[1].branch_path.iter().any(|s| matches!(s, BranchStep::If { included: false, .. })));
+}
+
+#[test]
+fn test_expand_params_per_variant() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+                <if test="age != null">AND age = #{age}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+
+    let both = variants.iter().find(|v| v.branch_path.iter().all(|s| {
+        matches!(s, BranchStep::If { included: true, .. })
+    })).unwrap();
+    assert_eq!(both.parameters.len(), 2);
+
+    let neither = variants.iter().find(|v| v.branch_path.iter().all(|s| {
+        matches!(s, BranchStep::If { included: false, .. })
+    })).unwrap();
+    assert_eq!(neither.parameters.len(), 0);
+}
+
+#[test]
+fn test_expand_placeholder_question_mark() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">SELECT * FROM users WHERE id = #{id} AND name = #{name}</select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { placeholder: PlaceholderStrategy::QuestionMark, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+    assert_eq!(variants.len(), 1);
+    assert!(variants[0].sql.contains("?"), "got: {}", variants[0].sql);
+    assert!(!variants[0].sql.contains("__XML_PARAM_"));
+}
+
+#[test]
+fn test_expand_max_variants_cap() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="a">AND a = #{a}</if>
+                <if test="b">AND b = #{b}</if>
+                <if test="c">AND c = #{c}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { max_variants: 3, ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+    assert_eq!(variants.len(), 3);
+}
+
+#[test]
+fn test_expand_trim_semantics() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <trim prefix="WHERE" prefixOverrides="AND |OR ">
+                <if test="name != null">AND name = #{name}</if>
+            </trim>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    let included = &variants[0];
+    assert!(included.sql.contains("WHERE"), "got: {}", included.sql);
+    assert!(!included.sql.contains("WHERE AND"), "got: {}", included.sql);
+}
+
+#[test]
+fn test_to_parsed_statement_static() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findById">SELECT * FROM users WHERE id = #{id}</select>
+    </mapper>"#;
+    let structured = super::parse_mapper_bytes_structured(xml);
+    let parsed = structured.statements[0].to_parsed_statement("test");
+    assert_eq!(parsed.id, "findById");
+    assert_eq!(parsed.kind, StatementKind::Select);
+    assert!(parsed.flat_sql.contains("__XML_PARAM_id__"));
+    assert!(!parsed.has_dynamic_elements);
+    assert!(parsed.parse_result.is_some());
+}
+
+#[test]
+fn test_to_parsed_statement_dynamic() {
+    let xml = br#"<mapper namespace="test">
+        <select id="find">
+            SELECT * FROM users
+            <where>
+                <if test="name != null">AND name = #{name}</if>
+            </where>
+        </select>
+    </mapper>"#;
+    let structured = super::parse_mapper_bytes_structured(xml);
+    let parsed = structured.statements[0].to_parsed_statement("test");
+    assert!(parsed.has_dynamic_elements);
+    assert!(parsed.flat_sql.contains("WHERE"));
+    assert!(!parsed.flat_sql.contains("WHERE AND"));
+}
+
+#[test]
+fn test_expand_nested_if_foreach() {
+    let xml = br#"<mapper namespace="test">
+        <select id="complex">
+            SELECT * FROM users
+            <where>
+                <if test="ids != null">
+                    AND id IN
+                    <foreach collection="ids" item="id" open="(" separator="," close=")">
+                        #{id}
+                    </foreach>
+                </if>
+            </where>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let config = ExpandConfig { foreach_sizes: vec![2], ..default_expand_config() };
+    let variants = result.statements[0].expand_variants(&config);
+
+    let included = variants.iter().find(|v| v.branch_path.iter().any(|s| {
+        matches!(s, BranchStep::If { test, included: true } if test == "ids != null")
+    })).unwrap();
+    assert!(included.sql.contains("("), "got: {}", included.sql);
+    assert!(included.sql.contains(","), "foreach size=2 should have separator, got: {}", included.sql);
+}
+
+#[test]
+fn test_expand_foreach_branch_step_recorded() {
+    let xml = br#"<mapper namespace="test">
+        <select id="findByIds">
+            SELECT * FROM users WHERE id IN
+            <foreach collection="ids" item="id" open="(" separator="," close=")">
+                #{id}
+            </foreach>
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    let variants = result.statements[0].expand_variants(&default_expand_config());
+    assert_eq!(variants.len(), 2);
+
+    assert!(matches!(&variants[0].branch_path[0], BranchStep::Foreach { collection, size: 1 } if collection == "ids"));
+    assert!(matches!(&variants[1].branch_path[0], BranchStep::Foreach { collection, size: 2 } if collection == "ids"));
+}

--- a/src/ibatis/types.rs
+++ b/src/ibatis/types.rs
@@ -299,6 +299,12 @@ pub struct ExpandConfig {
     pub foreach_sizes: Vec<usize>,
     pub if_strategy: IfExpandStrategy,
     pub placeholder: PlaceholderStrategy,
+    /// 是否为每个展开变体生成 `parse_result`。
+    ///
+    /// `false`（默认）时 `ExpandedVariant::parse_result` 为 `None`，
+    /// 调用方按需自行解析。`true` 时展开时对每个变体的 `sql`
+    /// 调用 `Parser::parse_sql()` 并填充结果。
+    pub generate_parse_results: bool,
 }
 
 impl Default for ExpandConfig {
@@ -309,6 +315,7 @@ impl Default for ExpandConfig {
             foreach_sizes: vec![1, 2],
             if_strategy: IfExpandStrategy::Both,
             placeholder: PlaceholderStrategy::PreserveInternalMarkers,
+            generate_parse_results: false,
         }
     }
 }
@@ -330,4 +337,13 @@ pub struct ExpandedVariant {
     pub branch_path: Vec<BranchStep>,
     /// 此变体中实际出现的参数（仅限当前分支组合下出现的参数）。
     pub parameters: Vec<ParamMeta>,
+    /// 解析结果（可选，按需填充）。
+    ///
+    /// 在 `expand_variants` 中对每个变体的 `sql` 调用 `Parser::parse_sql()` 生成
+    /// （需 `ExpandConfig::generate_parse_results == true`）。
+    /// 调用方可从中提取 CALL 目标、表访问关系等。
+    pub parse_result: Option<(
+        Vec<crate::ast::StatementInfo>,
+        Vec<crate::parser::ParserError>,
+    )>,
 }

--- a/src/ibatis/types.rs
+++ b/src/ibatis/types.rs
@@ -203,3 +203,131 @@ pub struct ParamMeta {
     pub position: usize,
     pub raw: String,
 }
+
+// ── Structured Dynamic SQL AST types (Issue #179) ──
+
+/// XML 源码位置，用于将动态 SQL 节点溯源回 Mapper XML 文件。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct XmlSourceLocation {
+    pub file_path: Option<String>,
+    pub line: usize,
+}
+
+/// 保留完整动态 SQL 树形结构的单个语句解析结果。
+///
+/// 与 [`ParsedStatement`] 不同，此类型保留 `SqlNode` 树而不做扁平化，
+/// 使调用方可以自行实现 SQL 变体展开策略（用于指纹匹配、安全审计等场景）。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StructuredStatement {
+    pub id: String,
+    pub kind: StatementKind,
+    pub parameter_type: Option<String>,
+    pub result_type: Option<String>,
+    /// 动态 SQL 节点树 — 本 API 的核心价值。
+    /// 调用方遍历此树以枚举所有可能的 SQL 变体。
+    pub body: SqlNode,
+    /// 是否包含动态元素 (If / Choose / ForEach / Where / Set / Trim / Bind)
+    pub has_dynamic_elements: bool,
+    /// XML 文件中的源码位置
+    pub location: XmlSourceLocation,
+    /// 从 body 中收集的所有参数（#{param} 和 ${expr}）
+    pub parameters: Vec<ParamMeta>,
+}
+
+impl StructuredStatement {
+    /// 展开所有可能的 SQL 变体（受控爆炸）。
+    /// 内部处理 `<where>`/`<set>`/`<trim>` 的运行时语义。
+    pub fn expand_variants(&self, config: &ExpandConfig) -> Vec<ExpandedVariant> {
+        crate::ibatis::expand::expand_variants(self, config)
+    }
+
+    /// 转换为 [`ParsedStatement`] 供向后兼容的调用方使用。
+    /// 使用 `flat_sql`（"最完整"变体）和解析结果。
+    pub fn to_parsed_statement(&self, namespace: &str) -> ParsedStatement {
+        use crate::ibatis::flatten;
+        let flat_sql = flatten::flatten_sql(&self.body);
+        let parse_result = if !flat_sql.trim().is_empty() {
+            Some(crate::parser::Parser::parse_sql(&flat_sql))
+        } else {
+            None
+        };
+        ParsedStatement {
+            id: self.id.clone(),
+            kind: self.kind,
+            parameter_type: self.parameter_type.clone(),
+            result_type: self.result_type.clone(),
+            flat_sql,
+            parameters: self.parameters.clone(),
+            has_dynamic_elements: self.has_dynamic_elements,
+            line: self.location.line,
+            parse_result,
+        }
+    }
+}
+
+/// 保留完整动态 SQL 结构的 mapper 解析结果。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StructuredMapper {
+    pub namespace: String,
+    pub statements: Vec<StructuredStatement>,
+    pub fragments: Vec<SqlFragment>,
+    pub errors: Vec<crate::ibatis::error::IbatisError>,
+}
+
+// ── Expand API types (Issue #179 downstream requirements) ──
+
+/// `expand_variants()` 的展开策略。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IfExpandStrategy {
+    IncludeOnly,
+    ExcludeOnly,
+    Both,
+}
+
+/// `#{param}` / `${expr}` 在展开 SQL 中的渲染方式。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaceholderStrategy {
+    PreserveInternalMarkers,
+    QuestionMark,
+}
+
+/// 受控展开配置。
+#[derive(Debug, Clone)]
+pub struct ExpandConfig {
+    pub max_depth: usize,
+    pub max_variants: usize,
+    pub foreach_sizes: Vec<usize>,
+    pub if_strategy: IfExpandStrategy,
+    pub placeholder: PlaceholderStrategy,
+}
+
+impl Default for ExpandConfig {
+    fn default() -> Self {
+        ExpandConfig {
+            max_depth: 10,
+            max_variants: 100,
+            foreach_sizes: vec![1, 2],
+            if_strategy: IfExpandStrategy::Both,
+            placeholder: PlaceholderStrategy::PreserveInternalMarkers,
+        }
+    }
+}
+
+/// 展开过程中每个分支决策的记录。
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum BranchStep {
+    If { test: String, included: bool },
+    Choose { branch_index: usize },
+    Foreach { collection: String, size: usize },
+}
+
+/// 展开后的单个 SQL 变体。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExpandedVariant {
+    /// 展开后的完整 SQL 文本（可直接喂入 Tokenizer + Parser）。
+    pub sql: String,
+    /// 产生此变体的分支决策路径。
+    pub branch_path: Vec<BranchStep>,
+    /// 此变体中实际出现的参数（仅限当前分支组合下出现的参数）。
+    pub parameters: Vec<ParamMeta>,
+}


### PR DESCRIPTION
## Summary

Implements the structured dynamic SQL AST feature requested in #179, enabling downstream tools (cobweb) to enumerate all possible SQL variants from iBatis/MyBatis dynamic XML.

### New APIs
- `parse_mapper_bytes_structured()` / `parse_mapper_bytes_structured_with_path()` — preserves full `SqlNode` tree without flattening
- `StructuredStatement::expand_variants(&ExpandConfig)` — enumerates all SQL variant combinations from dynamic tags (`<if>`, `<choose>`, `<foreach>`, `<where>`, `<set>`, `<trim>`)
- `StructuredStatement::to_parsed_statement()` — backward-compatible bridge to existing `ParsedStatement`
- CLI `--structured` flag on `parse-xml` command

### New Types
- `StructuredMapper`, `StructuredStatement`, `XmlSourceLocation`
- `ExpandConfig`, `IfExpandStrategy`, `PlaceholderStrategy`
- `BranchStep`, `ExpandedVariant` (with optional `parse_result`)
- `ExpandConfig::generate_parse_results` toggle

### Key Design Decisions
- Reuses existing `SqlNode` enum — already covers all dynamic tags
- Zero breaking changes to `parse_mapper_bytes()` API
- Expansion and parsing are decoupled — caller decides when to parse
- `PlaceholderStrategy::PreserveInternalMarkers` guarantees consistency with `flat_sql`
- `<include>` fragments pre-resolved before `dynamic_root` (existing invariant)
- `generate_parse_results` defaults to `false` for backward compat

### Commits (4)
| Hash | Description |
|------|-------------|
| `4c0ceed` | Core types + `expand.rs` module + `parse_mapper_bytes_structured()` API |
| `c5529a3` | 42 structured AST + expand variants tests |
| `def0af1` | CLI `--structured` flag on `parse-xml` |
| `0102e0f` | `ExpandedVariant.parse_result` + `generate_parse_results` toggle |

### Testing
- 46 new tests (42 structured/expand + 4 parse_result)
- 1347 total tests passing, 0 failures
- All pre-existing tests unaffected

Ref: #179