### PR TITLE
fix(ibatis): prevent #param# matching inside SQL string literals

### DIFF
--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -199,14 +199,38 @@ fn flush_text_to_nodes(text_buf: &mut String, nodes: &mut Vec<SqlNode>) {
     nodes.extend(parse_text_to_nodes(&text));
 }
 
-fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
+pub(crate) fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
     let mut nodes = Vec::new();
     let mut current_text = String::new();
     let chars: Vec<char> = text.chars().collect();
     let len = chars.len();
     let mut i = 0;
+    let mut in_single_quote = false;
 
     while i < len {
+        if in_single_quote {
+            if chars[i] == '\'' {
+                if i + 1 < len && chars[i + 1] == '\'' {
+                    current_text.push_str("''");
+                    i += 2;
+                    continue;
+                }
+                current_text.push('\'');
+                in_single_quote = false;
+            } else {
+                current_text.push(chars[i]);
+            }
+            i += 1;
+            continue;
+        }
+
+        if chars[i] == '\'' {
+            current_text.push('\'');
+            in_single_quote = true;
+            i += 1;
+            continue;
+        }
+
         if chars[i] == '#' && i + 1 < len && chars[i + 1] == '{' {
             if let Some(end) = find_closing_brace(&chars, i + 2) {
                 if !current_text.is_empty() {
@@ -232,14 +256,14 @@ fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
             }
         }
 
-        // iBatis 2.x #param# format
+        // iBatis 2.x #param# format — only when NOT inside a string literal
         if chars[i] == '#' && (i + 1 >= len || chars[i + 1] != '{') {
             let start = i + 1;
             let mut end = start;
-            while end < len && chars[end] != '#' {
+            while end < len && chars[end] != '\'' && chars[end] != '#' {
                 end += 1;
             }
-            if end < len && end > start {
+            if end < len && chars[end] == '#' && end > start {
                 let param: String = chars[start..end].iter().collect();
                 if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
                     if !current_text.is_empty() {
@@ -253,14 +277,14 @@ fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
             }
         }
 
-        // iBatis 2.x $param$ format
+        // iBatis 2.x $param$ format — only when NOT inside a string literal
         if chars[i] == '$' && (i + 1 >= len || chars[i + 1] != '{') {
             let start = i + 1;
             let mut end = start;
-            while end < len && chars[end] != '$' {
+            while end < len && chars[end] != '\'' && chars[end] != '$' {
                 end += 1;
             }
-            if end < len && end > start {
+            if end < len && chars[end] == '$' && end > start {
                 let param: String = chars[start..end].iter().collect();
                 if !param.contains(' ') && !param.contains('\n') && !param.contains('\r') {
                     if !current_text.is_empty() {

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -1613,6 +1613,68 @@ fn test_expand_parse_results_variants_with_parse_result() {
 }
 
 #[test]
+fn test_hash_in_sql_string_literal_not_mistaken_for_param() {
+    // Regression: '# inside SQL string literals was misinterpreted as iBatis 2.x #param# delimiters.
+    // The SQL: select substr(#{str},instr(#{str},'#')+1,instr(#{str},'#',instr(#{str},'#')+1)-instr(#{str},'#')-1)
+    // Contains 5 occurrences of #{str} and 5 occurrences of '#' — the '#' must stay as text.
+    let xml = br#"<mapper namespace="test">
+        <select id="getSeqNo" parameterType="String" resultType="String">
+            select substr(#{str},instr(#{str},'#')+1,instr(#{str},'#',instr(#{str},'#')+1)-instr(#{str},'#')-1)
+        </select>
+    </mapper>"#;
+    let result = super::parse_mapper_bytes_structured(xml);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let stmt = &result.statements[0];
+    assert_eq!(stmt.id, "getSeqNo");
+
+    // All parameters must be named "str" — no garbage like "')+1" or "'"
+    for (i, p) in stmt.parameters.iter().enumerate() {
+        assert_eq!(
+            p.name, "str",
+            "parameter[{}] should be 'str', got '{}'",
+            i, p.name
+        );
+    }
+    // Exactly 5 #{str} occurrences
+    assert_eq!(stmt.parameters.len(), 5, "expected 5 params, got {}: {:?}", stmt.parameters.len(), stmt.parameters);
+
+    // flat_sql should preserve '#' literals
+    let parsed = stmt.to_parsed_statement("test");
+    assert!(parsed.flat_sql.contains(",'#'"), "flat_sql should contain '#' literal, got: {}", parsed.flat_sql);
+    assert!(
+        !parsed.flat_sql.contains("__XML_PARAM____"),
+        "flat_sql should not have double-underscore param corruption: {}",
+        parsed.flat_sql
+    );
+
+    // The SQL must parse without errors
+    if let Some((_, errors)) = &parsed.parse_result {
+        assert!(errors.is_empty(), "SQL parse errors: {:?}", errors);
+    }
+}
+
+#[test]
+fn test_ibatis2_param_respects_string_literals() {
+    // Simpler case: iBatis 2.x #value# format should NOT match when # is inside '...'
+    // The text "WHERE sep = '#' AND id = #value#" should yield:
+    //   Text("WHERE sep = '#' AND id = "), Parameter("value")
+    let nodes = super::parser::parse_text_to_nodes("WHERE sep = '#' AND id = #value#");
+    // Expect: Text("WHERE sep = '#' AND id = "), Parameter("value")
+    let params: Vec<_> = nodes.iter().filter(|n| matches!(n, SqlNode::Parameter { .. })).collect();
+    assert_eq!(params.len(), 1, "expected exactly 1 parameter, got nodes: {:?}", nodes);
+    if let SqlNode::Parameter { name, .. } = params[0] {
+        assert_eq!(name, "value", "parameter name should be 'value', got '{}'", name);
+    }
+    // The '#' text literal should be preserved in a Text node
+    let text_content: String = nodes.iter().filter_map(|n| match n {
+        SqlNode::Text { content } => Some(content.as_str()),
+        _ => None,
+    }).collect();
+    assert!(text_content.contains("'#'"), "text should contain '#' literal, got: {}", text_content);
+}
+
+#[test]
 fn test_expand_parse_results_empty_variant_has_none() {
     let xml = br#"<mapper namespace="test">
         <select id="find">


### PR DESCRIPTION
## Problem

The iBatis 2.x `#param#` scanner in `parse_text_to_nodes()` did not respect SQL string literal boundaries. When SQL contained `'#'` (e.g., `instr(#{str},'#')`), the `#` inside the string literal was incorrectly treated as an iBatis 2.x parameter delimiter.

**Example input:**
```xml
<select id="getSeqNo" parameterType="String" resultType="String">
  select substr(#{str},instr(#{str},'#')+1,instr(#{str},'#',instr(#{str},'#')+1)-instr(#{str},'#')-1)
</select>
```

**Before (broken):** Produced garbage parameters named `')+1` and `'`, and corrupted `flat_sql`.

**After (fixed):** Correctly produces 5 `str` parameters, all `'#'` literals preserved as text.

## Fix

1. **Track single-quote state** — When inside a `'...'` string literal, skip all `#`/`$` parameter scanning and emit characters as text. Handles escaped quotes (`''`).

2. **Add quote boundary to scan loops** — The iBatis 2.x `#param#` and `$param$` forward scans now stop at `'` boundaries instead of greedily consuming across string literals.

3. **Tighten match validation** — Only match when the scan terminates at the correct delimiter (`#` or `$`), not at a quote character.

## Testing

- 2 new regression tests added
- All 92 existing ibatis tests pass (zero regressions)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)