### PR TITLE
feat(java): switch-expression and return-statement SQL extraction, cross-method PS backfill, 16 new tests

### DIFF
--- a/docs/plans/2026-05-29-cross-file-improvements.md
+++ b/docs/plans/2026-05-29-cross-file-improvements.md
@@ -1,0 +1,813 @@
+# 跨文件解析增强 实施计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 修复 9 个失败的跨文件/控制流诊断测试，将通过率从 82/91 提升到 89+/91。
+
+**Architecture:** 在现有 `CrossFileState` 基础上，新增 `field_access` 常量解析、参数名替换、传递式方法行为记录、继承方法导入四项能力。所有改动集中在 `extract.rs`、`method_call.rs`、`variable.rs`、`mod.rs`、`types.rs` 五个文件。
+
+**Tech Stack:** Rust, tree-sitter-java
+
+---
+
+## 当前状态
+
+| 分组 | 通过 | 失败 | 说明 |
+|------|------|------|------|
+| A-J (原始) | 40/40 | 0 | P0/P1/P2 改进全部通过 |
+| K-O (控制流) | 32/34 | 2 | m4(Java14 switch), o10(return SQL) |
+| P-Q (跨文件) | 10/17 | 7 | 本次目标 |
+| **总计** | **82/91** | **9** | |
+
+## 失败根因分类
+
+| 根因 | 影响测试 | 修复复杂度 | ROI |
+|------|---------|-----------|-----|
+| A: `field_access` 常量查找缺失 | P4, P5, P6, P11 | 低 | **最高（4 测试）** |
+| B: 跨文件 PS 参数名替换 | P7 | 中 | 高 |
+| C: 传递式方法行为记录 | P8 | 中 | 高 |
+| D: 继承方法导入 | P12 | 高 | 中 |
+| E: Java14 switch 表达式 | m4 | 中 | 低（边缘场景） |
+| F: return 语句中的 SQL | o10 | 中 | 低（边缘场景） |
+
+## 修复优先级
+
+| 优先级 | 修复项 | 预期效果 | 预计通过率 |
+|--------|--------|---------|-----------|
+| **XP0** | field_access 常量解析 | +4 测试 | 86/91 (95%) |
+| **XP1** | 跨文件参数名映射 | +1 测试 | 87/91 (96%) |
+| **XP2** | 传递式方法行为 | +1 测试 | 88/91 (97%) |
+| **XP3** | 继承方法导入 | +1 测试 | 89/91 (98%) |
+| ~~XP4~~ | ~~Java14 switch~~ | ~~+1 测试~~ | 暂缓 |
+| ~~XP5~~ | ~~return SQL~~ | ~~+1 测试~~ | 暂缓 |
+
+---
+
+## Task 1: `field_access` 常量解析 (XP0)
+
+**目标:** 让 `string_constants` 能解析 `SqlConstants.USER_QUERY` 形式的跨文件常量引用。
+
+**原理:** `string_constants` HashMap 的 key 当前是简单变量名（如 `USER_QUERY`）。跨文件场景中 tree-sitter 生成 `field_access` 节点，结构为：
+
+```
+field_access "SqlConstants.USER_QUERY"
+  identifier "SqlConstants"
+  . "."
+  identifier "USER_QUERY"
+```
+
+只需要取最后一段 `identifier`（`USER_QUERY`）去 `string_constants` 中查找即可。
+
+**Files:**
+- Modify: `src/java/extract.rs` — `collect_concat_parts` (2处 identifier 分支)
+- Modify: `src/java/method_call.rs` — `find_first_string_arg` (1处 identifier 分支)
+
+**Step 1: 添加 `resolve_field_access_constant` 辅助函数**
+
+在 `extract.rs` 的 `ExtractContext` impl 中添加：
+
+```rust
+/// 从 field_access 节点（如 `SqlConstants.USER_QUERY`）提取最后一段标识符，
+/// 然后在 string_constants 中查找对应的字符串值。
+fn resolve_field_access_constant(&self, node: Node) -> Option<String> {
+    if node.kind() != "field_access" {
+        return None;
+    }
+    // field_access 子节点: identifier "." identifier
+    // 取最后一个 identifier 作为常量名
+    let last_ident = node.child_by_field_name("field")
+        .unwrap_or_else(|| {
+            let mut cursor = node.walk();
+            node.children(&mut cursor)
+                .filter(|c| c.kind() == "identifier")
+                .last()
+                .unwrap_or(node)
+        });
+    let name = self.node_text(last_ident);
+    self.string_constants.get(&name).cloned()
+}
+```
+
+**注意:** tree-sitter-java 的 `field_access` 节点有 `field` 字段名指向最后一个 identifier。需验证。如果 `child_by_field_name("field")` 返回 None，则 fallback 到遍历子节点取最后一个 identifier。
+
+**Step 2: 在 `collect_concat_parts` 中添加 `field_access` 分支**
+
+位置：`extract.rs` 的 `collect_concat_parts` 函数，left 和 right 两处 match 各添加一个分支：
+
+```rust
+// left 侧（约 line 306 之后）
+"field_access" => {
+    if let Some(val) = self.resolve_field_access_constant(left) {
+        parts.push((val, false));
+    } else {
+        parts.push((self.make_placeholder_for_node(left), false));
+    }
+}
+
+// right 侧（约 line 330 之后）
+"field_access" => {
+    if let Some(val) = self.resolve_field_access_constant(right) {
+        parts.push((val, false));
+    } else {
+        parts.push((self.make_placeholder_for_node(right), false));
+    }
+}
+```
+
+**Step 3: 在 `find_first_string_arg` 中添加 `field_access` 分支**
+
+位置：`method_call.rs` 约 line 230
+
+```rust
+"field_access" => {
+    if let Some(val) = self.resolve_field_access_constant(child) {
+        return Some((val, false));
+    }
+}
+```
+
+**Step 4: 运行测试验证**
+
+```bash
+cargo test --features java --lib "diag_p4\|diag_p5\|diag_p6\|diag_p11" -- --nocapture
+```
+
+预期：4 个测试全部通过。
+
+**Step 5: 全量回归测试**
+
+```bash
+cargo test --features java --lib "diag_" 2>&1 | tail -5
+```
+
+预期：86 passed; 5 failed（P7, P8, P12, m4, o10）
+
+**Step 6: Commit**
+
+```bash
+git add src/java/extract.rs src/java/method_call.rs
+git commit -m "feat(java): add field_access constant resolution for cross-file scenarios
+
+Adds field_access node handling in collect_concat_parts and
+find_first_string_arg to resolve cross-file constant references
+like SqlConstants.USER_QUERY via string_constants lookup.
+
+Fixes: P4, P5, P6, P11 diagnostic tests (82/91 → 86/91)"
+```
+
+---
+
+## Task 2: 跨文件 PS 参数名映射 (XP1)
+
+**目标:** 当 `UserService.save(name, email)` 调用 `JdbcHelper.bindParams(ps, a, b)` 时，PS 的占位符应使用调用者的实参名（`name`, `email`），而非被调用者的形参名（`a`, `b`）。
+
+**原理:** 当前 `apply_pending_injections` 从 `MethodPsBehavior.setter_patterns` 中直接取 `var_name`（形参名 `a`, `b`）。跨文件场景需要做 **形参→实参 的映射替换**。
+
+当前数据流：
+```
+JdbcHelper.bindParams(ps, a, b):
+  record_method_behavior → key="bindParams:3", setter_patterns=[
+    Literal{index:1, var_name:"a"},
+    Literal{index:2, var_name:"b"}
+  ]
+
+UserService.save(name, email):
+  visit_method_invocation("JdbcHelper.bindParams(ps, name, email)")
+  → PendingInjection{method_name:"bindParams", arg_count:3}
+
+apply_pending_injections:
+  查找 "bindParams:3" → 得到 setter_patterns
+  用 var_name "a"/"b" 生成占位符 ← 错误！应该是 "name"/"email"
+```
+
+**核心思路:** `PendingInjection` 需要记录调用时的**实参列表**。`apply_pending_injections` 时，将 `setter_patterns` 中的形参名替换为对应位置的实参名。
+
+**Files:**
+- Modify: `src/java/method_call.rs` — `PendingInjection` 结构体、`visit_method_invocation`、`apply_pending_injections`
+
+**Step 1: 扩展 `PendingInjection` 结构体**
+
+```rust
+pub(super) struct PendingInjection {
+    pub(super) ps_var: String,
+    pub(super) method_name: String,
+    pub(super) arg_count: usize,
+    pub(super) extraction_idx: Option<usize>,
+    // 新增：记录调用时传入的非 PS 参数的表达式文本
+    pub(super) arg_expressions: Vec<String>,
+}
+```
+
+**Step 2: 在 `visit_method_invocation` 中收集实参**
+
+当前创建 `PendingInjection` 的代码（约 line 56-83）需要扩展，在遍历 arguments 时记录每个非标点参数的文本：
+
+```rust
+if let Some(args_node) = node.child_by_field_name("arguments") {
+    if args_node.kind() == "argument_list" {
+        let mut cursor = args_node.walk();
+        let mut found_ps_var: Option<String> = None;
+        let mut arg_count = 0usize;
+        let mut arg_expressions: Vec<String> = Vec::new();
+        for child in args_node.children(&mut cursor) {
+            if child.kind() == "," || child.kind() == "(" || child.kind() == ")" {
+                continue;
+            }
+            arg_count += 1;
+            let arg_text = self.node_text(child);
+            if child.kind() == "identifier" {
+                if self.ps_var_to_extraction.contains_key(&arg_text) {
+                    found_ps_var = Some(arg_text.clone());
+                }
+            }
+            arg_expressions.push(arg_text);
+        }
+        if let Some(ps_var) = found_ps_var {
+            let ext_idx = self.ps_var_to_extraction.get(&ps_var).copied();
+            self.pending_injections.push(PendingInjection {
+                ps_var,
+                method_name: method_name.clone(),
+                arg_count,
+                extraction_idx: ext_idx,
+                arg_expressions,
+            });
+        }
+    }
+}
+```
+
+**Step 3: 在 `apply_pending_injections` 中做参数名替换**
+
+关键逻辑：查找 `MethodPsBehavior` 中 `ps_param_index`（PS 参数在第几位），从 `arg_expressions` 中取对应位置的实参名。然后构建 `形参名→实参名` 的映射表，替换 `setter_patterns` 中的 `var_name`。
+
+```rust
+// 在 apply_pending_injections 中，获取 behavior 之后：
+let behavior = match behavior {
+    Some(b) => b,
+    None => {
+        self.apply_fallback_dynamic(ext_idx);
+        continue;
+    }
+};
+
+// 新增：构建 形参名→实参名 映射
+let param_to_arg = self.build_param_arg_mapping(&behavior, &injection.arg_expressions);
+
+// 然后在遍历 setter_patterns 时，用映射替换 var_name
+for pattern in &behavior.setter_patterns {
+    match pattern {
+        SetterPattern::Literal { index, java_type, var_name } => {
+            let resolved_name = var_name.as_ref()
+                .and_then(|name| param_to_arg.get(name).cloned())
+                .or_else(|| var_name.clone());
+            // ... 用 resolved_name 替代 var_name 生成占位符
+        }
+        // DynamicLoop 不变
+    }
+}
+```
+
+**需要新增辅助函数 `build_param_arg_mapping`：**
+
+```rust
+/// 根据 MethodPsBehavior 的形参信息和调用时的实参列表，
+/// 构建形参名→实参名的映射。
+fn build_param_arg_mapping(
+    &self,
+    behavior: &MethodPsBehavior,
+    arg_expressions: &[String],
+) -> HashMap<String, String> {
+    // behavior.ps_param_index: PS 变量在参数列表中的位置
+    // behavior.setter_patterns 中 Literal 的 var_name: 形参名
+    // arg_expressions: 调用时传入的实参文本列表
+    
+    let mut mapping = HashMap::new();
+    for pattern in &behavior.setter_patterns {
+        if let SetterPattern::Literal { var_name: Some(param_name), .. } = pattern {
+            // 形参名 param_name 对应哪个实参位置？
+            // 这个信息在 MethodPsBehavior 中没有直接记录。
+            // 需要扩展 MethodPsBehavior 来记录每个 setter 的形参索引。
+        }
+    }
+    mapping
+}
+```
+
+**问题：** 当前 `SetterPattern::Literal` 只存储 `var_name`（形参名），不存储形参在方法签名中的位置索引。无法做形参→实参映射。
+
+**解决方案：** 扩展 `SetterPattern::Literal`，增加 `param_index: Option<usize>` 字段，在 `record_method_behavior` 时记录。
+
+**Step 3a: 扩展 `SetterPattern::Literal`**
+
+```rust
+// types.rs
+pub enum SetterPattern {
+    Literal {
+        index: usize,        // JDBC 参数索引 (ps.setInt 的第一个参数)
+        java_type: String,   // Java 类型 (String, int 等)
+        var_name: Option<String>,  // 形参名
+        param_index: Option<usize>, // 新增：该形参在方法签名中的位置（0-based）
+    },
+    DynamicLoop {
+        java_type: String,
+    },
+}
+```
+
+**Step 3b: 修改 `record_method_behavior` 记录 `param_index`**
+
+在 `record_method_behavior`（extract.rs 约 line 634）中，遍历 `jdbc_param_map` 时，`var_name` 已经知道（就是形参名如 `a`、`b`）。需要在遍历 `formal_parameter` 时记录每个参数名到其索引的映射：
+
+```rust
+// 在 record_method_behavior 开头，遍历参数时：
+let mut param_name_to_index: HashMap<String, usize> = HashMap::new();
+// ... 在 for child in params_node.children 循环中 ...
+if let (Some(t), Some(v)) = (&type_name, &var_name) {
+    param_name_to_index.insert(v.clone(), param_idx);
+    // ...
+}
+
+// 然后在构建 setter_patterns 时：
+for ((var_name, _), info) in &self.jdbc_param_map {
+    if var_name == &ps_var {
+        let param_idx = param_name_to_index.get(&info.var_name).copied();
+        setter_patterns.push(SetterPattern::Literal {
+            index: info.index,
+            java_type: info.java_type.clone(),
+            var_name: Some(info.var_name.clone()),
+            param_index: param_idx,  // 新增
+        });
+    }
+}
+```
+
+**Step 3c: 完整的 `build_param_arg_mapping`**
+
+```rust
+fn build_param_arg_mapping(
+    &self,
+    behavior: &MethodPsBehavior,
+    arg_expressions: &[String],
+) -> HashMap<String, String> {
+    let mut mapping = HashMap::new();
+    for pattern in &behavior.setter_patterns {
+        if let SetterPattern::Literal {
+            var_name: Some(ref param_name),
+            param_index: Some(idx),
+            ..
+        } = pattern {
+            if let Some(arg_expr) = arg_expressions.get(*idx) {
+                // arg_expr 可能是 "name" 或 "email" 这样的简单标识符
+                // 也可能是复杂表达式如 "user.getName()"
+                // 对于简单标识符，直接使用；复杂表达式取最后一个段
+                let resolved = if arg_expr.contains('.') {
+                    arg_expr.rsplit('.').next().unwrap_or(arg_expr)
+                } else {
+                    arg_expr.as_str()
+                };
+                mapping.insert(param_name.clone(), resolved.to_string());
+            }
+        }
+    }
+    mapping
+}
+```
+
+**Step 4: 运行测试**
+
+```bash
+cargo test --features java --lib "diag_p7" -- --nocapture
+```
+
+预期：P7 通过，占位符为 `__JAVA_VAR_String_name__` 和 `__JAVA_VAR_String_email__`。
+
+**Step 5: 全量回归**
+
+```bash
+cargo test --features java --lib "diag_" 2>&1 | tail -5
+```
+
+预期：87 passed; 4 failed（P8, P12, m4, o10）
+
+**Step 6: Commit**
+
+```bash
+git commit -m "feat(java): cross-file PS parameter name substitution
+
+Extends PendingInjection with arg_expressions, adds param_index
+to SetterPattern::Literal, and builds param→arg mapping in
+apply_pending_injections for correct cross-file placeholder names.
+
+Fixes: P7 diagnostic test (86/91 → 87/91)"
+```
+
+---
+
+## Task 3: 传递式方法行为记录 (XP2)
+
+**目标:** 当 `UserService.process(ps, name, age)` 调用 `ParamBinder.bindUser(ps, name, age)` 时，自动为 `process` 方法生成 `method_behaviors` 条目，使其行为等同于 `bindUser`。
+
+**原理:** 当前 `record_method_behavior` 只记录**直接**包含 `ps.setXxx()` 调用的方法。委托方法（只调用其他 helper 方法）不会被记录。
+
+核心思路：在 `visit_method_invocation` 处理方法调用时，如果发现调用的目标方法已在 `method_behaviors` 中有记录，且当前方法有 PS 参数，则为当前方法创建一个"转发"的行为记录。
+
+**Files:**
+- Modify: `src/java/extract.rs` — `record_method_behavior` 或新增函数
+
+**Step 1: 在 `visit_method_invocation` 中检测委托调用**
+
+在 `method_call.rs` 的 `visit_method_invocation` 中，处理完 SB 操作和 PendingInjection 后，检查：
+
+```rust
+// 在 visit_method_invocation 末尾，检查是否需要记录委托方法行为
+self.maybe_record_delegation(node, &method_name);
+```
+
+新增函数：
+
+```rust
+/// 检查当前方法是否在委托调用另一个有 PS 行为的方法。
+/// 如果是，且当前方法也有 PS 参数，则为当前方法创建转发行为记录。
+fn maybe_record_delegation(&mut self, node: Node, called_method_name: &str) {
+    // 必须在方法体内才能记录
+    let current_method = match &self.method_name {
+        Some(m) => m.clone(),
+        None => return,
+    };
+
+    // 被调用方法必须在 method_behaviors 中有记录
+    let called_key = format!("{}:{}", called_method_name, self.count_args(node));
+    let called_behavior = self.method_behaviors.get(&called_key).cloned()
+        .or_else(|| self.method_behaviors.get(called_method_name).cloned());
+    let called_behavior = match called_behavior {
+        Some(b) => b,
+        None => return,
+    };
+
+    // 当前方法的参数中必须有 PreparedStatement
+    // 检查调用参数中是否有 PS 变量
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) if n.kind() == "argument_list" => n,
+        _ => return,
+    };
+
+    let mut cursor = args_node.walk();
+    let mut arg_exprs: Vec<String> = Vec::new();
+    let mut has_ps_arg = false;
+    for child in args_node.children(&mut cursor) {
+        if child.kind() == "," || child.kind() == "(" || child.kind() == ")" {
+            continue;
+        }
+        let text = self.node_text(child);
+        if child.kind() == "identifier" && self.ps_var_to_extraction.contains_key(&text) {
+            has_ps_arg = true;
+        }
+        arg_exprs.push(text);
+    }
+
+    if !has_ps_arg {
+        return;
+    }
+
+    // 为当前方法创建转发行为
+    // 当前方法签名中 PS 参数的位置和名字需要在当前方法上下文中推断
+    // 简化方案：直接克隆被调用方法的行为，但修改 ps_param_name 为当前方法中的 PS 变量名
+    let ps_var_in_call = arg_exprs.get(called_behavior.ps_param_index)
+        .cloned()
+        .unwrap_or_default();
+
+    // 构建参数映射：被调用方法形参 → 当前调用实参
+    let mut forwarded_patterns = called_behavior.setter_patterns.clone();
+    for pattern in &mut forwarded_patterns {
+        if let SetterPattern::Literal { var_name: Some(ref mut name), param_index, .. } = pattern {
+            if let Some(idx) = *param_index {
+                if let Some(arg) = arg_exprs.get(idx) {
+                    // 替换形参名为实参名
+                    let resolved = if arg.contains('.') {
+                        arg.rsplit('.').next().unwrap_or(arg)
+                    } else {
+                        arg.as_str()
+                    };
+                    *name = resolved.to_string();
+                }
+            }
+        }
+    }
+
+    // 计算当前方法的参数总数（需要从方法声明中获取，简化处理）
+    // 使用当前已知的 arg_count 作为 key
+    let total_args = arg_exprs.len();
+
+    // 记录为当前方法的行为
+    let key = format!("{}:{}", current_method, total_args);
+    self.method_behaviors.insert(key, MethodPsBehavior {
+        ps_param_index: called_behavior.ps_param_index, // 可能不准确，但已足够
+        ps_param_name: ps_var_in_call.clone(),
+        setter_patterns: forwarded_patterns,
+    });
+}
+
+fn count_args(&self, node: Node) -> usize {
+    let args_node = match node.child_by_field_name("arguments") {
+        Some(n) if n.kind() == "argument_list" => n,
+        _ => return 0,
+    };
+    let mut cursor = args_node.walk();
+    args_node.children(&mut cursor)
+        .filter(|c| c.kind() != "," && c.kind() != "(" && c.kind() != ")")
+        .count()
+}
+```
+
+**注意:** 这里的关键简化是：委托方法的行为直接从被委托方法克隆，形参名替换为实参名。这不需要解析当前方法的完整签名——因为我们已知调用时传入了什么参数。
+
+**Step 2: 运行测试**
+
+```bash
+cargo test --features java --lib "diag_p8" -- --nocapture
+```
+
+预期：P8 通过。
+
+**Step 3: 全量回归**
+
+```bash
+cargo test --features java --lib "diag_" 2>&1 | tail -5
+```
+
+预期：88 passed; 3 failed（P12, m4, o10）
+
+**Step 4: Commit**
+
+```bash
+git commit -m "feat(java): transitive method behavior recording for delegation chains
+
+When a method delegates to another method with known PS behavior,
+automatically records a forwarding behavior for the delegating method.
+Enables 3+ layer cross-file parameter resolution.
+
+Fixes: P8 diagnostic test (87/91 → 88/91)"
+```
+
+---
+
+## Task 4: 继承方法导入 (XP3)
+
+**目标:** 当 `UserDao extends BaseDao` 时，`UserDao` 能使用 `BaseDao` 中定义的方法行为。
+
+**原理:** tree-sitter-java 的 `class_declaration` 节点有 `superclass` 字段（类型为 `superclass`，内容如 `extends BaseDao`）。需要：
+
+1. 在 `CrossFileState` 中新增 `class_methods` 映射：`class_name → Vec<(method_name, param_count)>`
+2. 处理文件时，检测 `extends`，将父类的 `method_behaviors` 导入当前上下文
+3. 需要按类名限定 method_behaviors 的 key（如 `"BaseDao.buildSelect:0"`）
+
+**核心难点:** 当前 `method_behaviors` 的 key 是 `"methodName:paramCount"`，没有类名限定。如果多个类有同名方法会产生冲突。需要扩展 key 格式。
+
+**Files:**
+- Modify: `src/java/types.rs` — `CrossFileState` 新增字段
+- Modify: `src/java/mod.rs` — 文件处理后收集类→方法映射
+- Modify: `src/java/extract.rs` — `visit_type_declaration` 捕获 extends
+- Modify: `src/java/method_call.rs` — `apply_pending_injections` 查找父类方法
+
+**Step 1: 扩展 `CrossFileState`**
+
+```rust
+// mod.rs
+pub struct CrossFileState {
+    pub method_behaviors: HashMap<String, MethodPsBehavior>,
+    pub string_constants: HashMap<String, String>,
+    /// 类名 → 该类的父类名
+    pub class_parents: HashMap<String, String>,
+    /// 类名 → 该类定义的方法行为 key 列表
+    pub class_method_keys: HashMap<String, Vec<String>>,
+}
+```
+
+**Step 2: 在 `visit_type_declaration` 中捕获 extends**
+
+```rust
+// extract.rs — visit_type_declaration
+pub(super) fn visit_type_declaration(&mut self, node: Node) {
+    let old_class = self.class_name.clone();
+    let old_parent = self.current_parent_class.clone();
+
+    if let Some(name_node) = node.child_by_field_name("name") {
+        self.class_name = Some(self.node_text(name_node));
+
+        // 新增：捕获 extends
+        if let Some(sc_node) = node.child_by_field_name("superclass") {
+            // sc_node 是 "superclass" 类型，子节点: "extends" keyword + type_identifier
+            let mut cursor = sc_node.walk();
+            for child in sc_node.children(&mut cursor) {
+                if child.kind() == "type_identifier" {
+                    self.current_parent_class = Some(self.node_text(child));
+                    break;
+                }
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        self.visit(child);
+    }
+
+    self.class_name = old_class;
+    self.current_parent_class = old_parent;
+}
+```
+
+**Step 3: 在 `ExtractContext` 中新增字段**
+
+```rust
+// extract.rs
+pub(super) struct ExtractContext<'a> {
+    // ... 现有字段 ...
+    /// 当前类的父类名
+    pub(super) current_parent_class: Option<String>,
+    /// 当前类定义的方法行为 key（在 record_method_behavior 中收集）
+    pub(super) recorded_method_keys: Vec<(String, String)>, // (class_name, method_key)
+}
+```
+
+**Step 4: 修改 `record_method_behavior` 记录类名**
+
+```rust
+// 在 record_method_behavior 末尾，insert 之后：
+if let Some(class_name) = &self.class_name {
+    self.recorded_method_keys.push((class_name.clone(), key.clone()));
+}
+```
+
+**Step 5: 文件处理后更新 `CrossFileState`**
+
+在 `extract_sql_from_java_files_with_state` 中，文件处理完成后：
+
+```rust
+// 更新 class_parents
+if let Some(class_name) = &ctx.class_name {
+    if let Some(parent) = &ctx.current_parent_class {
+        state.class_parents.insert(class_name.clone(), parent.clone());
+    }
+}
+
+// 更新 class_method_keys
+for (class_name, method_key) in &ctx.recorded_method_keys {
+    state.class_method_keys
+        .entry(class_name.clone())
+        .or_default()
+        .push(method_key.clone());
+}
+```
+
+**Step 6: 在 `apply_pending_injections` 中查找父类方法**
+
+当在当前类的 `method_behaviors` 中找不到时，尝试查找父类的：
+
+```rust
+// 在 apply_pending_injections 中，behavior lookup 失败后：
+let behavior = self.method_behaviors.get(&behavior_key).cloned()
+    .or_else(|| self.method_behaviors.get(&injection.method_name).cloned())
+    .or_else(|| {
+        // 尝试从父类方法中查找
+        self.lookup_inherited_behavior(&injection.method_name, injection.arg_count)
+    });
+```
+
+新增 `lookup_inherited_behavior`：
+
+```rust
+fn lookup_inherited_behavior(&self, method_name: &str, arg_count: usize) -> Option<MethodPsBehavior> {
+    // 需要访问 class_parents 和 class_method_keys
+    // 但 ExtractContext 没有直接持有这些跨文件信息
+    // 解决方案：在文件处理开始时，将父类的 method_behaviors 合并进来
+    // 这需要在 extract_sql_from_java_files_with_state 中做预处理
+    unimplemented!()
+}
+```
+
+**更好的方案：预处理导入**
+
+在 `extract_sql_from_java_files_with_state` 中，创建 `ExtractContext` 之前，检查当前文件是否 extends 了某个已知类，如果是，将该类的 `method_behaviors` 复制一份（key 改为不带类名前缀）合并到当前 context：
+
+```rust
+// 在 for (file_path, source) in files 循环中，创建 ctx 之前：
+let mut extra_behaviors = HashMap::new();
+// 预解析文件获取 class 和 extends 信息
+if let Some(pre_tree) = parser.parse(source, None) {
+    if let Some(class_decl) = find_first_class_declaration(pre_tree.root_node()) {
+        if let Some(parent_name) = extract_superclass_name(class_decl, source) {
+            // 查找父类的方法
+            if let Some(parent_methods) = state.class_method_keys.get(&parent_name) {
+                for method_key in parent_methods {
+                    if let Some(behavior) = state.method_behaviors.get(method_key) {
+                        // 用去掉类名前缀的 key 存储
+                        let short_key = method_key.split(':').last()
+                            .unwrap_or(method_key)
+                            .to_string();
+                        extra_behaviors.insert(short_key, behavior.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+但这需要额外一次 parse（预解析），成本较高。
+
+**更优方案：在 CrossFileState 中用限定 key 存储，查找时 fallback**
+
+1. `record_method_behavior` 用限定 key `"ClassName.methodName:paramCount"` 存储
+2. 同时保留不带类名的 key 作为 fallback
+3. 查找时先查 `"ClassName.methodName:paramCount"`，再查 `"methodName:paramCount"`，再查父类的
+
+这样只需修改存储格式，不需要预解析。
+
+**Step 7: 运行测试**
+
+```bash
+cargo test --features java --lib "diag_p12" -- --nocapture
+```
+
+预期：P12 通过。
+
+**Step 8: 全量回归**
+
+```bash
+cargo test --features java --lib "diag_" 2>&1 | tail -5
+```
+
+预期：89 passed; 2 failed（m4, o10）
+
+**Step 9: Commit**
+
+```bash
+git commit -m "feat(java): inheritance method behavior import
+
+Tracks extends relationships in CrossFileState, qualifies
+method_behavior keys with class name, and falls back to parent
+class behaviors when resolving method calls in child classes.
+
+Fixes: P12 diagnostic test (88/91 → 89/91)"
+```
+
+---
+
+## Task 5: 全量验证与收尾
+
+**Step 1: 全量测试**
+
+```bash
+cargo test --features java --lib "diag_" 2>&1 | tail -5
+```
+
+预期：89 passed; 2 failed (m4, o10)
+
+**Step 2: 原始 1313 测试回归**
+
+```bash
+cargo test --features java --lib 2>&1 | grep "^test result" | head -1
+```
+
+预期：全部通过，无回归。
+
+**Step 3: 验证已知限制仍然正确记录**
+
+```bash
+cargo test --features java --lib "diag_m4\|diag_o10" -- --nocapture
+```
+
+确认 m4 和 o10 仍然失败，且失败消息准确描述了限制。
+
+**Step 4: 最终 Commit**
+
+```bash
+git commit -m "test(java): verify cross-file improvements — 89/91 pass
+
+89 pass / 2 known limitations (Java 14 switch expression, return SQL).
+No regressions in 1313 original tests."
+```
+
+---
+
+## 关键设计决策
+
+1. **`resolve_field_access_constant` 只取最后一段 identifier** — 不做类名匹配，因为同一文件内常量名通常唯一。如果未来有同名常量冲突，可扩展为全限定名匹配。
+
+2. **`SetterPattern::Literal` 新增 `param_index`** — 这是 Task 2 的基础，也是 Task 3 委托记录的基础。一次性添加，后续任务直接使用。
+
+3. **委托方法行为记录采用"克隆+替换"策略** — 不需要解析当前方法的完整签名，只利用调用时的实参信息。简化实现但可能遗漏边缘情况（如当前方法有额外的 PS 操作）。
+
+4. **继承采用"限定 key + fallback"策略** — 避免预解析文件的额外成本。限定 key 格式为 `"ClassName.methodName:paramCount"`，查找时逐级 fallback。
+
+5. **m4 和 o10 暂不修复** — Java 14 switch expression 和 return-SQL 属于边缘场景，ROI 不高，记录为已知限制。
+
+## 风险与缓解
+
+| 风险 | 概率 | 缓解 |
+|------|------|------|
+| `param_index` 添加导致现有代码编译错误 | 低 | 所有构造 `SetterPattern::Literal` 的地方都需要更新 |
+| 委托记录与直接 PS 操作冲突 | 中 | 如果方法既有直接 setXxx 又有委托调用，以直接操作为准 |
+| 继承 fallback 找到错误父类方法 | 低 | 限定 key 包含类名，fallback 只在非限定查找失败时触发 |
+| field_access 的 `field` 字段名在不同 tree-sitter-java 版本不同 | 低 | 添加 fallback 逻辑（遍历子节点取最后一个 identifier） |

--- a/src/java/extract.rs
+++ b/src/java/extract.rs
@@ -49,8 +49,10 @@ pub fn extract(
         pending_injections: Vec::new(),
         class_ps_to_extraction: HashMap::new(),
         dynamic_setters: Vec::new(),
+        string_constants: HashMap::new(),
     };
     ctx.visit(root);
+    ctx.apply_pending_injections();
     let extractions: Vec<ExtractedSql> = ctx
         .extractions
         .into_iter()
@@ -82,6 +84,7 @@ pub(super) struct ExtractContext<'a> {
     pub(super) pending_injections: Vec<PendingInjection>,
     pub(super) class_ps_to_extraction: HashMap<String, usize>,
     pub(super) dynamic_setters: Vec<(String, String)>,
+    pub(super) string_constants: HashMap<String, String>,
 }
 
 impl<'a> ExtractContext<'a> {
@@ -126,7 +129,6 @@ impl<'a> ExtractContext<'a> {
         for child in node.children(&mut cursor) {
             self.visit(child);
         }
-        self.apply_pending_injections();
         self.class_name = old_class;
     }
 
@@ -147,7 +149,7 @@ impl<'a> ExtractContext<'a> {
         for (k, v) in field_sql_vars {
             self.sql_vars.insert(k, v);
         }
-        let old_var_types = std::mem::take(&mut self.var_types);
+        let old_var_types = self.var_types.clone();
         let old_jdbc_param_map = std::mem::take(&mut self.jdbc_param_map);
         let old_ps_var_to_extraction = std::mem::take(&mut self.ps_var_to_extraction);
         let old_dynamic_setters = std::mem::take(&mut self.dynamic_setters);
@@ -165,12 +167,8 @@ impl<'a> ExtractContext<'a> {
                     for pc in child.children(&mut param_cursor) {
                         match pc.kind() {
                             "type_identifier"
-                            | "primitive_type"
                             | "generic_type"
-                            | "integral_type"
-                            | "floating_point_type"
-                            | "boolean_type"
-                            | "array_type" => {
+                            | "scoped_type_identifier" => {
                                 type_name = self.extract_type_name(pc);
                             }
                             "identifier" => {
@@ -216,7 +214,9 @@ impl<'a> ExtractContext<'a> {
 
         self.method_name = old_method;
         self.sql_vars = old_sql_vars;
-        self.var_types = old_var_types;
+        for (k, v) in old_var_types {
+            self.var_types.entry(k).or_insert(v);
+        }
         self.jdbc_param_map = old_jdbc_param_map;
         self.ps_var_to_extraction = old_ps_var_to_extraction;
         self.dynamic_setters = old_dynamic_setters;
@@ -245,6 +245,30 @@ impl<'a> ExtractContext<'a> {
                 let combined: String = parts.into_iter().map(|(s, _)| s).collect();
                 Some((combined, false))
             }
+            "ternary_expression" => {
+                let consequence = node.child_by_field_name("consequence");
+                let alternative = node.child_by_field_name("alternative");
+                let mut results = Vec::new();
+                if let Some(cons) = consequence {
+                    if let Some((sql, _)) = self.extract_string_value(cons) {
+                        if super::heuristics::looks_like_sql(&sql) {
+                            results.push(sql);
+                        }
+                    }
+                }
+                if let Some(alt) = alternative {
+                    if let Some((sql, _)) = self.extract_string_value(alt) {
+                        if super::heuristics::looks_like_sql(&sql) {
+                            results.push(sql);
+                        }
+                    }
+                }
+                if results.is_empty() {
+                    None
+                } else {
+                    Some((results.join(""), false))
+                }
+            }
             _ => None,
         }
     }
@@ -269,6 +293,21 @@ impl<'a> ExtractContext<'a> {
                 "binary_expression" => {
                     parts.extend(self.collect_concat_parts(left));
                 }
+                "identifier" => {
+                    let name = self.node_text(left);
+                    if let Some(val) = self.string_constants.get(&name) {
+                        parts.push((val.clone(), false));
+                    } else {
+                        parts.push((self.make_placeholder_for_node(left), false));
+                    }
+                }
+                "field_access" => {
+                    if let Some(val) = self.resolve_field_access_constant(left) {
+                        parts.push((val, false));
+                    } else {
+                        parts.push((self.make_placeholder_for_node(left), false));
+                    }
+                }
                 _ => {
                     parts.push((self.make_placeholder_for_node(left), false));
                 }
@@ -284,6 +323,21 @@ impl<'a> ExtractContext<'a> {
                 }
                 "binary_expression" => {
                     parts.extend(self.collect_concat_parts(right));
+                }
+                "identifier" => {
+                    let name = self.node_text(right);
+                    if let Some(val) = self.string_constants.get(&name) {
+                        parts.push((val.clone(), false));
+                    } else {
+                        parts.push((self.make_placeholder_for_node(right), false));
+                    }
+                }
+                "field_access" => {
+                    if let Some(val) = self.resolve_field_access_constant(right) {
+                        parts.push((val, false));
+                    } else {
+                        parts.push((self.make_placeholder_for_node(right), false));
+                    }
                 }
                 _ => {
                     parts.push((self.make_placeholder_for_node(right), false));
@@ -317,6 +371,11 @@ impl<'a> ExtractContext<'a> {
             | "integral_type"
             | "floating_point_type"
             | "boolean_type" => Some(self.node_text(node)),
+            "scoped_type_identifier" => {
+                let text = self.node_text(node);
+                let short = text.rsplit('.').next().unwrap_or(&text);
+                Some(short.to_string())
+            }
             "generic_type" => {
                 let mut cursor = node.walk();
                 for child in node.children(&mut cursor) {
@@ -583,7 +642,7 @@ impl<'a> ExtractContext<'a> {
                     let mut var_name: Option<String> = None;
                     for p in child.children(&mut pc) {
                         match p.kind() {
-                            "type_identifier" | "generic_type" => {
+                            "type_identifier" | "generic_type" | "scoped_type_identifier" => {
                                 type_name = self.extract_type_name(p);
                             }
                             "identifier" => {
@@ -637,13 +696,27 @@ impl<'a> ExtractContext<'a> {
             return;
         }
 
+        let total_params = {
+            let mut count = 0usize;
+            if let Some(params_node) = node.child_by_field_name("parameters") {
+                let mut cursor = params_node.walk();
+                for child in params_node.children(&mut cursor) {
+                    if child.kind() == "formal_parameter" {
+                        count += 1;
+                    }
+                }
+            }
+            count
+        };
+
         setter_patterns.sort_by_key(|p| match p {
             crate::java::types::SetterPattern::Literal { index, .. } => *index,
             crate::java::types::SetterPattern::DynamicLoop { .. } => usize::MAX,
         });
 
+        let key = format!("{}:{}", method_name_str, total_params);
         self.method_behaviors.insert(
-            method_name_str,
+            key,
             crate::java::types::MethodPsBehavior {
                 ps_param_index: ps_idx,
                 ps_param_name: ps_var,
@@ -655,10 +728,36 @@ impl<'a> ExtractContext<'a> {
     pub(super) fn node_text(&self, node: Node) -> String {
         self.source[node.byte_range()].to_string()
     }
+
+    fn resolve_field_access_constant(&self, node: Node) -> Option<String> {
+        if node.kind() != "field_access" {
+            return None;
+        }
+        let last_ident = node.child_by_field_name("field")
+            .or_else(|| {
+                let mut cursor = node.walk();
+                node.children(&mut cursor)
+                    .filter(|c| c.kind() == "identifier")
+                    .last()
+            });
+        match last_ident {
+            Some(n) => {
+                let name = self.node_text(n);
+                self.string_constants.get(&name).cloned()
+            }
+            None => None,
+        }
+    }
+}
+
+pub(crate) fn starts_with_sql_keyword(sql: &str) -> bool {
+    let first_word = sql.trim().split_whitespace().next().unwrap_or("");
+    let upper = first_word.to_uppercase();
+    matches!(upper.as_str(), "SELECT" | "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "WITH")
 }
 
 fn sanitize_var_name(var_name: &str) -> String {
-    var_name
+    let mapped: String = var_name
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '_' {
@@ -667,11 +766,22 @@ fn sanitize_var_name(var_name: &str) -> String {
                 '_'
             }
         })
-        .collect()
-}
-
-fn starts_with_sql_keyword(sql: &str) -> bool {
-    let first_word = sql.trim().split_whitespace().next().unwrap_or("");
-    let upper = first_word.to_uppercase();
-    matches!(upper.as_str(), "SELECT" | "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "WITH")
+        .collect();
+    let mut result = String::with_capacity(mapped.len());
+    let mut prev_underscore = false;
+    for c in mapped.chars() {
+        if c == '_' {
+            if !prev_underscore {
+                result.push(c);
+            }
+            prev_underscore = true;
+        } else {
+            result.push(c);
+            prev_underscore = false;
+        }
+    }
+    while result.ends_with('_') {
+        result.pop();
+    }
+    if result.is_empty() { "_".to_string() } else { result }
 }

--- a/src/java/extract.rs
+++ b/src/java/extract.rs
@@ -111,6 +111,12 @@ impl<'a> ExtractContext<'a> {
             "assignment_expression" => {
                 self.visit_assignment_expression(node);
             }
+            "return_statement" => {
+                self.visit_return_statement(node);
+            }
+            "switch_expression" => {
+                self.visit_switch_expression(node);
+            }
             _ => {
                 let mut cursor = node.walk();
                 for child in node.children(&mut cursor) {
@@ -130,6 +136,81 @@ impl<'a> ExtractContext<'a> {
             self.visit(child);
         }
         self.class_name = old_class;
+    }
+
+    pub(super) fn visit_switch_expression(&mut self, node: Node) {
+        let body = match node.child_by_field_name("body") {
+            Some(b) => b,
+            None => { self.recurse(node); return; }
+        };
+        let mut cursor = body.walk();
+        for child in body.children(&mut cursor) {
+            if child.kind() == "switch_rule" {
+                self.extract_switch_rule_sql(child);
+            } else if child.kind() == "switch_block_statement_group" {
+                self.recurse(child);
+            }
+        }
+    }
+
+    fn extract_switch_rule_sql(&mut self, rule: Node) {
+        let mut cursor = rule.walk();
+        for child in rule.children(&mut cursor) {
+            match child.kind() {
+                "expression_statement" => {
+                    let expr = child.children(&mut child.walk())
+                        .find(|c| c.kind() != ";");
+                    if let Some(expr_node) = expr {
+                        self.extract_expression_sql(expr_node, child.start_position().row + 1, child.start_position().column);
+                    }
+                }
+                "block" => self.recurse(child),
+                _ => {}
+            }
+        }
+    }
+
+    fn extract_expression_sql(&mut self, node: Node, line: usize, column: usize) {
+        let (sql_text, is_text_block) = match self.extract_string_value(node) {
+            Some(v) => v,
+            None => return,
+        };
+        if !super::heuristics::looks_like_sql(&sql_text) {
+            return;
+        }
+        let sql_kind = super::heuristics::detect_sql_kind_from_content(&sql_text);
+        let param_style = super::heuristics::detect_parameter_style(&sql_text);
+        let sql_converted = self.convert_placeholders(&sql_text);
+        let is_concatenated = node.kind() == "binary_expression";
+        let parse_result = self.try_parse_sql(&sql_converted, sql_kind);
+
+        self.extractions.push(ExtractedSql {
+            sql: sql_converted,
+            origin: SqlOrigin {
+                method: ExtractionMethod::Constant,
+                class_name: self.class_name.clone(),
+                method_name: self.method_name.clone(),
+                annotation_name: None,
+                api_method_name: None,
+                variable_name: None,
+                line,
+                column,
+            },
+            sql_kind,
+            parameter_style: param_style,
+            is_concatenated,
+            is_text_block,
+            parse_result,
+        });
+    }
+
+    pub(super) fn visit_return_statement(&mut self, node: Node) {
+        let value_node = node.children(&mut node.walk())
+            .find(|c| c.kind() != "return");
+        if let Some(value) = value_node {
+            self.extract_expression_sql(value, node.start_position().row + 1, node.start_position().column);
+        }
+        self.recurse(node);
     }
 
     pub(super) fn visit_method_declaration(&mut self, node: Node) {
@@ -168,7 +249,11 @@ impl<'a> ExtractContext<'a> {
                         match pc.kind() {
                             "type_identifier"
                             | "generic_type"
-                            | "scoped_type_identifier" => {
+                            | "scoped_type_identifier"
+                            | "primitive_type"
+                            | "integral_type"
+                            | "floating_point_type"
+                            | "boolean_type" => {
                                 type_name = self.extract_type_name(pc);
                             }
                             "identifier" => {
@@ -206,7 +291,9 @@ impl<'a> ExtractContext<'a> {
         // Backfill JDBC parameter type/name inference from setXxx() calls
         self.backfill_jdbc_params();
 
+        self.track_return_sql(node);
         self.record_method_behavior(node);
+        self.record_delegation_behavior(node);
 
         for (var, idx) in &self.ps_var_to_extraction {
             self.class_ps_to_extraction.insert(var.clone(), *idx);
@@ -269,6 +356,15 @@ impl<'a> ExtractContext<'a> {
                     Some((results.join(""), false))
                 }
             }
+            "field_access" => {
+                self.resolve_field_access_constant(node)
+                    .map(|v| (v, false))
+            }
+            "identifier" => {
+                let name = self.node_text(node);
+                self.string_constants.get(&name)
+                    .map(|v| (v.clone(), false))
+            }
             _ => None,
         }
     }
@@ -308,6 +404,18 @@ impl<'a> ExtractContext<'a> {
                         parts.push((self.make_placeholder_for_node(left), false));
                     }
                 }
+                "method_invocation" => {
+                    if let Some(name_n) = left.child_by_field_name("name") {
+                        let name = self.node_text(name_n);
+                        if let Some(val) = self.string_constants.get(&name) {
+                            parts.push((val.clone(), false));
+                        } else {
+                            parts.push((self.make_placeholder_for_node(left), false));
+                        }
+                    } else {
+                        parts.push((self.make_placeholder_for_node(left), false));
+                    }
+                }
                 _ => {
                     parts.push((self.make_placeholder_for_node(left), false));
                 }
@@ -335,6 +443,18 @@ impl<'a> ExtractContext<'a> {
                 "field_access" => {
                     if let Some(val) = self.resolve_field_access_constant(right) {
                         parts.push((val, false));
+                    } else {
+                        parts.push((self.make_placeholder_for_node(right), false));
+                    }
+                }
+                "method_invocation" => {
+                    if let Some(name_n) = right.child_by_field_name("name") {
+                        let name = self.node_text(name_n);
+                        if let Some(val) = self.string_constants.get(&name) {
+                            parts.push((val.clone(), false));
+                        } else {
+                            parts.push((self.make_placeholder_for_node(right), false));
+                        }
                     } else {
                         parts.push((self.make_placeholder_for_node(right), false));
                     }
@@ -420,11 +540,24 @@ impl<'a> ExtractContext<'a> {
 
     pub(super) fn make_placeholder_for_node(&self, node: Node) -> String {
         let var_name = self.node_text(node);
-        let sanitized = sanitize_var_name(&var_name);
+        let display_name = match node.kind() {
+            "field_access" => {
+                var_name.rsplit('.').next().unwrap_or(&var_name).to_string()
+            }
+            "method_invocation" => {
+                node.child_by_field_name("name")
+                    .map(|n| self.node_text(n))
+                    .unwrap_or_else(|| var_name.clone())
+            }
+            _ => var_name.clone(),
+        };
+        let sanitized = sanitize_var_name(&display_name);
         let inferred_type = self.infer_expression_type(node);
         match inferred_type {
             Some(t) => format!("__JAVA_VAR_{}_{}__", t, sanitized),
-            None => match self.var_types.get(&var_name) {
+            None => match self.var_types.get(&display_name)
+                .or_else(|| self.var_types.get(&var_name))
+            {
                 Some(t) => format!("__JAVA_VAR_{}_{}__", t, sanitized),
                 None => {
                     let default_type = self
@@ -631,6 +764,7 @@ impl<'a> ExtractContext<'a> {
 
         let mut ps_param_name: Option<String> = None;
         let mut ps_param_index: Option<usize> = None;
+        let mut param_name_to_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
 
         if let Some(params_node) = node.child_by_field_name("parameters") {
             let mut cursor = params_node.walk();
@@ -656,6 +790,7 @@ impl<'a> ExtractContext<'a> {
                             ps_param_name = Some(v.clone());
                             ps_param_index = Some(param_idx);
                         }
+                        param_name_to_idx.insert(v.clone(), param_idx);
                     }
                     param_idx += 1;
                 }
@@ -674,10 +809,13 @@ impl<'a> ExtractContext<'a> {
         let mut setter_patterns: Vec<crate::java::types::SetterPattern> = Vec::new();
         for ((var_name, _), info) in &self.jdbc_param_map {
             if var_name == &ps_var {
+                let pidx = info.var_name.as_ref()
+                    .and_then(|n| param_name_to_idx.get(n).copied());
                 setter_patterns.push(crate::java::types::SetterPattern::Literal {
                     index: info.index,
                     java_type: info.java_type.clone(),
                     var_name: info.var_name.clone(),
+                    param_index: pidx,
                 });
             }
         }
@@ -723,6 +861,110 @@ impl<'a> ExtractContext<'a> {
                 setter_patterns,
             },
         );
+    }
+
+    fn track_return_sql(&mut self, node: Node) {
+        let method_name_str = match &self.method_name {
+            Some(n) => n.clone(),
+            None => return,
+        };
+        let body = match node.child_by_field_name("body") {
+            Some(b) => b,
+            None => return,
+        };
+        let mut last_return: Option<Node> = None;
+        let mut cursor = body.walk();
+        for child in body.children(&mut cursor) {
+            if child.kind() == "return_statement" {
+                last_return = Some(child);
+            }
+        }
+        let ret_stmt = match last_return {
+            Some(n) => n,
+            None => return,
+        };
+        let ret_value = match ret_stmt.children(&mut ret_stmt.walk())
+            .find(|c| c.kind() != "return")
+        {
+            Some(n) => n,
+            None => return,
+        };
+        if let Some((sql_text, _)) = self.extract_string_value(ret_value) {
+            if super::heuristics::looks_like_sql(&sql_text) {
+                self.string_constants.insert(method_name_str, sql_text);
+            }
+        }
+    }
+
+    fn record_delegation_behavior(&mut self, node: Node) {
+        let method_name_str = match &self.method_name {
+            Some(n) => n.clone(),
+            None => return,
+        };
+        if self.method_behaviors.contains_key(&format!("{}:", method_name_str))
+            || self.method_behaviors.contains_key(&method_name_str) {
+            return;
+        }
+
+        let mut ps_param_index: Option<usize> = None;
+        if let Some(params_node) = node.child_by_field_name("parameters") {
+            let mut cursor = params_node.walk();
+            let mut idx = 0usize;
+            for child in params_node.children(&mut cursor) {
+                if child.kind() == "formal_parameter" {
+                    let mut pc = child.walk();
+                    let mut type_name: Option<String> = None;
+                    for p in child.children(&mut pc) {
+                        if p.kind() == "type_identifier" || p.kind() == "generic_type" || p.kind() == "scoped_type_identifier" {
+                            type_name = self.extract_type_name(p);
+                        }
+                    }
+                    if type_name.as_deref() == Some("PreparedStatement") {
+                        ps_param_index = Some(idx);
+                    }
+                    idx += 1;
+                }
+            }
+        }
+        let ps_idx = match ps_param_index {
+            Some(i) => i,
+            None => return,
+        };
+
+        let total_params = {
+            let mut count = 0usize;
+            if let Some(params_node) = node.child_by_field_name("parameters") {
+                let mut cursor = params_node.walk();
+                for child in params_node.children(&mut cursor) {
+                    if child.kind() == "formal_parameter" {
+                        count += 1;
+                    }
+                }
+            }
+            count
+        };
+
+        for injection in &self.pending_injections {
+            if injection.extraction_idx.is_some() {
+                continue;
+            }
+            let behavior_key = format!("{}:{}", injection.method_name, injection.arg_count);
+            let behavior = self.method_behaviors.get(&behavior_key)
+                .or_else(|| self.method_behaviors.get(&injection.method_name));
+            if let Some(behavior) = behavior {
+                if behavior.ps_param_index < injection.call_arg_names.len() {
+                    self.method_behaviors.insert(
+                        format!("{}:{}", method_name_str, total_params),
+                        crate::java::types::MethodPsBehavior {
+                            ps_param_index: ps_idx,
+                            ps_param_name: String::new(),
+                            setter_patterns: behavior.setter_patterns.clone(),
+                        },
+                    );
+                }
+                return;
+            }
+        }
     }
 
     pub(super) fn node_text(&self, node: Node) -> String {

--- a/src/java/heuristics.rs
+++ b/src/java/heuristics.rs
@@ -10,7 +10,8 @@ pub(super) enum NativeQueryFlag {
 }
 
 pub(super) fn looks_like_sql(text: &str) -> bool {
-    let upper = text.to_uppercase();
+    let normalized: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let upper = normalized.to_uppercase();
     SQL_KEYWORDS.iter().any(|kw| upper.contains(kw))
 }
 

--- a/src/java/method_call.rs
+++ b/src/java/method_call.rs
@@ -13,6 +13,7 @@ pub(super) struct PendingInjection {
     pub(super) method_name: String,
     pub(super) arg_count: usize,
     pub(super) extraction_idx: Option<usize>,
+    pub(super) call_arg_names: Vec<Option<String>>,
 }
 
 impl<'a> ExtractContext<'a> {
@@ -58,17 +59,28 @@ impl<'a> ExtractContext<'a> {
                 let mut cursor = args_node.walk();
                 let mut found_ps_var: Option<String> = None;
                 let mut arg_count = 0usize;
+                let mut call_arg_names: Vec<Option<String>> = Vec::new();
                 for child in args_node.children(&mut cursor) {
                     if child.kind() == "," || child.kind() == "(" || child.kind() == ")" {
                         continue;
                     }
                     arg_count += 1;
-                    if child.kind() == "identifier" {
-                        let arg_name = self.node_text(child);
-                        if self.ps_var_to_extraction.contains_key(&arg_name) {
-                            found_ps_var = Some(arg_name);
+                    let arg_name = match child.kind() {
+                        "identifier" => Some(self.node_text(child)),
+                        "field_access" => {
+                            child.child_by_field_name("field")
+                                .map(|n| self.node_text(n))
+                        }
+                        _ => None,
+                    };
+                    if let Some(ref name) = arg_name {
+                        if self.ps_var_to_extraction.contains_key(name)
+                            || self.var_types.get(name).map_or(false, |t| t == "PreparedStatement")
+                        {
+                            found_ps_var = Some(name.clone());
                         }
                     }
+                    call_arg_names.push(arg_name);
                 }
                 if let Some(ps_var) = found_ps_var {
                     let ext_idx = self.ps_var_to_extraction.get(&ps_var).copied();
@@ -77,6 +89,7 @@ impl<'a> ExtractContext<'a> {
                         method_name: method_name.clone(),
                         arg_count,
                         extraction_idx: ext_idx,
+                        call_arg_names,
                     });
                 }
             }
@@ -165,7 +178,6 @@ impl<'a> ExtractContext<'a> {
                 let extraction_idx = match pushed_extraction_idx {
                     Some(idx) => Some(idx),
                     None => {
-                        // First arg may be a tracked SQL variable; resolve its extraction index
                         let mut cursor = args_node.walk();
                         let mut found = None;
                         for child in args_node.children(&mut cursor) {
@@ -176,6 +188,21 @@ impl<'a> ExtractContext<'a> {
                                     break;
                                 }
                             }
+                            if child.kind() == "method_invocation" {
+                                if let Some(name_n) = child.child_by_field_name("name") {
+                                    if self.node_text(name_n) == "toString" {
+                                        if let Some(obj) = child.child_by_field_name("object") {
+                                            if obj.kind() == "identifier" {
+                                                let arg_name = self.node_text(obj);
+                                                if let Some(tracked) = self.sql_vars.get(&arg_name) {
+                                                    found = Some(tracked.extraction_index);
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                         found
                     }
@@ -183,6 +210,25 @@ impl<'a> ExtractContext<'a> {
                 if let Some(idx) = extraction_idx {
                     if let Some(&old_idx) = self.ps_var_to_extraction.get(&target_var) {
                         self.backfill_for_ps_var(&target_var, old_idx);
+                    }
+                    if let Some(ext) = self.extractions.get_mut(idx) {
+                        let mut param_num = 0usize;
+                        let mut result = String::with_capacity(ext.sql.len() + 200);
+                        let mut in_quote = false;
+                        for c in ext.sql.chars() {
+                            if c == '\'' {
+                                in_quote = !in_quote;
+                                result.push(c);
+                            } else if c == '?' && !in_quote {
+                                param_num += 1;
+                                result.push_str(&format!("__JAVA_VAR_JDBC_PARAM_{}__", param_num));
+                            } else {
+                                result.push(c);
+                            }
+                        }
+                        if param_num > 0 {
+                            ext.sql = result;
+                        }
                     }
                     self.ps_var_to_extraction.insert(target_var, idx);
                 }
@@ -326,6 +372,27 @@ impl<'a> ExtractContext<'a> {
             }
             "method_invocation" => {
                 node.child_by_field_name("name").map(|n| self.node_text(n))
+            }
+            "binary_expression" => {
+                let mut found = None;
+                let mut stack = vec![node];
+                while let Some(current) = stack.pop() {
+                    let mut cursor = current.walk();
+                    for child in current.children(&mut cursor) {
+                        match child.kind() {
+                            "identifier" => {
+                                found = Some(self.node_text(child));
+                                break;
+                            }
+                            "binary_expression" => stack.push(child),
+                            _ => {}
+                        }
+                    }
+                    if found.is_some() {
+                        break;
+                    }
+                }
+                found
             }
             _ => None,
         }
@@ -504,9 +571,19 @@ impl<'a> ExtractContext<'a> {
                         index,
                         java_type,
                         var_name,
+                        param_index,
                     } => {
                         let old = format!("__JAVA_VAR_JDBC_PARAM_{}__", index);
-                        let new = match var_name {
+                        let resolved_name = var_name.as_ref().and_then(|name| {
+                            param_index.and_then(|pidx| {
+                                injection.call_arg_names.get(pidx)
+                                    .and_then(|n| n.as_ref().map(|s| s.as_str()))
+                                    .filter(|actual| actual != &name.as_str())
+                            })
+                        });
+                        let resolved_name = resolved_name
+                            .or_else(|| var_name.as_ref().map(|n| n.as_str()));
+                        let new = match resolved_name {
                             Some(name) => {
                                 let sanitized = name
                                     .chars()

--- a/src/java/method_call.rs
+++ b/src/java/method_call.rs
@@ -11,6 +11,8 @@ use crate::java::types::*;
 pub(super) struct PendingInjection {
     pub(super) ps_var: String,
     pub(super) method_name: String,
+    pub(super) arg_count: usize,
+    pub(super) extraction_idx: Option<usize>,
 }
 
 impl<'a> ExtractContext<'a> {
@@ -21,7 +23,7 @@ impl<'a> ExtractContext<'a> {
         };
         let method_name = self.node_text(name_node);
 
-        if method_name == "append" || method_name == "insert" || method_name == "delete" {
+        if method_name == "append" || method_name == "insert" || method_name == "delete" || method_name == "replace" {
             if let Some(root_var) = self.find_method_chain_root(node) {
                 if self.sql_vars.contains_key(&root_var)
                     && self.sql_vars.get(&root_var).map_or(false, |v| v.is_string_builder)
@@ -55,10 +57,12 @@ impl<'a> ExtractContext<'a> {
             if args_node.kind() == "argument_list" {
                 let mut cursor = args_node.walk();
                 let mut found_ps_var: Option<String> = None;
+                let mut arg_count = 0usize;
                 for child in args_node.children(&mut cursor) {
                     if child.kind() == "," || child.kind() == "(" || child.kind() == ")" {
                         continue;
                     }
+                    arg_count += 1;
                     if child.kind() == "identifier" {
                         let arg_name = self.node_text(child);
                         if self.ps_var_to_extraction.contains_key(&arg_name) {
@@ -67,9 +71,12 @@ impl<'a> ExtractContext<'a> {
                     }
                 }
                 if let Some(ps_var) = found_ps_var {
+                    let ext_idx = self.ps_var_to_extraction.get(&ps_var).copied();
                     self.pending_injections.push(PendingInjection {
                         ps_var,
                         method_name: method_name.clone(),
+                        arg_count,
+                        extraction_idx: ext_idx,
                     });
                 }
             }
@@ -194,6 +201,27 @@ impl<'a> ExtractContext<'a> {
             match child.kind() {
                 "string_literal" | "binary_expression" => {
                     return self.extract_string_value(child);
+                }
+                "identifier" => {
+                    let name = self.node_text(child);
+                    if let Some(val) = self.string_constants.get(&name) {
+                        return Some((val.clone(), false));
+                    }
+                }
+                "field_access" => {
+                    let last_ident = child.child_by_field_name("field")
+                        .or_else(|| {
+                            let mut c = child.walk();
+                            child.children(&mut c)
+                                .filter(|n| n.kind() == "identifier")
+                                .last()
+                        });
+                    if let Some(n) = last_ident {
+                        let name = self.node_text(n);
+                        if let Some(val) = self.string_constants.get(&name) {
+                            return Some((val.clone(), false));
+                        }
+                    }
                 }
                 _ => continue,
             }
@@ -451,12 +479,18 @@ impl<'a> ExtractContext<'a> {
     pub(super) fn apply_pending_injections(&mut self) {
         let injections = std::mem::take(&mut self.pending_injections);
         for injection in injections {
-            let ext_idx = match self.class_ps_to_extraction.get(&injection.ps_var) {
-                Some(&idx) => idx,
-                None => continue,
+            let ext_idx = match injection.extraction_idx {
+                Some(idx) => idx,
+                None => match self.class_ps_to_extraction.get(&injection.ps_var) {
+                    Some(&idx) => idx,
+                    None => continue,
+                },
             };
-            let behavior = match self.method_behaviors.get(&injection.method_name) {
-                Some(b) => b.clone(),
+            let behavior_key = format!("{}:{}", injection.method_name, injection.arg_count);
+            let behavior = self.method_behaviors.get(&behavior_key).cloned()
+                .or_else(|| self.method_behaviors.get(&injection.method_name).cloned());
+            let behavior = match behavior {
+                Some(b) => b,
                 None => {
                     self.apply_fallback_dynamic(ext_idx);
                     continue;

--- a/src/java/mod.rs
+++ b/src/java/mod.rs
@@ -1,7 +1,6 @@
 //! Java 源码 SQL 提取支持。
-//!
-//! 从 Java 源文件中提取嵌入在注解、方法调用参数、字符串常量中的 SQL 语句，
-//! 并将提取的 SQL 馈入核心 Parser 得到结构化 AST。
+
+use tree_sitter::Parser;
 
 pub mod error;
 pub mod extract;
@@ -22,15 +21,10 @@ pub use mapper_interface::{
     MapperInterfaceInfo, MapperMethodInfo, MethodParam, parse_mapper_interface,
 };
 pub use types::{
-    ExtractedSql, ExtractionMethod, JavaExtractConfig, JavaExtractResult, ParameterStyle, SqlKind,
-    SqlOrigin, SqlParseResult,
+    CrossFileState, ExtractedSql, ExtractionMethod, JavaExtractConfig, JavaExtractResult,
+    MethodPsBehavior, ParameterStyle, SetterPattern, SqlKind, SqlOrigin, SqlParseResult,
 };
 
-use tree_sitter::Parser;
-
-/// 从 Java 源码字节提取 SQL。
-///
-/// 接受 UTF-8 字符串，返回提取结果。
 pub fn extract_sql_from_java(
     source: &str,
     file_path: &str,
@@ -57,5 +51,92 @@ pub fn extract_sql_from_java(
     extract::extract(source, tree.root_node(), file_path, config)
 }
 
+pub fn extract_sql_from_java_files(
+    files: &[(&str, &str)],
+    config: &JavaExtractConfig,
+) -> Vec<JavaExtractResult> {
+    let mut state = CrossFileState::default();
+    extract_sql_from_java_files_with_state(files, config, &mut state)
+}
+
+pub fn extract_sql_from_java_files_with_state(
+    files: &[(&str, &str)],
+    config: &JavaExtractConfig,
+    state: &mut CrossFileState,
+) -> Vec<JavaExtractResult> {
+    let mut results = Vec::new();
+    let mut parser = Parser::new();
+    parser
+        .set_language(&tree_sitter_java::LANGUAGE.into())
+        .expect("Failed to set Java language for tree-sitter");
+
+    for (file_path, source) in files {
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => {
+                results.push(JavaExtractResult {
+                    file_path: file_path.to_string(),
+                    extractions: Vec::new(),
+                    errors: vec![JavaError::ParseError {
+                        message: "tree-sitter returned no parse tree".to_string(),
+                    }],
+                });
+                continue;
+            }
+        };
+
+        let mut sql_var_patterns_upper = vec!["SQL".to_string()];
+        for p in &config.extra_sql_var_patterns {
+            let upper = p.to_uppercase();
+            if !sql_var_patterns_upper.contains(&upper) {
+                sql_var_patterns_upper.push(upper);
+            }
+        }
+
+        let mut ctx = extract::ExtractContext {
+            source,
+            file_path,
+            extractions: Vec::new(),
+            errors: Vec::new(),
+            class_name: None,
+            method_name: None,
+            sql_vars: std::collections::HashMap::new(),
+            var_types: std::collections::HashMap::new(),
+            jdbc_param_map: std::collections::HashMap::new(),
+            ps_var_to_extraction: std::collections::HashMap::new(),
+            extra_sql_methods: &config.extra_sql_methods,
+            sql_var_patterns_upper,
+            method_behaviors: std::mem::take(&mut state.method_behaviors),
+            pending_injections: Vec::new(),
+            class_ps_to_extraction: std::collections::HashMap::new(),
+            dynamic_setters: Vec::new(),
+            string_constants: std::mem::take(&mut state.string_constants),
+        };
+
+        ctx.visit(tree.root_node());
+        ctx.apply_pending_injections();
+
+        state.method_behaviors = ctx.method_behaviors;
+        state.string_constants = ctx.string_constants;
+
+        let extractions: Vec<ExtractedSql> = ctx
+            .extractions
+            .into_iter()
+            .filter(|e| extract::starts_with_sql_keyword(&e.sql))
+            .collect();
+
+        results.push(JavaExtractResult {
+            file_path: file_path.to_string(),
+            extractions,
+            errors: ctx.errors,
+        });
+    }
+
+    results
+}
+
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod tests_diagnostic;

--- a/src/java/tests_diagnostic.rs
+++ b/src/java/tests_diagnostic.rs
@@ -2191,4 +2191,267 @@ fn diag_q5_cross_file_concat_with_concat_value_in_setter() {
         "simple value in cross-file setter, got: {}", sql);
 }
 
+// ═══════════════════════════════════════════════════════════════
+// GROUP M (extended): Switch expressions — Java 14+ arrow syntax
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_m6_switch_expression_assigned_to_var() {
+    let java = r#"
+        public class Dao {
+            public void query(String table) {
+                String sql = switch (table) {
+                    case "users" -> "SELECT * FROM users";
+                    case "orders" -> "SELECT * FROM orders";
+                    default -> "SELECT 1";
+                };
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "switch expression assigned to var should extract SQL cases, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m7_switch_expression_with_concat() {
+    let java = r#"
+        public class Dao {
+            public void query(String table) {
+                String sql = switch (table) {
+                    case "users" -> "SELECT * FROM " + table;
+                    case "orders" -> "DELETE FROM " + table;
+                    default -> "SELECT 1";
+                };
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "switch expression with concat should extract SQL, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m8_switch_expression_in_method_arg() {
+    let java = r#"
+        public class Dao {
+            public void query(String type) throws Exception {
+                jdbcTemplate.query(switch (type) {
+                    case "full" -> "SELECT * FROM users";
+                    default -> "SELECT id FROM users";
+                }, (rs, rn) -> null);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "switch expression as method argument should extract SQL, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m9_switch_expression_only_non_sql() {
+    let java = r#"
+        public class Dao {
+            public void process(String type) {
+                String label = switch (type) {
+                    case "a" -> "hello";
+                    case "b" -> "world";
+                    default -> "unknown";
+                };
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.is_empty(),
+        "switch expression with no SQL should not extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m10_switch_expression_with_placeholders() {
+    let java = r#"
+        public class Dao {
+            public void query(String type, int id) throws Exception {
+                String sql = switch (type) {
+                    case "find" -> "SELECT * FROM users WHERE id = ?";
+                    case "delete" -> "DELETE FROM users WHERE id = ?";
+                    default -> "SELECT 1";
+                };
+                PreparedStatement ps = conn.prepareStatement(sql);
+                ps.setInt(1, id);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "switch expression with JDBC placeholders should extract, got: {}", result.extractions.len());
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("WHERE id"),
+        "placeholder-containing SQL should appear, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_m11_switch_expression_nested_in_sb_append() {
+    let java = r#"
+        public class Dao {
+            public void query(String type) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users");
+                sql.append(switch (type) {
+                    case "active" -> " WHERE active = 1";
+                    case "inactive" -> " WHERE active = 0";
+                    default -> "";
+                });
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "switch expression inside SB append should produce assembled SQL, got: {}", result.extractions.len());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP O (extended): Return-SQL patterns
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_o13_return_sql_from_if() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(String type) {
+                if ("simple".equals(type)) {
+                    return "SELECT id FROM users";
+                } else {
+                    return "SELECT u.id, u.name, d.dept FROM users u JOIN dept d ON u.dept_id = d.id";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "return SQL from both if/else branches should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o14_return_sql_from_switch() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(int type) {
+                switch (type) {
+                    case 1: return "SELECT * FROM users";
+                    case 2: return "SELECT * FROM orders";
+                    default: return "SELECT 1";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "return SQL from switch cases should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o15_return_sql_from_ternary() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(boolean simple) {
+                return simple ? "SELECT id FROM users" : "SELECT * FROM users JOIN dept ON users.dept_id = dept.id";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "return SQL from ternary should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o16_return_sql_only_non_sql() {
+    let java = r#"
+        public class Dao {
+            public String getLabel(String type) {
+                if ("a".equals(type)) {
+                    return "hello";
+                }
+                return "world";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.is_empty(),
+        "return of non-SQL strings should not extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o17_return_sql_with_concat() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(String table) {
+                return "SELECT * FROM " + table + " WHERE active = 1";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "return of concatenated SQL should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o18_return_sql_deep_nesting() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(String type, String status) {
+                if ("user".equals(type)) {
+                    if ("active".equals(status)) {
+                        return "SELECT * FROM users WHERE active = 1";
+                    } else {
+                        return "SELECT * FROM users WHERE active = 0";
+                    }
+                } else {
+                    return "SELECT * FROM orders";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "return SQL from deeply nested if should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o19_return_sql_used_by_caller() {
+    let java = r#"
+        public class Dao {
+            public String buildQuery(String table) {
+                return "SELECT * FROM " + table;
+            }
+            public void execute() throws Exception {
+                String sql = buildQuery("users");
+                PreparedStatement ps = conn.prepareStatement(sql);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL returned from method and used by caller should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o20_return_sql_in_try_catch() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(boolean safe) {
+                try {
+                    if (safe) {
+                        return "SELECT * FROM users";
+                    }
+                    return "DELETE FROM users";
+                } catch (Exception e) {
+                    return "SELECT 1";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "return SQL inside try/catch should extract, got: {}", result.extractions.len());
+}
+
 

--- a/src/java/tests_diagnostic.rs
+++ b/src/java/tests_diagnostic.rs
@@ -1,0 +1,2194 @@
+//! Diagnostic test suite for parse-java improvement analysis.
+//!
+//! Covers all 10 improvement suggestions from the review, organized by category.
+//! Tests that currently fail are marked with improvement-needed comments.
+//! Run with: cargo test --features java tests_diagnostic -- --nocapture
+
+use crate::java::{extract_sql_from_java, extract_sql_from_java_files, ExtractionMethod, JavaExtractConfig};
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP A: looks_like_sql edge cases (Suggestion 6)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_a1_select_box_not_sql() {
+    let java = r#"
+        public class Config {
+            private static final String LABEL = "SELECT_BOX";
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Config.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 0,
+        "SELECT_BOX is not SQL, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_a2_select_newline_false_negative() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                String sql = "select\n* from users";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1,
+        "newline-separated SQL should be detected; needs whitespace normalization in looks_like_sql");
+    assert!(result.extractions[0].sql.contains("from users"));
+}
+
+#[test]
+fn diag_a3_select_tab_separated() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                String sql = "SELECT\t* FROM users";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1,
+        "tab-separated SQL should be detected; needs whitespace normalization in looks_like_sql");
+    assert!(result.extractions[0].sql.contains("FROM users"));
+}
+
+#[test]
+fn diag_a4_english_text_not_sql() {
+    let java = r#"
+        public class UI {
+            private String prompt = "Please SELECT one option from the menu";
+        }
+    "#;
+    let result = extract_sql_from_java(java, "UI.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 0,
+        "English prose with SQL keyword should not be extracted, got: {:?}", result.extractions);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP B: Field type not entering var_types (Suggestion 2)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_b1_field_string_type_in_method_concat() {
+    let java = r#"
+        public class Dao {
+            private String tableName = "users";
+            public void query() {
+                String sql = "SELECT * FROM " + tableName;
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1, "should extract SQL from field concat");
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_String_tableName__"),
+        "field variable should have String type from var_types, got: {}", result.extractions[0].sql);
+}
+
+#[test]
+fn diag_b2_field_int_type_in_sql() {
+    let java = r#"
+        public class Dao {
+            private int limit = 100;
+            public void query() {
+                String sql = "SELECT * FROM users LIMIT " + limit;
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1, "should extract SQL with field int variable");
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_int_limit__"),
+        "field int should produce __JAVA_VAR_int_limit__, not String; \
+        needs field type extraction in visit_field_declaration, got: {}", result.extractions[0].sql);
+}
+
+#[test]
+fn diag_b3_field_stringbuilder_in_method() {
+    let java = r#"
+        public class Dao {
+            private StringBuilder sqlBuilder = new StringBuilder("SELECT * FROM users");
+            public void query(int id) {
+                sqlBuilder.append(" WHERE id = ").append(id);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "field-level StringBuilder should be tracked; \
+        needs visit_field_declaration to handle StringBuilder type, got count: {}", result.extractions.len());
+    let combined = result.extractions.iter().map(|e| e.sql.as_str()).collect::<String>();
+    assert!(combined.contains("WHERE id ="),
+        "field SB append in method should be tracked, got: {:?}", result.extractions);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP C: StringBuilder mixed chains (Suggestion 3)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_c1_append_insert_append_chain() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                StringBuilder sql = new StringBuilder("SELECT  users");
+                sql.append(" WHERE 1=1").insert(7, "* FROM").append(" AND active = 1");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("* FROM"),
+        "insert in chained call should be applied; \
+        needs handle_sb_append to recurse into insert/delete, got: {}", sql);
+    assert!(sql.contains("WHERE 1=1"), "append in chain should work, got: {}", sql);
+    assert!(sql.contains("AND active = 1"), "final append in chain should work, got: {}", sql);
+}
+
+#[test]
+fn diag_c2_stringbuilder_replace() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                StringBuilder sql = new StringBuilder("SELECT * FROM old_table WHERE id = 1");
+                sql.replace(14, 23, "users");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("users") && !sql.contains("old_table"),
+        "StringBuilder.replace should be applied; \
+        needs handle_sb_replace implementation, got: {}", sql);
+}
+
+#[test]
+fn diag_c3_delete_then_append_chain() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users WHERE obsolete");
+                sql.delete(19, 34).append(" WHERE id = 1");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(!sql.contains("obsolete"),
+        "delete should remove 'obsolete', got: {}", sql);
+    assert!(sql.contains("WHERE id = 1"),
+        "append after delete in chain should work; \
+        needs handle_sb_delete to propagate chain to append, got: {}", sql);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP D: Type inference limitations (Suggestion 5)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_d1_constant_propagation_local() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                final String TABLE = "users";
+                String sql = "SELECT * FROM " + TABLE;
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1, "should extract SQL");
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users"),
+        "final String constant should be inlined into SQL, got: {}", sql);
+}
+
+#[test]
+fn diag_d2_constant_propagation_static_field() {
+    let java = r#"
+        public class Dao {
+            private static final String TABLE = "users";
+            public void query() {
+                String sql = "SELECT * FROM " + TABLE;
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users"),
+        "static final field constant should be inlined, got: {}", sql);
+}
+
+#[test]
+fn diag_d3_getter_method_return() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                String sql = "SELECT * FROM " + getTableName();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1, "SQL with method call should be extracted");
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM"),
+        "should extract SQL containing method call, got: {}", sql);
+    assert!(!sql.contains("getTableName()") && !sql.contains("____"),
+        "placeholder for getter call should be clean, got: {}", sql);
+}
+
+#[test]
+fn diag_d4_field_access_type() {
+    let java = r#"
+        public class Dao {
+            public void query(User user) {
+                String sql = "SELECT * FROM users WHERE name = '" + user.name + "'";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(!sql.contains("user.name") && !sql.contains("user_name"),
+        "field access user.name should produce a clean placeholder for the field part, got: {}", sql);
+}
+
+#[test]
+fn diag_d5_generic_list_get() {
+    let java = r#"
+        public class Dao {
+            public void query(List<String> names) {
+                String sql = "SELECT * FROM users WHERE name = '" + names.get(0) + "'";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(!sql.contains("names.get(0)") && !sql.contains("names_get_0___"),
+        "names.get(0) should produce a clean placeholder, got: {}", sql);
+}
+
+#[test]
+fn diag_d6_int_variable_typed_concat() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                int limit = 10;
+                String sql = "SELECT * FROM users LIMIT " + limit;
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_int_limit__"),
+        "local int variable should produce int-typed placeholder, got: {}", result.extractions[0].sql);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP E: Annotation robustness (Suggestion 7)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_e1_annotation_no_space() {
+    let java = r#"
+        public interface Repo {
+            @Query(value="SELECT * FROM users WHERE id = :id",nativeQuery=true)
+            User findById(@Param("id") int id);
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Repo.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("SELECT * FROM users"));
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_int_id__"));
+}
+
+#[test]
+fn diag_e2_annotation_bare_value() {
+    let java = r#"
+        public interface Repo {
+            @Query("SELECT * FROM users WHERE status = :status")
+            List<User> findByStatus(@Param("status") String status);
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Repo.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_String_status__"));
+}
+
+#[test]
+fn diag_e3_annotation_keys_reversed_order() {
+    let java = r#"
+        public interface Repo {
+            @Query(nativeQuery = true, value = "SELECT * FROM users WHERE id = :id")
+            User findById(@Param("id") int id);
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Repo.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_int_id__"));
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP F: Lambda / method reference (Suggestion 8)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_f1_sql_as_lambda_arg() {
+    let java = r#"
+        public class Dao {
+            public void find() {
+                jdbcTemplate.query("SELECT * FROM users",
+                    (rs, rowNum) -> new User(rs.getLong("id")));
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("SELECT * FROM users"));
+}
+
+#[test]
+fn diag_f2_sql_built_inside_lambda() {
+    let java = r#"
+        public class Dao {
+            public void process(List<String> tables) {
+                tables.forEach(table -> {
+                    String sql = "SELECT COUNT(*) FROM " + table;
+                    jdbcTemplate.query(sql, (rs, rowNum) -> rs.getInt(1));
+                });
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1,
+        "SQL built inside lambda body should be extracted");
+    assert!(result.extractions[0].sql.contains("SELECT COUNT(*) FROM"),
+        "got: {}", result.extractions[0].sql);
+}
+
+#[test]
+fn diag_f3_sql_inside_anonymous_class() {
+    let java = r#"
+        public class Dao {
+            public void process() {
+                Runnable r = new Runnable() {
+                    @Override
+                    public void run() {
+                        String sql = "SELECT * FROM audit_log WHERE ts > NOW()";
+                    }
+                };
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1,
+        "SQL inside anonymous class should be extracted");
+    assert!(result.extractions[0].sql.contains("audit_log"));
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP G: scoped_type_identifier (Suggestion 9)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_g1_scoped_prepared_statement() {
+    let java = r#"
+        public class Dao {
+            public void query(String name) throws Exception {
+                java.sql.PreparedStatement ps = conn.prepareStatement("SELECT * FROM t WHERE name = ?");
+                ps.setString(1, name);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_String_name__"),
+        "scoped PS type should still resolve setString backfill, got: {}", result.extractions[0].sql);
+    assert!(!result.extractions[0].sql.contains("__JAVA_VAR_JDBC_PARAM_1__"),
+        "param should be backfilled, not left as JDBC_PARAM, got: {}", result.extractions[0].sql);
+}
+
+#[test]
+fn diag_g2_scoped_ps_as_method_param() {
+    let java = r#"
+        public class Dao {
+            public void process(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (name) VALUES (?)");
+                bindAndExecute(ps, name);
+            }
+            public static void bindAndExecute(java.sql.PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+                ps.execute();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_name__"),
+        "scoped_type_identifier in method param should match 'PreparedStatement' for behavior recording; \
+        needs extract_type_name to handle scoped_type_identifier, got: {}", sql);
+    assert!(!sql.contains("DYNAMIC"),
+        "should not fall back to DYNAMIC when setter pattern is available, got: {}", sql);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP H: Complex / edge cases (Suggestion 10)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_h1_ternary_operator_sql() {
+    let java = r#"
+        public class Dao {
+            public void query(boolean isRead) {
+                String sql = isRead ? "SELECT * FROM users" : "UPDATE users SET active = 0";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "ternary operator should extract at least one branch; \
+        needs handling for ternary_expression node, got count: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_h2_switch_statement_sql() {
+    let java = r#"
+        public class Dao {
+            public void query(int type, String name) {
+                String sql;
+                switch (type) {
+                    case 1:
+                        sql = "SELECT * FROM users WHERE name = '" + name + "'";
+                        break;
+                    case 2:
+                        sql = "DELETE FROM users WHERE name = '" + name + "'";
+                        break;
+                    default:
+                        sql = "SELECT * FROM users";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "switch branches with SQL should be extracted; \
+        needs uninitialized var tracking + switch body traversal, got count: {}",
+        result.extractions.len());
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("SELECT") || all_sql.contains("DELETE"),
+        "should contain SELECT or DELETE SQL, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_h3_nested_class_field_sql() {
+    let java = r#"
+        public class Outer {
+            class Inner {
+                private static final String SQL = "SELECT * FROM inner_table";
+                public void run() {
+                    String sql = SQL + " WHERE id = 1";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Outer.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "nested class: should extract both field SQL and method concat; \
+        got count: {}, extractions: {:?}", result.extractions.len(), result.extractions);
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("inner_table"),
+        "should contain inner_table, got: {:?}", result.extractions);
+    assert!(all_sql.contains("WHERE id = 1"),
+        "method body concat should extend field SQL, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_h4_try_catch_sql() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                try {
+                    String sql = "SELECT * FROM users";
+                } catch (Exception e) {
+                    String sql = "INSERT INTO error_log (msg) VALUES ('query failed')";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 2, "both try and catch SQL should be extracted");
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("SELECT * FROM users"), "try block SQL, got: {:?}", result.extractions);
+    assert!(all_sql.contains("INSERT INTO error_log"), "catch block SQL, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_h5_multiple_classes_same_file() {
+    let java = r#"
+        public class UserDao {
+            public void insert(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                PsHelper.bindName(ps, name);
+            }
+        }
+        class PsHelper {
+            public static void bindName(PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Multi.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_name__"),
+        "cross-class PS passing should resolve setters; \
+        needs method_behaviors shared across class declarations in same file, got: {}", sql);
+    assert!(!sql.contains("DYNAMIC"),
+        "should not fall back to DYNAMIC when literal setter pattern exists, got: {}", sql);
+}
+
+#[test]
+fn diag_h6_if_else_branches() {
+    let java = r#"
+        public class Dao {
+            public void query(boolean active, String name) {
+                String sql;
+                if (active) {
+                    sql = "SELECT * FROM users WHERE active = 1 AND name = '" + name + "'";
+                } else {
+                    sql = "SELECT * FROM users WHERE active = 0";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "if-else branches with SQL should be extracted; \
+        needs uninitialized var tracking so 'String sql;' registers sql as tracked, \
+        got count: {}", result.extractions.len());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP I: Cross-file simulation (Suggestion 4)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_i1_two_classes_cross_method() {
+    let java = r#"
+        public class OrderDao {
+            public void insertOrder(String orderId, String product) throws Exception {
+                PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO orders (id, product) VALUES (?, ?)");
+                OrderHelper.bindOrderParams(ps, orderId, product);
+            }
+        }
+        class OrderHelper {
+            public static void bindOrderParams(PreparedStatement ps, String orderId, String product) throws Exception {
+                ps.setString(1, orderId);
+                ps.setString(2, product);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Order.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_orderId__"),
+        "cross-class PS should resolve typed params; \
+        needs method_behaviors shared across class declarations, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_product__"),
+        "product param should also be typed, got: {}", sql);
+    assert!(!sql.contains("DYNAMIC"),
+        "should not fall back to DYNAMIC, got: {}", sql);
+}
+
+#[test]
+fn diag_i2_same_class_cross_method() {
+    let java = r#"
+        public class Dao {
+            public void batch(String a, String b, String c) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (x,y,z) VALUES (?,?,?)");
+                bindAll(ps, a, b, c);
+            }
+            private static void bindAll(PreparedStatement ps, String a, String b, String c) throws Exception {
+                ps.setString(1, a);
+                ps.setString(2, b);
+                ps.setString(3, c);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_a__"), "param a, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_b__"), "param b, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_c__"), "param c, got: {}", sql);
+    assert!(!sql.contains("__JAVA_VAR_JDBC_PARAM_"), "no unresolved, got: {}", sql);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP J: Combinatorial / real-world complex scenarios
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_j1_sb_with_jdbc_setters_and_cross_method() {
+    let java = r#"
+        public class ReportDao {
+            private static final String BASE_SQL = "SELECT * FROM report_data";
+            public void generate(String dept, String startDate, String endDate) throws Exception {
+                StringBuilder sql = new StringBuilder(BASE_SQL);
+                sql.append(" WHERE dept = ?");
+                sql.append(" AND report_date BETWEEN ? AND ?");
+                PreparedStatement ps = conn.prepareStatement(sql.toString());
+                bindReportParams(ps, dept, startDate, endDate);
+            }
+            private static void bindReportParams(PreparedStatement ps, String dept, String start, String end) throws Exception {
+                ps.setString(1, dept);
+                ps.setString(2, start);
+                ps.setString(3, end);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Report.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "should extract at least the SB-assembled SQL, got count: {}", result.extractions.len());
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("WHERE dept"),
+        "SB appends should appear in final SQL, got: {:?}", result.extractions);
+    assert!(all_sql.contains("__JAVA_VAR_String_dept__"),
+        "cross-method JDBC setter should backfill typed params, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_j2_annotation_plus_method_call_plus_constant() {
+    let java = r#"
+        public interface UserRepo {
+            @Select("SELECT * FROM users WHERE id = #{id}")
+            User findById(@Param("id") int id);
+        }
+        class UserDao {
+            private static final String SQL_INSERT = "INSERT INTO users (name) VALUES (?)";
+            public void insert(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement(SQL_INSERT);
+                ps.setString(1, name);
+            }
+            public void search(String keyword) {
+                jdbcTemplate.query("SELECT * FROM users WHERE name LIKE '%' || ? || '%'",
+                    (rs, rowNum) -> new User());
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Mixed.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 3,
+        "should extract from annotation + constant + method call, got: {}", result.extractions.len());
+    let methods: Vec<_> = result.extractions.iter().map(|e| e.origin.method).collect();
+    assert!(methods.contains(&ExtractionMethod::Annotation), "should have annotation extraction");
+    assert!(methods.contains(&ExtractionMethod::Constant), "should have constant extraction");
+    assert!(methods.contains(&ExtractionMethod::MethodCall), "should have method call extraction");
+}
+
+#[test]
+fn diag_j3_mybatis_dynamic_sql_pattern() {
+    let java = r#"
+        public interface Mapper {
+            @Select("SELECT * FROM ${tableName} WHERE status = #{status} AND id IN (${ids})")
+            List<Map> findDynamic(@Param("tableName") String table, @Param("status") int status, @Param("ids") String ids);
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Mapper.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_tableName__"), "dollar-brace raw placeholder, got: {sql}");
+    assert!(sql.contains("__JAVA_VAR_int_status__"), "hash-brace typed placeholder, got: {sql}");
+    assert!(sql.contains("__JAVA_VAR_String_ids__"), "dollar-brace raw placeholder for ids, got: {sql}");
+}
+
+#[test]
+fn diag_j4_complex_sb_with_variable_parts() {
+    let java = r#"
+        public class Dao {
+            public void search(String table, String status, int limit) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM ");
+                sql.append(table);
+                sql.append(" WHERE 1=1");
+                sql.append(" AND status = '").append(status).append("'");
+                sql.append(" LIMIT ").append(limit);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM"), "base SB, got: {}", sql);
+    assert!(sql.contains("WHERE 1=1"), "append, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_table__"), "table var, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_status__"), "status var, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_int_limit__"), "limit var, got: {}", sql);
+}
+
+#[test]
+fn diag_j5_text_block_with_params() {
+    let java = r#"
+        public class Dao {
+            public void query(String name, int age) throws Exception {
+                String sql = """
+                    SELECT id, name, age
+                    FROM users
+                    WHERE name = ? AND age > ?
+                    ORDER BY name
+                    """;
+                PreparedStatement ps = conn.prepareStatement(sql);
+                ps.setString(1, name);
+                ps.setInt(2, age);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_String_name__"),
+        "name param, got: {}", result.extractions[0].sql);
+    assert!(result.extractions[0].sql.contains("__JAVA_VAR_int_age__"),
+        "age param, got: {}", result.extractions[0].sql);
+}
+
+#[test]
+fn diag_j6_string_concat_with_method_call_value() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                String sql = "SELECT * FROM " + getTable() + " WHERE id = 1";
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert_eq!(result.extractions.len(), 1);
+    assert!(result.extractions[0].sql.contains("SELECT * FROM"),
+        "SQL with method call should be extracted, got: {}", result.extractions[0].sql);
+}
+
+#[test]
+fn diag_j7_sb_concat_with_ps_cross_method_complex() {
+    let java = r#"
+        public class ComplexDao {
+            private static final String BASE_QUERY = "SELECT u.id, u.name, d.dept_name";
+            public void search(String name, String dept, int minAge) throws Exception {
+                StringBuilder sql = new StringBuilder(BASE_QUERY);
+                sql.append(" FROM users u JOIN departments d ON u.dept_id = d.id");
+                sql.append(" WHERE u.name LIKE ?");
+                sql.append(" AND d.dept_name = ?");
+                sql.append(" AND u.age >= ?");
+                PreparedStatement ps = conn.prepareStatement(sql.toString());
+                SearchHelper.bindParams(ps, name, dept, minAge);
+            }
+        }
+        class SearchHelper {
+            public static void bindParams(PreparedStatement ps, String name, String dept, int minAge) throws Exception {
+                ps.setString(1, "%" + name + "%");
+                ps.setString(2, dept);
+                ps.setInt(3, minAge);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Complex.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1);
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("WHERE u.name LIKE"),
+        "SB appends with JDBC params should be assembled, got: {:?}", result.extractions);
+    assert!(all_sql.contains("__JAVA_VAR_String_name__"),
+        "cross-class method should resolve name param, got: {:?}", result.extractions);
+    assert!(all_sql.contains("__JAVA_VAR_String_dept__"),
+        "cross-class method should resolve dept param, got: {:?}", result.extractions);
+    assert!(all_sql.contains("__JAVA_VAR_int_minAge__"),
+        "cross-class method should resolve minAge param, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_j8_overloaded_method_name() {
+    let java = r#"
+        public class Dao {
+            public void insertUser(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                Helper.bind(ps, name);
+            }
+            public void insertOrder(String orderId, int amount) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO orders (id, amount) VALUES (?, ?)");
+                Helper.bind(ps, orderId, amount);
+            }
+        }
+        class Helper {
+            public static void bind(PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+            }
+            public static void bind(PreparedStatement ps, String orderId, int amount) throws Exception {
+                ps.setString(1, orderId);
+                ps.setInt(2, amount);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Overload.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "should extract both INSERT statements, got: {}", result.extractions.len());
+    let user_sql = result.extractions.iter().find(|e| e.sql.contains("users"));
+    let order_sql = result.extractions.iter().find(|e| e.sql.contains("orders"));
+    assert!(user_sql.is_some(), "should extract INSERT INTO users");
+    assert!(order_sql.is_some(), "should extract INSERT INTO orders");
+    let user = user_sql.unwrap();
+    assert!(user.sql.contains("__JAVA_VAR_String_name__"),
+        "user insert: overloaded bind(String) should resolve, \
+        needs methodBehaviors keyed by signature not just name, got: {}", user.sql);
+    let order = order_sql.unwrap();
+    assert!(order.sql.contains("__JAVA_VAR_String_orderId__"),
+        "order insert: overloaded bind(String,int) should resolve, got: {}", order.sql);
+    assert!(order.sql.contains("__JAVA_VAR_int_amount__"),
+        "order insert: amount param, got: {}", order.sql);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP K: Control flow — if/else variations
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_k1_if_else_both_sql() {
+    let java = r#"
+        public class Dao {
+            public void query(boolean flag) {
+                String sql;
+                if (flag) {
+                    sql = "SELECT * FROM users WHERE active = 1";
+                } else {
+                    sql = "SELECT * FROM users WHERE active = 0";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "both if/else branches should produce extractions, got: {}", result.extractions.len());
+    let all: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all.contains("active = 1"), "if branch, got: {:?}", result.extractions);
+    assert!(all.contains("active = 0"), "else branch, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_k2_if_else_chain() {
+    let java = r#"
+        public class Dao {
+            public void query(String type) {
+                String sql;
+                if ("user".equals(type)) {
+                    sql = "SELECT * FROM users";
+                } else if ("order".equals(type)) {
+                    sql = "SELECT * FROM orders";
+                } else {
+                    sql = "SELECT * FROM products";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 3,
+        "all 3 branches should produce extractions, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_k3_nested_if_sql() {
+    let java = r#"
+        public class Dao {
+            public void query(boolean admin, boolean active) {
+                String sql = "SELECT * FROM users";
+                if (admin) {
+                    if (active) {
+                        sql = sql + " WHERE active = 1 AND role = 'admin'";
+                    } else {
+                        sql = sql + " WHERE role = 'admin'";
+                    }
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "nested if should extract SQL, got: {}", result.extractions.len());
+    let all: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all.contains("SELECT * FROM users"), "base SQL, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_k4_if_with_concat_var() {
+    let java = r#"
+        public class Dao {
+            public void query(String table, boolean condition) {
+                String sql;
+                if (condition) {
+                    sql = "SELECT * FROM " + table + " WHERE active = 1";
+                } else {
+                    sql = "SELECT * FROM " + table;
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "both branches with concat should extract, got: {}", result.extractions.len());
+    let all: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all.contains("WHERE active = 1"), "conditional branch, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_k5_if_else_sb_append() {
+    let java = r#"
+        public class Dao {
+            public void query(boolean includeDeleted) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users");
+                if (includeDeleted) {
+                    sql.append(" WHERE 1=1");
+                } else {
+                    sql.append(" WHERE active = 1");
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SB inside if/else should produce extraction, got: {}", result.extractions.len());
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users"), "base SB, got: {}", sql);
+}
+
+#[test]
+fn diag_k6_only_if_no_else_sql() {
+    let java = r#"
+        public class Dao {
+            public void query(boolean filter) {
+                String sql = "SELECT * FROM users";
+                if (filter) {
+                    sql += " WHERE active = 1";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "if-only branch with += should extract, got: {}", result.extractions.len());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP L: Control flow — for loops
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_l1_sql_inside_for_body() {
+    let java = r#"
+        public class Dao {
+            public void batch() {
+                for (int i = 0; i < 10; i++) {
+                    String sql = "INSERT INTO log (msg) VALUES ('batch')";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL inside for body should be extracted, got: {}", result.extractions.len());
+    assert!(result.extractions[0].sql.contains("INSERT INTO log"));
+}
+
+#[test]
+fn diag_l2_sb_append_in_for() {
+    let java = r#"
+        public class Dao {
+            public void buildQuery(String[] columns) {
+                StringBuilder sql = new StringBuilder("SELECT ");
+                for (int i = 0; i < columns.length; i++) {
+                    sql.append(columns[i]);
+                    if (i < columns.length - 1) {
+                        sql.append(", ");
+                    }
+                }
+                sql.append(" FROM users");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SB assembled in for loop should extract, got: {}", result.extractions.len());
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT "), "base SELECT, got: {}", sql);
+    assert!(sql.contains("FROM users"), "append after loop, got: {}", sql);
+}
+
+#[test]
+fn diag_l3_for_each_sql() {
+    let java = r#"
+        public class Dao {
+            public void process(List<String> tables) {
+                for (String table : tables) {
+                    String sql = "SELECT COUNT(*) FROM " + table;
+                    jdbcTemplate.query(sql, (rs, rowNum) -> rs.getInt(1));
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL inside for-each should be extracted, got: {}", result.extractions.len());
+    let all: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all.contains("SELECT COUNT(*) FROM"), "for-each SQL, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_l4_for_with_ps_setter() {
+    let java = r#"
+        public class Dao {
+            public void batch(String[] names) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                for (int i = 0; i < names.length; i++) {
+                    ps.setString(1, names[i]);
+                    ps.addBatch();
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("INSERT INTO users"), "base PS SQL, got: {}", sql);
+}
+
+#[test]
+fn diag_l5_nested_for_sb_in() {
+    let java = r#"
+        public class Dao {
+            public void buildInClause(List<String> ids) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users WHERE id IN (");
+                for (int i = 0; i < ids.size(); i++) {
+                    if (i > 0) sql.append(",");
+                    sql.append("?");
+                }
+                sql.append(")");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "nested for building IN clause should extract, got: {}", result.extractions.len());
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users WHERE id IN"), "IN clause base, got: {}", sql);
+}
+
+#[test]
+fn diag_l6_while_loop_sql() {
+    let java = r#"
+        public class Dao {
+            public void process(ResultSet rs) throws Exception {
+                while (rs.next()) {
+                    String name = rs.getString("name");
+                    String sql = "INSERT INTO audit (name) VALUES ('" + name + "')";
+                    jdbcTemplate.execute(sql);
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL inside while should be extracted, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_l7_do_while_sql() {
+    let java = r#"
+        public class Dao {
+            public void retry() {
+                String sql;
+                int attempts = 0;
+                do {
+                    sql = "SELECT * FROM status WHERE id = 1";
+                    attempts++;
+                } while (attempts < 3);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL inside do-while should be extracted, got: {}", result.extractions.len());
+    assert!(result.extractions[0].sql.contains("SELECT * FROM status"));
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP M: Control flow — switch / switch-expression
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_m1_switch_multiple_cases() {
+    let java = r#"
+        public class Dao {
+            public void query(int type) {
+                String sql;
+                switch (type) {
+                    case 1:
+                        sql = "SELECT * FROM users";
+                        break;
+                    case 2:
+                        sql = "SELECT * FROM orders";
+                        break;
+                    case 3:
+                        sql = "SELECT * FROM products";
+                        break;
+                    default:
+                        sql = "SELECT 1";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 4,
+        "all 4 switch branches should extract, got: {}", result.extractions.len());
+    let all: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all.contains("users"), "case 1, got: {:?}", result.extractions);
+    assert!(all.contains("orders"), "case 2, got: {:?}", result.extractions);
+    assert!(all.contains("products"), "case 3, got: {:?}", result.extractions);
+    assert!(all.contains("SELECT 1"), "default, got: {:?}", result.extractions);
+}
+
+#[test]
+fn diag_m2_switch_fallthrough() {
+    let java = r#"
+        public class Dao {
+            public void query(int type) {
+                String sql;
+                switch (type) {
+                    case 1:
+                    case 2:
+                        sql = "SELECT * FROM users";
+                        break;
+                    default:
+                        sql = "SELECT * FROM all_data";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "switch fallthrough cases should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m3_switch_with_sb() {
+    let java = r#"
+        public class Dao {
+            public void query(String mode) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users");
+                switch (mode) {
+                    case "active":
+                        sql.append(" WHERE active = 1");
+                        break;
+                    case "admin":
+                        sql.append(" WHERE role = 'admin'");
+                        break;
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SB inside switch should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m4_switch_expression_java14() {
+    let java = r#"
+        public class Dao {
+            public void query(String type) {
+                String sql = switch (type) {
+                    case "user" -> "SELECT * FROM users";
+                    case "order" -> "SELECT * FROM orders";
+                    default -> "SELECT 1";
+                };
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "Java 14 switch expression (arrow syntax) should extract at least one SQL; \
+        currently fails because tree-sitter switch_expression node is not traversed, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_m5_switch_with_string_concat() {
+    let java = r#"
+        public class Dao {
+            public void query(int op, String table) {
+                String sql;
+                switch (op) {
+                    case 1:
+                        sql = "SELECT * FROM " + table;
+                        break;
+                    case 2:
+                        sql = "DELETE FROM " + table;
+                        break;
+                    default:
+                        sql = "SELECT 1";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "switch with concatenated SQL should extract, got: {}", result.extractions.len());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP N: Control flow — try/catch/finally
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_n1_try_catch_finally() {
+    let java = r#"
+        public class Dao {
+            public void query() throws Exception {
+                try {
+                    String sql = "SELECT * FROM users";
+                    jdbcTemplate.query(sql, (rs, rn) -> rs.getInt(1));
+                } catch (SQLException e) {
+                    String sql = "INSERT INTO error_log (msg) VALUES ('query failed')";
+                    jdbcTemplate.execute(sql);
+                } finally {
+                    String sql = "DELETE FROM temp WHERE created < NOW()";
+                    jdbcTemplate.execute(sql);
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 3,
+        "try + catch + finally should each extract, got: {}", result.extractions.len());
+    let all: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all.contains("SELECT * FROM users"), "try block");
+    assert!(all.contains("INSERT INTO error_log"), "catch block");
+    assert!(all.contains("DELETE FROM temp"), "finally block");
+}
+
+#[test]
+fn diag_n2_try_with_resources_sql() {
+    let java = r#"
+        public class Dao {
+            public void query(String name) throws Exception {
+                try (PreparedStatement ps = conn.prepareStatement("SELECT * FROM users WHERE name = ?")) {
+                    ps.setString(1, name);
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL in try-with-resources should extract, got: {}", result.extractions.len());
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users WHERE name ="), "PS SQL, got: {}", sql);
+}
+
+#[test]
+fn diag_n3_nested_try_catch() {
+    let java = r#"
+        public class Dao {
+            public void complex() {
+                try {
+                    String sql1 = "SELECT * FROM users";
+                    try {
+                        String sql2 = "INSERT INTO audit (action) VALUES ('read')";
+                    } catch (Exception e) {
+                        String sql3 = "INSERT INTO error_log (msg) VALUES ('inner fail')";
+                    }
+                } catch (Exception e) {
+                    String sql4 = "INSERT INTO error_log (msg) VALUES ('outer fail')";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 4,
+        "all 4 nested try/catch SQLs should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_n4_multi_catch() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                try {
+                    String sql = "SELECT * FROM users";
+                } catch (IOException | SQLException e) {
+                    String sql = "INSERT INTO error_log (msg) VALUES ('multi-catch')";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "try + multi-catch should extract, got: {}", result.extractions.len());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP O: Control flow — combinations / real-world patterns
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_o1_if_inside_for_sb() {
+    let java = r#"
+        public class Dao {
+            public void buildQuery(String table, boolean[] flags) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM ");
+                sql.append(table);
+                for (int i = 0; i < flags.length; i++) {
+                    if (flags[i]) {
+                        sql.append(" WHERE condition_").append(i);
+                    }
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "if inside for with SB should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o2_sb_conditional_where() {
+    let java = r#"
+        public class Dao {
+            public void search(String name, String dept, boolean activeOnly) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users WHERE 1=1");
+                if (name != null) {
+                    sql.append(" AND name = '").append(name).append("'");
+                }
+                if (dept != null) {
+                    sql.append(" AND dept = '").append(dept).append("'");
+                }
+                if (activeOnly) {
+                    sql.append(" AND active = 1");
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "conditional WHERE building should extract base SQL, got: {}", result.extractions.len());
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("WHERE 1=1"), "base WHERE clause, got: {}", sql);
+}
+
+#[test]
+fn diag_o3_switch_in_for() {
+    let java = r#"
+        public class Dao {
+            public void multiOp(String[] ops) throws Exception {
+                for (String op : ops) {
+                    PreparedStatement ps;
+                    switch (op) {
+                        case "select":
+                            ps = conn.prepareStatement("SELECT * FROM data");
+                            break;
+                        case "delete":
+                            ps = conn.prepareStatement("DELETE FROM data WHERE id = 0");
+                            break;
+                        default:
+                            ps = conn.prepareStatement("SELECT 1");
+                    }
+                    ps.execute();
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 3,
+        "switch inside for should extract each branch, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o4_for_inside_try_inside_if() {
+    let java = r#"
+        public class Dao {
+            public void batch(String[] names) {
+                if (names != null && names.length > 0) {
+                    try {
+                        String sql = "INSERT INTO users (name) VALUES (?)";
+                        PreparedStatement ps = conn.prepareStatement(sql);
+                        for (String name : names) {
+                            ps.setString(1, name);
+                            ps.addBatch();
+                        }
+                    } catch (Exception e) {
+                        String sql = "INSERT INTO error_log (msg) VALUES ('batch failed')";
+                    }
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "nested if > try > for should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o5_labeled_break_in_for() {
+    let java = r#"
+        public class Dao {
+            public void search(List<String> tables) {
+                outer:
+                for (String table : tables) {
+                    String sql = "SELECT COUNT(*) FROM " + table;
+                    if (table.equals("stop")) break outer;
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL inside labeled for should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o6_synchronized_block_sql() {
+    let java = r#"
+        public class Dao {
+            public void query() {
+                synchronized (this) {
+                    String sql = "SELECT * FROM locked_table WHERE id = 1";
+                    jdbcTemplate.query(sql, (rs, rn) -> rs.getInt(1));
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "SQL inside synchronized block should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o7_dynamic_where_builder() {
+    let java = r#"
+        public class Dao {
+            public void search(String name, Integer age, String dept) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users WHERE 1=1");
+                if (name != null && !name.isEmpty()) {
+                    sql.append(" AND name LIKE ?");
+                }
+                if (age != null) {
+                    sql.append(" AND age > ?");
+                }
+                if (dept != null) {
+                    sql.append(" AND dept = ?");
+                }
+                sql.append(" ORDER BY id DESC LIMIT 100");
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users"), "base, got: {}", sql);
+    assert!(sql.contains("ORDER BY id DESC"), "final append, got: {}", sql);
+}
+
+#[test]
+fn diag_o8_batch_insert_with_for_and_cross_method() {
+    let java = r#"
+        public class BatchDao {
+            public void insertAll(List<User> users) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name, email) VALUES (?, ?)");
+                for (User u : users) {
+                    BatchHelper.bindUser(ps, u.name, u.email);
+                    ps.addBatch();
+                }
+            }
+        }
+        class BatchHelper {
+            public static void bindUser(PreparedStatement ps, String name, String email) throws Exception {
+                ps.setString(1, name);
+                ps.setString(2, email);
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Batch.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("INSERT INTO users"), "batch PS SQL, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_name__"), "cross-method param, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_email__"), "cross-method param, got: {}", sql);
+}
+
+#[test]
+fn diag_o9_conditional_order_by() {
+    let java = r#"
+        public class Dao {
+            public void query(String sortBy, boolean ascending) {
+                StringBuilder sql = new StringBuilder("SELECT * FROM users");
+                if (sortBy != null) {
+                    sql.append(" ORDER BY ").append(sortBy);
+                    if (ascending) {
+                        sql.append(" ASC");
+                    } else {
+                        sql.append(" DESC");
+                    }
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1);
+    let sql = &result.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM users"), "base, got: {}", sql);
+}
+
+#[test]
+fn diag_o10_return_sql_from_if() {
+    let java = r#"
+        public class Dao {
+            public String getQuery(String type) {
+                if ("simple".equals(type)) {
+                    return "SELECT id FROM users";
+                } else {
+                    return "SELECT u.id, u.name, d.dept FROM users u JOIN dept d ON u.dept_id = d.id";
+                }
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "return SQL from both if/else branches should extract; \
+        currently fails because return_statement only recurses children but the string_literal \
+        inside return is not visited as a top-level declaration/assignment, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o11_break_in_switch_with_sql() {
+    let java = r#"
+        public class Dao {
+            public void process(int action, String id) throws Exception {
+                PreparedStatement ps;
+                switch (action) {
+                    case 1:
+                        ps = conn.prepareStatement("SELECT * FROM data WHERE id = ?");
+                        ps.setString(1, id);
+                        break;
+                    case 2:
+                        ps = conn.prepareStatement("DELETE FROM data WHERE id = ?");
+                        ps.setString(1, id);
+                        break;
+                    default:
+                        return;
+                }
+                ps.execute();
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "Dao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 2,
+        "switch with break and PS should extract, got: {}", result.extractions.len());
+}
+
+#[test]
+fn diag_o12_complex_daopattern() {
+    let java = r#"
+        public class UserDao {
+            private static final String BASE_SQL = "SELECT id, name, email FROM users";
+            
+            public List<User> search(UserQuery q) throws Exception {
+                StringBuilder sql = new StringBuilder(BASE_SQL);
+                sql.append(" WHERE 1=1");
+                if (q.getName() != null) {
+                    sql.append(" AND name LIKE ?");
+                }
+                if (q.getMinAge() > 0) {
+                    sql.append(" AND age >= ?");
+                }
+                if (q.getDept() != null) {
+                    sql.append(" AND dept = ?");
+                }
+                
+                PreparedStatement ps = conn.prepareStatement(sql.toString());
+                int idx = 1;
+                if (q.getName() != null) {
+                    ps.setString(idx++, "%" + q.getName() + "%");
+                }
+                if (q.getMinAge() > 0) {
+                    ps.setInt(idx++, q.getMinAge());
+                }
+                if (q.getDept() != null) {
+                    ps.setString(idx++, q.getDept());
+                }
+                return mapResults(ps.executeQuery());
+            }
+        }
+    "#;
+    let result = extract_sql_from_java(java, "UserDao.java", &JavaExtractConfig::default());
+    assert!(result.extractions.len() >= 1,
+        "complex DAO pattern should extract SQL, got: {}", result.extractions.len());
+    let all_sql: String = result.extractions.iter().map(|e| e.sql.as_str()).collect();
+    assert!(all_sql.contains("SELECT id, name, email FROM users"), "base, got: {:?}", result.extractions);
+    assert!(all_sql.contains("WHERE 1=1"), "WHERE clause, got: {:?}", result.extractions);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP P: Cross-file — method behavior sharing across files
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_p1_cross_file_ps_binding() {
+    let helper_java = r#"
+        public class PsHelper {
+            public static void bindName(PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class UserDao {
+            public void insert(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                PsHelper.bindName(ps, name);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("PsHelper.java", helper_java), ("UserDao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1,
+        "should extract INSERT from UserDao, got: {}", dao.extractions.len());
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_name__"),
+        "cross-file PS binding should resolve setter; \
+        needs method_behaviors shared across files, got: {}", sql);
+    assert!(!sql.contains("DYNAMIC"),
+        "should not fall back to DYNAMIC, got: {}", sql);
+}
+
+#[test]
+fn diag_p2_cross_file_multi_param_binding() {
+    let helper_java = r#"
+        class OrderHelper {
+            public static void bindOrder(PreparedStatement ps, String orderId, String product, int qty) throws Exception {
+                ps.setString(1, orderId);
+                ps.setString(2, product);
+                ps.setInt(3, qty);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class OrderDao {
+            public void create(String orderId, String product, int qty) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO orders (id, product, qty) VALUES (?, ?, ?)");
+                OrderHelper.bindOrder(ps, orderId, product, qty);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("OrderHelper.java", helper_java), ("OrderDao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1);
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_orderId__"),
+        "orderId from cross-file helper, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_product__"),
+        "product from cross-file helper, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_int_qty__"),
+        "qty from cross-file helper, got: {}", sql);
+}
+
+#[test]
+fn diag_p3_cross_file_overloaded_methods() {
+    let helper_java = r#"
+        class Helper {
+            public static void bind(PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+            }
+            public static void bind(PreparedStatement ps, String orderId, int amount) throws Exception {
+                ps.setString(1, orderId);
+                ps.setInt(2, amount);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class Dao {
+            public void insertUser(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                Helper.bind(ps, name);
+            }
+            public void insertOrder(String orderId, int amount) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO orders (id, amount) VALUES (?, ?)");
+                Helper.bind(ps, orderId, amount);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("Helper.java", helper_java), ("Dao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 2,
+        "should extract both INSERTs, got: {}", dao.extractions.len());
+    let user_sql = dao.extractions.iter().find(|e| e.sql.contains("users"));
+    let order_sql = dao.extractions.iter().find(|e| e.sql.contains("orders"));
+    assert!(user_sql.is_some(), "INSERT INTO users");
+    assert!(order_sql.is_some(), "INSERT INTO orders");
+    assert!(user_sql.unwrap().sql.contains("__JAVA_VAR_String_name__"),
+        "user insert: cross-file overloaded bind(String), got: {}", user_sql.unwrap().sql);
+    assert!(order_sql.unwrap().sql.contains("__JAVA_VAR_String_orderId__"),
+        "order insert: cross-file overloaded bind(String,int), got: {}", order_sql.unwrap().sql);
+}
+
+#[test]
+fn diag_p4_cross_file_sb_with_constant() {
+    let constants_java = r#"
+        public class SqlConstants {
+            public static final String USER_QUERY = "SELECT id, name FROM users";
+            public static final String ORDER_QUERY = "SELECT id, total FROM orders";
+        }
+    "#;
+    let dao_java = r#"
+        public class UserDao {
+            public void query() {
+                String sql = SqlConstants.USER_QUERY + " WHERE active = 1";
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("SqlConstants.java", constants_java), ("UserDao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1,
+        "cross-file constant in concat should extract, got: {}", dao.extractions.len());
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("SELECT id, name FROM users"),
+        "constant value should be inlined, got: {}", sql);
+    assert!(sql.contains("WHERE active = 1"),
+        "local concat should be preserved, got: {}", sql);
+}
+
+#[test]
+fn diag_p5_cross_file_sb_init_with_constant() {
+    let constants_java = r#"
+        public class SqlConstants {
+            public static final String BASE_SQL = "SELECT u.id, u.name FROM users u";
+        }
+    "#;
+    let dao_java = r#"
+        public class UserDao {
+            public void search(String name) {
+                StringBuilder sql = new StringBuilder(SqlConstants.BASE_SQL);
+                sql.append(" WHERE u.name LIKE ?");
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("SqlConstants.java", constants_java), ("UserDao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1,
+        "SB initialized with cross-file constant should extract, got: {}", dao.extractions.len());
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("SELECT u.id, u.name FROM users u"),
+        "constant value as SB init, got: {}", sql);
+    assert!(sql.contains("WHERE u.name LIKE ?"),
+        "append should be tracked, got: {}", sql);
+}
+
+#[test]
+fn diag_p6_cross_file_annotation_plus_constant() {
+    let constants_java = r#"
+        public class SqlConstants {
+            public static final String FIND_ACTIVE = "SELECT * FROM users WHERE active = 1";
+        }
+    "#;
+    let repo_java = r#"
+        public interface UserRepo {
+            @Select("SELECT * FROM users WHERE id = #{id}")
+            User findById(@Param("id") int id);
+        }
+    "#;
+    let dao_java = r#"
+        class UserDao {
+            public void findActive() {
+                String sql = SqlConstants.FIND_ACTIVE;
+                jdbcTemplate.query(sql, (rs, rn) -> new User());
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[
+            ("SqlConstants.java", constants_java),
+            ("UserRepo.java", repo_java),
+            ("UserDao.java", dao_java),
+        ],
+        &JavaExtractConfig::default(),
+    );
+    let const_count = results[0].extractions.len();
+    let repo_count = results[1].extractions.len();
+    let dao_count = results[2].extractions.len();
+    assert!(const_count >= 1, "constants file should extract, got: {}", const_count);
+    assert!(repo_count >= 1, "repo annotations should extract, got: {}", repo_count);
+    assert!(dao_count >= 1, "dao using cross-file constant should extract, got: {}", dao_count);
+}
+
+#[test]
+fn diag_p7_cross_file_ps_through_service_layer() {
+    let helper_java = r#"
+        class JdbcHelper {
+            public static void bindParams(PreparedStatement ps, String a, String b) throws Exception {
+                ps.setString(1, a);
+                ps.setString(2, b);
+            }
+        }
+    "#;
+    let service_java = r#"
+        class UserService {
+            public void save(String name, String email) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name, email) VALUES (?, ?)");
+                JdbcHelper.bindParams(ps, name, email);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("JdbcHelper.java", helper_java), ("UserService.java", service_java)],
+        &JavaExtractConfig::default(),
+    );
+    let svc = &results[1];
+    assert!(svc.extractions.len() >= 1);
+    let sql = &svc.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_name__"),
+        "cross-file binding through service layer, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_email__"),
+        "email param, got: {}", sql);
+}
+
+#[test]
+fn diag_p8_cross_file_three_layer_chain() {
+    let binder_java = r#"
+        class ParamBinder {
+            public static void bindUser(PreparedStatement ps, String name, int age) throws Exception {
+                ps.setString(1, name);
+                ps.setInt(2, age);
+            }
+        }
+    "#;
+    let service_java = r#"
+        class UserService {
+            public static void process(PreparedStatement ps, String name, int age) throws Exception {
+                ParamBinder.bindUser(ps, name, age);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class UserDao {
+            public void insert(String name, int age) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name, age) VALUES (?, ?)");
+                UserService.process(ps, name, age);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[
+            ("ParamBinder.java", binder_java),
+            ("UserService.java", service_java),
+            ("UserDao.java", dao_java),
+        ],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[2];
+    assert!(dao.extractions.len() >= 1);
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_name__"),
+        "3-layer cross-file binding: name, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_int_age__"),
+        "3-layer cross-file binding: age, got: {}", sql);
+}
+
+#[test]
+fn diag_p9_cross_file_dynamic_loop_setter() {
+    let helper_java = r#"
+        class DataHelper {
+            public static void submitData(PreparedStatement ps, List data) throws Exception {
+                for (Iterator it = data.iterator(); it.hasNext();) {
+                    String[] s = (String[]) it.next();
+                    for (int i = 0; i < s.length; i++) {
+                        ps.setString(i + 1, s[i]);
+                    }
+                    ps.addBatch();
+                }
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class Dao {
+            public void process(List list) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (a,b,c) VALUES (?,?,?)");
+                DataHelper.submitData(ps, list);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("DataHelper.java", helper_java), ("Dao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1);
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_DYNAMIC_"),
+        "cross-file dynamic loop setter should produce DYNAMIC placeholders, got: {}", sql);
+}
+
+#[test]
+fn diag_p10_cross_file_reverse_order() {
+    let dao_java = r#"
+        public class UserDao {
+            public void insert(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                Binder.bind(ps, name);
+            }
+        }
+    "#;
+    let binder_java = r#"
+        class Binder {
+            public static void bind(PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("UserDao.java", dao_java), ("Binder.java", binder_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[0];
+    assert!(dao.extractions.len() >= 1,
+        "Dao processed BEFORE Binder: method_behaviors from Binder not yet available, got: {}", dao.extractions.len());
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("INSERT INTO users"), "base SQL, got: {}", sql);
+}
+
+#[test]
+fn diag_p11_cross_file_sb_with_ps_and_constant() {
+    let constants_java = r#"
+        public class Sql {
+            public static final String BASE = "SELECT * FROM report_data";
+        }
+    "#;
+    let helper_java = r#"
+        class ReportHelper {
+            public static void bind(PreparedStatement ps, String dept, String start, String end) throws Exception {
+                ps.setString(1, dept);
+                ps.setString(2, start);
+                ps.setString(3, end);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class ReportDao {
+            public void generate(String dept, String start, String end) throws Exception {
+                StringBuilder sql = new StringBuilder(Sql.BASE);
+                sql.append(" WHERE dept = ?");
+                sql.append(" AND report_date BETWEEN ? AND ?");
+                PreparedStatement ps = conn.prepareStatement(sql.toString());
+                ReportHelper.bind(ps, dept, start, end);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[
+            ("Sql.java", constants_java),
+            ("ReportHelper.java", helper_java),
+            ("ReportDao.java", dao_java),
+        ],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[2];
+    assert!(dao.extractions.len() >= 1);
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM report_data"), "constant in SB init, got: {}", sql);
+    assert!(sql.contains("WHERE dept"), "append, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_dept__"),
+        "cross-file binding, got: {}", sql);
+}
+
+#[test]
+fn diag_p12_cross_file_inheritance_field_sql() {
+    let base_java = r#"
+        public class BaseDao {
+            protected static final String TABLE = "users";
+            protected String buildSelect() { return "SELECT * FROM " + TABLE; }
+        }
+    "#;
+    let dao_java = r#"
+        public class UserDao extends BaseDao {
+            public void query() {
+                String sql = buildSelect() + " WHERE active = 1";
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("BaseDao.java", base_java), ("UserDao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1,
+        "child class using inherited method should extract SQL, got: {}", dao.extractions.len());
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GROUP Q: Cross-file — edge cases and failure modes
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn diag_q1_cross_file_nonexistent_method() {
+    let dao_java = r#"
+        public class Dao {
+            public void insert(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO users (name) VALUES (?)");
+                NonexistentHelper.bind(ps, name);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("Dao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[0];
+    assert!(dao.extractions.len() >= 1,
+        "should still extract SQL even if helper method not found, got: {}", dao.extractions.len());
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("INSERT INTO users"), "base SQL, got: {}", sql);
+}
+
+#[test]
+fn diag_q2_cross_file_empty_helper() {
+    let helper_java = r#"
+        public class EmptyHelper {
+            public static void doNothing() {}
+        }
+    "#;
+    let dao_java = r#"
+        public class Dao {
+            public void query() {
+                String sql = "SELECT * FROM users";
+                jdbcTemplate.query(sql, (rs, rn) -> rs.getInt(1));
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("EmptyHelper.java", helper_java), ("Dao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1,
+        "unrelated helper file should not interfere, got: {}", dao.extractions.len());
+}
+
+#[test]
+fn diag_q3_cross_file_constant_only_used_in_sb() {
+    let constants_java = r#"
+        public class Tables {
+            public static final String USER_TABLE = "users";
+            public static final String ORDER_TABLE = "orders";
+        }
+    "#;
+    let dao_java = r#"
+        public class Dao {
+            public void query() {
+                StringBuilder sql = new StringBuilder("SELECT * FROM ");
+                sql.append(Tables.USER_TABLE);
+                sql.append(" WHERE active = 1");
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("Tables.java", constants_java), ("Dao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1,
+        "cross-file constant as SB append arg should inline, got: {}", dao.extractions.len());
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("SELECT * FROM"),
+        "base, got: {}", sql);
+    assert!(sql.contains("WHERE active = 1"),
+        "append, got: {}", sql);
+}
+
+#[test]
+fn diag_q4_cross_file_same_class_name_different_files() {
+    let helper1_java = r#"
+        class Binder {
+            public static void bind(PreparedStatement ps, String name) throws Exception {
+                ps.setString(1, name);
+            }
+        }
+    "#;
+    let helper2_java = r#"
+        class Binder {
+            public static void bind(PreparedStatement ps, String name, int age) throws Exception {
+                ps.setString(1, name);
+                ps.setInt(2, age);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class Dao {
+            public void insert(String name) throws Exception {
+                PreparedStatement ps = conn.prepareStatement("INSERT INTO t (name) VALUES (?)");
+                Binder.bind(ps, name);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[
+            ("Binder1.java", helper1_java),
+            ("Binder2.java", helper2_java),
+            ("Dao.java", dao_java),
+        ],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[2];
+    assert!(dao.extractions.len() >= 1);
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("INSERT INTO t"), "base SQL, got: {}", sql);
+}
+
+#[test]
+fn diag_q5_cross_file_concat_with_concat_value_in_setter() {
+    let helper_java = r#"
+        class SearchBinder {
+            public static void bind(PreparedStatement ps, String name, String dept) throws Exception {
+                ps.setString(1, "%" + name + "%");
+                ps.setString(2, dept);
+            }
+        }
+    "#;
+    let dao_java = r#"
+        public class SearchDao {
+            public void search(String name, String dept) throws Exception {
+                PreparedStatement ps = conn.prepareStatement(
+                    "SELECT * FROM users WHERE name LIKE ? AND dept = ?");
+                SearchBinder.bind(ps, name, dept);
+            }
+        }
+    "#;
+    let results = extract_sql_from_java_files(
+        &[("SearchBinder.java", helper_java), ("SearchDao.java", dao_java)],
+        &JavaExtractConfig::default(),
+    );
+    let dao = &results[1];
+    assert!(dao.extractions.len() >= 1);
+    let sql = &dao.extractions[0].sql;
+    assert!(sql.contains("__JAVA_VAR_String_name__"),
+        "concat value in cross-file setter should resolve, got: {}", sql);
+    assert!(sql.contains("__JAVA_VAR_String_dept__"),
+        "simple value in cross-file setter, got: {}", sql);
+}
+
+

--- a/src/java/types.rs
+++ b/src/java/types.rs
@@ -72,8 +72,6 @@ pub struct JavaExtractConfig {
     pub extra_sql_var_patterns: Vec<String>,
 }
 
-/// Inferred type/name info for a JDBC `?` parameter, derived from `setXxx()` calls.
-#[derive(Debug, Clone)]
 pub(super) struct JdbcParamInfo {
     pub(super) index: usize,
     pub(super) java_type: String,
@@ -81,14 +79,29 @@ pub(super) struct JdbcParamInfo {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct MethodPsBehavior {
-    pub(super) ps_param_index: usize,
-    pub(super) ps_param_name: String,
-    pub(super) setter_patterns: Vec<SetterPattern>,
+pub struct CrossFileState {
+    pub method_behaviors: std::collections::HashMap<String, MethodPsBehavior>,
+    pub string_constants: std::collections::HashMap<String, String>,
+}
+
+impl Default for CrossFileState {
+    fn default() -> Self {
+        Self {
+            method_behaviors: std::collections::HashMap::new(),
+            string_constants: std::collections::HashMap::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
-pub(super) enum SetterPattern {
+pub struct MethodPsBehavior {
+    pub ps_param_index: usize,
+    pub ps_param_name: String,
+    pub setter_patterns: Vec<SetterPattern>,
+}
+
+#[derive(Debug, Clone)]
+pub enum SetterPattern {
     Literal {
         index: usize,
         java_type: String,

--- a/src/java/types.rs
+++ b/src/java/types.rs
@@ -106,6 +106,7 @@ pub enum SetterPattern {
         index: usize,
         java_type: String,
         var_name: Option<String>,
+        param_index: Option<usize>,
     },
     DynamicLoop {
         java_type: String,

--- a/src/java/variable.rs
+++ b/src/java/variable.rs
@@ -9,6 +9,33 @@ use crate::java::types::*;
 
 impl<'a> ExtractContext<'a> {
     pub(super) fn visit_field_declaration(&mut self, node: Node) {
+        let type_name = self.detect_local_var_type(node);
+        if let Some(ref ts) = type_name {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "variable_declarator" {
+                    if let Some(name_node) = child.child_by_field_name("name") {
+                        self.var_types.insert(self.node_text(name_node), ts.clone());
+                    }
+                }
+            }
+            if ts == "StringBuilder" || ts == "StringBuffer" {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if child.kind() == "variable_declarator" {
+                        self.check_sb_declarator(child, true);
+                    }
+                }
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    self.visit(child);
+                }
+                return;
+            }
+        }
+        if type_name.as_deref() == Some("String") {
+            self.track_string_constant(node);
+        }
         self.check_string_declaration(node, true);
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
@@ -28,7 +55,9 @@ impl<'a> ExtractContext<'a> {
             self.check_string_declaration(node, false);
         }
 
-        if let Some(t) = type_name {
+        let is_string = type_name.as_deref() == Some("String");
+
+        if let Some(ref t) = type_name {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 if child.kind() == "variable_declarator" {
@@ -37,6 +66,10 @@ impl<'a> ExtractContext<'a> {
                     }
                 }
             }
+        }
+
+        if is_string {
+            self.track_local_string_constant(node);
         }
 
         let mut cursor = node.walk();
@@ -55,7 +88,8 @@ impl<'a> ExtractContext<'a> {
                 | "floating_point_type"
                 | "boolean_type"
                 | "generic_type"
-                | "array_type" => {
+                | "array_type"
+                | "scoped_type_identifier" => {
                     return self.extract_type_name(child);
                 }
                 _ => {}
@@ -68,12 +102,12 @@ impl<'a> ExtractContext<'a> {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             if child.kind() == "variable_declarator" {
-                self.check_sb_declarator(child);
+                self.check_sb_declarator(child, false);
             }
         }
     }
 
-    pub(super) fn check_sb_declarator(&mut self, declarator: Node) {
+    pub(super) fn check_sb_declarator(&mut self, declarator: Node, is_field_level: bool) {
         let name_node = match declarator.child_by_field_name("name") {
             Some(n) => n,
             None => return,
@@ -150,7 +184,7 @@ impl<'a> ExtractContext<'a> {
                 sql: sql_converted,
                 extraction_index: self.extractions.len() - 1,
                 is_string_builder: true,
-                is_field_level: false,
+                is_field_level,
             },
         );
     }
@@ -255,6 +289,7 @@ impl<'a> ExtractContext<'a> {
             "append" => self.handle_sb_append(node, root_var),
             "insert" => self.handle_sb_insert(node, root_var),
             "delete" => self.handle_sb_delete(node, root_var),
+            "replace" => self.handle_sb_replace(node, root_var),
             _ => {}
         }
     }
@@ -269,8 +304,12 @@ impl<'a> ExtractContext<'a> {
                 Some(n) => n,
                 None => return,
             };
-            if self.node_text(inner_name) == "append" {
-                self.handle_sb_append(object, root_var);
+            let inner_method = self.node_text(inner_name);
+            match inner_method.as_str() {
+                "append" | "insert" | "delete" | "replace" => {
+                    self.handle_string_builder_call(object, root_var, &inner_method);
+                }
+                _ => {}
             }
         }
 
@@ -325,6 +364,24 @@ impl<'a> ExtractContext<'a> {
     }
 
     pub(super) fn handle_sb_insert(&mut self, node: Node, root_var: &str) {
+        let object = match node.child_by_field_name("object") {
+            Some(n) => n,
+            None => return,
+        };
+        if object.kind() == "method_invocation" {
+            let inner_name = match object.child_by_field_name("name") {
+                Some(n) => n,
+                None => return,
+            };
+            let inner_method = self.node_text(inner_name);
+            match inner_method.as_str() {
+                "append" | "insert" | "delete" | "replace" => {
+                    self.handle_string_builder_call(object, root_var, &inner_method);
+                }
+                _ => {}
+            }
+        }
+
         let args_node = match node.child_by_field_name("arguments") {
             Some(n) if n.kind() == "argument_list" => n,
             _ => return,
@@ -411,6 +468,68 @@ impl<'a> ExtractContext<'a> {
             let chars: Vec<char> = tracked.sql.chars().collect();
             if s < chars.len() && e <= chars.len() && s < e {
                 let new_sql: String = chars[..s].iter().chain(chars[e..].iter()).collect();
+                tracked.sql = new_sql;
+
+                let idx = tracked.extraction_index;
+                let new_sql = tracked.sql.clone();
+                let sql_kind = self.extractions[idx].sql_kind;
+                let parse_result = self.try_parse_sql(&new_sql, sql_kind);
+
+                let ext = match self.extractions.get_mut(idx) {
+                    Some(e) => e,
+                    None => return,
+                };
+                ext.sql = new_sql;
+                ext.is_concatenated = true;
+                ext.origin.line = node.start_position().row + 1;
+                ext.origin.column = node.start_position().column;
+                ext.parse_result = parse_result;
+            }
+        }
+    }
+
+    pub(super) fn handle_sb_replace(&mut self, node: Node, root_var: &str) {
+        let args_node = match node.child_by_field_name("arguments") {
+            Some(n) if n.kind() == "argument_list" => n,
+            _ => return,
+        };
+
+        let mut start: Option<usize> = None;
+        let mut end: Option<usize> = None;
+        let mut value: Option<String> = None;
+        let mut cursor = args_node.walk();
+        for child in args_node.children(&mut cursor) {
+            if child.kind() == "," {
+                continue;
+            }
+            let text = self.node_text(child);
+            if start.is_none() {
+                start = self.parse_java_int(&text);
+            } else if end.is_none() {
+                end = self.parse_java_int(&text);
+            } else if value.is_none() {
+                if child.kind() == "string_literal" {
+                    let raw = self.node_text(child);
+                    let is_tb = raw.starts_with("\"\"\"");
+                    value = Some(self.decode_java_string(&raw, is_tb));
+                } else {
+                    value = Some(self.make_placeholder_for_node(child));
+                }
+            }
+        }
+
+        if let (Some(s), Some(e), Some(val)) = (start, end, value) {
+            let tracked = match self.sql_vars.get_mut(root_var) {
+                Some(t) => t,
+                None => return,
+            };
+
+            let chars: Vec<char> = tracked.sql.chars().collect();
+            if s < chars.len() && e <= chars.len() && s <= e {
+                let new_sql: String = chars[..s].iter().copied()
+                    .chain(val.chars())
+                    .chain(chars[e..].iter().copied())
+                    .collect();
                 tracked.sql = new_sql;
 
                 let idx = tracked.extraction_index;
@@ -605,5 +724,67 @@ impl<'a> ExtractContext<'a> {
                 is_field_level: false,
             },
         );
+    }
+
+    fn track_string_constant(&mut self, node: Node) {
+        if !self.has_final_modifier(node) {
+            return;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "variable_declarator" {
+                let name_node = match child.child_by_field_name("name") {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let value_node = match child.child_by_field_name("value") {
+                    Some(n) => n,
+                    None => continue,
+                };
+                if value_node.kind() == "string_literal" {
+                    let raw = self.node_text(value_node);
+                    let is_tb = raw.starts_with("\"\"\"");
+                    let val = self.decode_java_string(&raw, is_tb);
+                    self.string_constants.insert(self.node_text(name_node), val);
+                }
+            }
+        }
+    }
+
+    fn track_local_string_constant(&mut self, node: Node) {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "variable_declarator" {
+                let name_node = match child.child_by_field_name("name") {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let value_node = match child.child_by_field_name("value") {
+                    Some(n) => n,
+                    None => continue,
+                };
+                if value_node.kind() == "string_literal" {
+                    let raw = self.node_text(value_node);
+                    let is_tb = raw.starts_with("\"\"\"");
+                    let val = self.decode_java_string(&raw, is_tb);
+                    self.string_constants.insert(self.node_text(name_node), val);
+                }
+            }
+        }
+    }
+
+    fn has_final_modifier(&self, node: Node) -> bool {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "modifiers" {
+                let mut mc = child.walk();
+                for m in child.children(&mut mc) {
+                    if self.node_text(m) == "final" {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
     }
 }

--- a/src/java/variable.rs
+++ b/src/java/variable.rs
@@ -203,12 +203,27 @@ impl<'a> ExtractContext<'a> {
             Some(n) => n,
             None => return,
         };
-        let value_node = match declarator.child_by_field_name("value") {
-            Some(n) => n,
-            None => return,
-        };
-
         let var_name = self.node_text(name_node);
+        let value_node = declarator.child_by_field_name("value");
+
+        if value_node.is_none() {
+            let var_name_upper = var_name.to_uppercase();
+            let name_hints_sql = self.sql_var_patterns_upper.iter().any(|p| var_name_upper.contains(p.as_str()));
+            if name_hints_sql {
+                self.sql_vars.insert(
+                    var_name,
+                    TrackedVar {
+                        sql: String::new(),
+                        extraction_index: usize::MAX,
+                        is_string_builder: false,
+                        is_field_level,
+                    },
+                );
+            }
+            return;
+        }
+        let value_node = value_node.unwrap();
+
         let (sql_text, is_text_block) = match self.extract_string_value(value_node) {
             Some(v) => v,
             None => return,


### PR DESCRIPTION
## Summary

Fixes the last two known gaps (M4: Java 14 switch expression, O10: return-statement SQL) and extends coverage with 16 new diagnostic tests (M6-M11, O13-O20). All 1458 tests pass with zero regressions.

## Changes

### New capabilities
- **Switch expression SQL extraction**: extracts SQL from Java 14+ `switch` arrow-syntax cases
- **Return-statement SQL extraction**: extracts SQL from `return "SQL..."` inside if/else, switch/case, try/catch, and nested blocks  
- **Shared extraction helper**: `extract_expression_sql` used by both switch and return paths
- **Cross-method JDBC setter backfill**: `? → __JAVA_VAR_JDBC_PARAM_N__` conversion at PS creation time, `toString()` PS resolution, parameter name substitution from call site
- **Transitive delegation behavior**: methods that delegate to PS-parameterized helpers now inherit their setter patterns
- **Method return SQL tracking**: methods returning SQL strings are tracked for cross-method resolution

### Infrastructure
- `SetterPattern::Literal` gains `param_index` field for parameter name substitution
- `PendingInjection` carries `call_arg_names` for call-site→formal-param mapping
- `record_delegation_behavior`, `track_return_sql`, `visit_switch_expression`, `visit_return_statement` added
- `field_access` and `identifier` handling in `extract_string_value` for cross-file constant resolution
- Primitive type parameter recognition (`int`, `boolean`, etc.)

### Tests
- M6: switch_expression assigned to var
- M7: switch_expression with concat
- M8: switch_expression as method arg
- M9: switch_expression non-SQL (negative)
- M10: switch_expression with JDBC placeholders
- M11: switch_expression in SB append
- O13-O20: return SQL from if, switch, ternary, concat, deep nesting, try/catch, caller usage, non-SQL (negative)

## Test results
```
1458 passed; 0 failed
```