### PR TITLE
fix(ci): build Windows release with --features cli for Win7 compatibility (#186)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
           restore-keys: x86_64-pc-windows-gnu-cargo-
 
       - name: Build
-        run: cargo build --release --features ${{ env.BUILD_FEATURES }} --target x86_64-pc-windows-gnu
+        run: cargo build --release --features cli --target x86_64-pc-windows-gnu
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.6.2"
+version = "0.6.4"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Fixes #186: Windows 7 crash 'GetHostNameW entry point not found in WS2_32.dll'.

## Root Cause

The Windows release binary was built with `--features full`, which pulls in `tokio` -> `socket2` -> `windows-sys` (`GetHostNameW` from `WS2_32.dll`). `GetHostNameW` is a Windows 8+ API - not available on Windows 7.

## Changes

1. **release.yml**: Windows build now uses `--features cli` instead of `--features full`. The CLI-only binary has no networking dependencies and is fully compatible with Windows 7.
2. **Version bump**: 0.6.3 -> 0.6.4

## Windows 7 Available Commands

All CLI subcommands work: parse, format, tokenize, validate, json2sql, parse-xml, parse-java.

`serve`, `playground`, and `ogsql-mcp` remain available on Windows 8+ by building with `--features full`.