### PR TITLE
fix(validate): resolve strict mode false positives for declared variables and TYPE names (#181)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1950,6 +1950,7 @@ impl PlVariableValidator {
                             && !is_known_function(fname)
                             && !self.is_known_func(fname)
                             && !is_pl_builtin(fname)
+                            && !self.is_declared(fname)
                         {
                             self.errors.push(UndefinedVariableError {
                                 variable_name: fname.clone(),

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -1093,3 +1093,27 @@ fn test_strict_mode_flags_in_if_condition() {
     assert!(!func_errors.is_empty(), "strict mode should flag unknown function in IF condition");
     assert_eq!(func_errors[0].variable_name, "some_condition");
 }
+
+#[test]
+fn test_strict_mode_allows_declared_var_as_subscript() {
+    let (block, params) = parse_proc_validate(
+        "CREATE OR REPLACE PROCEDURE test_subscript IS v_arr INTEGER; result INTEGER; BEGIN result := v_arr(1); END;"
+    );
+    let strict = super::validate_pl_variables_with_extra_vars_and_funcs(&block, &params, &[], &[], true);
+    let func_errors: Vec<_> = strict.iter()
+        .filter(|e| e.kind == super::UndefinedRefKind::Function)
+        .collect();
+    assert!(func_errors.is_empty(), "declared variable used as subscript should not be flagged: {:?}", func_errors);
+}
+
+#[test]
+fn test_strict_mode_allows_param_as_subscript() {
+    let (block, params) = parse_proc_validate(
+        "CREATE OR REPLACE PROCEDURE test_param_subscript(p_arr IN INTEGER) IS result INTEGER; BEGIN result := p_arr(1); END;"
+    );
+    let strict = super::validate_pl_variables_with_extra_vars_and_funcs(&block, &params, &[], &[], true);
+    let func_errors: Vec<_> = strict.iter()
+        .filter(|e| e.kind == super::UndefinedRefKind::Function)
+        .collect();
+    assert!(func_errors.is_empty(), "parameter used as subscript should not be flagged: {:?}", func_errors);
+}

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -2899,6 +2899,15 @@ fn collect_defined_routine_names(stmts: &[ogsql_parser::StatementInfo]) -> Vec<S
                                 names.push(last.to_lowercase());
                             }
                         }
+                        ogsql_parser::ast::PackageItem::Type(t) => {
+                            let name = match t {
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::Record { name, .. } => name,
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::TableOf { name, .. } => name,
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::VarrayOf { name, .. } => name,
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::RefCursor { name } => name,
+                            };
+                            names.push(name.to_lowercase());
+                        }
                         _ => {}
                     }
                 }
@@ -2915,6 +2924,15 @@ fn collect_defined_routine_names(stmts: &[ogsql_parser::StatementInfo]) -> Vec<S
                             if let Some(last) = p.name.last() {
                                 names.push(last.to_lowercase());
                             }
+                        }
+                        ogsql_parser::ast::PackageItem::Type(t) => {
+                            let name = match t {
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::Record { name, .. } => name,
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::TableOf { name, .. } => name,
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::VarrayOf { name, .. } => name,
+                                ogsql_parser::ast::plpgsql::PlTypeDecl::RefCursor { name } => name,
+                            };
+                            names.push(name.to_lowercase());
                         }
                         _ => {}
                     }


### PR DESCRIPTION
## Summary

Fixes two false positive cases in `--strict` mode validation (follow-up to #182).

## Changes

### 1. Declared variable used as array subscript — `fix(analyzer)`
**Before:** `p_spectrum(i)` flagged as `undefined function 'p_spectrum'` even though `p_spectrum` is a declared VARRAY parameter.

**Fix:** Add `!self.is_declared(fname)` check in the `check_expr` FunctionCall branch. If the name is already a declared variable/parameter, it's array subscript access, not a function call.

### 2. TYPE constructor calls — `fix(validate)`
**Before:** `t_spectrum_array()` flagged as `undefined function 't_spectrum_array'` even though `TYPE t_spectrum_array IS VARRAY(4096) OF FLOAT8` is declared in the package spec.

**Fix:** `collect_defined_routine_names` now also extracts TYPE names from `PackageItem::Type` in both package specs and package bodies. TYPE names are included in the known functions list.

## Test Results

- `cargo test --lib` — 1259 passed
- 2 new regression tests for declared variable subscript access
- Manual test on `astro_functions_pkg.sql`: 13 errors → 0 errors (1 pre-existing warning)

```
$ ogsql validate --strict -f astro_functions_pkg.sql
VALID (1 warning(s)):
  warning: function mode requires exactly 1 argument(s) at line 558, column 67
```