### PR TITLE
fix(ibatis): stored procedure callable statement parsing (v0.6.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru"
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.6.6"
+version = "0.6.8"
 dependencies = [
  "axum",
  "clap",
@@ -1483,9 +1483,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/src/ibatis/expand.rs
+++ b/src/ibatis/expand.rs
@@ -58,9 +58,10 @@ fn expand_node(node: &SqlNode, variants: &mut Vec<ExpansionState>, depth: usize,
                 v.sql_buffer.push_str(&rendered);
             }
         }
-        SqlNode::Parameter { name, java_type } => {
+        SqlNode::Parameter { name, java_type, jdbc_type, .. } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
             for v in variants.iter_mut() {
-                v.sql_buffer.push_str(&render_parameter(name, java_type, config.placeholder));
+                v.sql_buffer.push_str(&render_parameter(name, type_str, config.placeholder));
                 if !v.params.iter().any(|p| p.name == *name) {
                     v.params.push(ParamMeta {
                         name: name.clone(),
@@ -72,9 +73,10 @@ fn expand_node(node: &SqlNode, variants: &mut Vec<ExpansionState>, depth: usize,
                 }
             }
         }
-        SqlNode::RawExpr { expr, java_type } => {
+        SqlNode::RawExpr { expr, java_type, jdbc_type } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
             for v in variants.iter_mut() {
-                v.sql_buffer.push_str(&render_raw(expr, java_type, config.placeholder));
+                v.sql_buffer.push_str(&render_raw(expr, type_str, config.placeholder));
                 if !v.params.iter().any(|p| p.name == *expr) {
                     v.params.push(ParamMeta {
                         name: expr.clone(),
@@ -327,11 +329,11 @@ fn render_text_params(text: &str, strategy: PlaceholderStrategy) -> String {
     }
 }
 
-fn render_parameter(name: &str, java_type: &Option<String>, strategy: PlaceholderStrategy) -> String {
+fn render_parameter(name: &str, type_str: Option<&str>, strategy: PlaceholderStrategy) -> String {
     match strategy {
         PlaceholderStrategy::PreserveInternalMarkers => {
             let sanitized = sanitize_param_name(name);
-            match java_type {
+            match type_str {
                 Some(t) => format!("{}{}_{}{}", PARAM_PREFIX, t.to_uppercase(), sanitized, PLACEHOLDER_SUFFIX),
                 None => format!("{}{}{}", PARAM_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
             }
@@ -340,11 +342,11 @@ fn render_parameter(name: &str, java_type: &Option<String>, strategy: Placeholde
     }
 }
 
-fn render_raw(expr: &str, java_type: &Option<String>, strategy: PlaceholderStrategy) -> String {
+fn render_raw(expr: &str, type_str: Option<&str>, strategy: PlaceholderStrategy) -> String {
     match strategy {
         PlaceholderStrategy::PreserveInternalMarkers => {
             let sanitized = sanitize_param_name(expr);
-            match java_type {
+            match type_str {
                 Some(t) => format!("{}{}_{}{}", RAW_PREFIX, t.to_uppercase(), sanitized, PLACEHOLDER_SUFFIX),
                 None => format!("{}{}{}", RAW_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
             }

--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -22,16 +22,18 @@ pub fn sanitize_param_name(name: &str) -> String {
 pub fn flatten_sql(node: &SqlNode) -> String {
     match node {
         SqlNode::Text { content } => replace_params(content),
-        SqlNode::Parameter { name, java_type } => {
+        SqlNode::Parameter { name, java_type, jdbc_type, .. } => {
             let sanitized = sanitize_param_name(name);
-            match java_type {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            match type_str {
                 Some(t) => format!("{}{}_{}{}", PARAM_PREFIX, t.to_uppercase(), sanitized, PLACEHOLDER_SUFFIX),
                 None => format!("{}{}{}", PARAM_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
             }
         }
-        SqlNode::RawExpr { expr, java_type } => {
+        SqlNode::RawExpr { expr, java_type, jdbc_type } => {
             let sanitized = sanitize_param_name(expr);
-            match java_type {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            match type_str {
                 Some(t) => format!("{}{}_{}{}", RAW_PREFIX, t.to_uppercase(), sanitized, PLACEHOLDER_SUFFIX),
                 None => format!("{}{}{}", RAW_PREFIX, sanitized, PLACEHOLDER_SUFFIX),
             }
@@ -63,8 +65,9 @@ pub fn flatten_sql(node: &SqlNode) -> String {
                 suffix_overrides.as_deref(),
             )
         }
-        SqlNode::ForEach { open, separator: _, close, prepend, children, .. } => {
-            let content = flatten_children(children);
+        SqlNode::ForEach { open, separator, close, prepend, children, .. } => {
+            let sep = separator.as_deref().unwrap_or("");
+            let content = flatten_children_with_separator(children, sep);
             let open_str = open.as_deref().unwrap_or("");
             let close_str = close.as_deref().unwrap_or("");
             let body = format!("{}{}{}", open_str, content, close_str);
@@ -81,6 +84,19 @@ pub fn flatten_sql(node: &SqlNode) -> String {
 fn flatten_children(children: &[SqlNode]) -> String {
     let raw: String = children.iter().map(flatten_sql).collect();
     deduplicate_conjunctions(&raw)
+}
+
+/// Flatten children with a separator between non-empty segments.
+/// Used by ForEach to preserve the `separator` attribute.
+fn flatten_children_with_separator(children: &[SqlNode], separator: &str) -> String {
+    let segments: Vec<String> = children
+        .iter()
+        .map(|c| flatten_sql(c))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let joined = segments.join(separator);
+    deduplicate_conjunctions(&joined)
 }
 
 fn deduplicate_conjunctions(sql: &str) -> String {
@@ -137,19 +153,21 @@ pub fn collect_params(node: &SqlNode) -> Vec<(String, Option<String>, String)> {
 
 fn collect_params_recursive(node: &SqlNode, params: &mut Vec<(String, Option<String>, String)>) {
     match node {
-        SqlNode::Parameter { name, java_type } => {
-            let raw = match java_type {
-                Some(t) => format!("#{{{},{}}}", name, format!("javaType={}", t)),
+        SqlNode::Parameter { name, java_type, jdbc_type, .. } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            let raw = match type_str {
+                Some(t) => format!("#{{{},{}}}", name, format!("jdbcType={}", t)),
                 None => format!("#{{{}}}", name),
             };
-            params.push((name.clone(), java_type.clone(), raw));
+            params.push((name.clone(), type_str.map(|s| s.to_string()), raw));
         }
-        SqlNode::RawExpr { expr, java_type } => {
-            let raw = match java_type {
-                Some(t) => format!("${{{},{}}}", expr, format!("javaType={}", t)),
+        SqlNode::RawExpr { expr, java_type, jdbc_type } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            let raw = match type_str {
+                Some(t) => format!("${{{},{}}}", expr, format!("jdbcType={}", t)),
                 None => format!("${{{}}}", expr),
             };
-            params.push((expr.clone(), java_type.clone(), raw));
+            params.push((expr.clone(), type_str.map(|s| s.to_string()), raw));
         }
         SqlNode::If { children, .. }
         | SqlNode::Where { children, .. }
@@ -420,7 +438,7 @@ mod param_tests {
 
     #[test]
     fn test_param_with_type_annotation() {
-        assert_eq!(replace_params("#{price,javaType=double,jdbcType=NUMERIC}"), "__XML_PARAM_DOUBLE_price__");
+        assert_eq!(replace_params("#{price,javaType=double,jdbcType=NUMERIC}"), "__XML_PARAM_NUMERIC_price__");
     }
 
     #[test]

--- a/src/ibatis/mod.rs
+++ b/src/ibatis/mod.rs
@@ -138,12 +138,15 @@ pub fn parse_mapper_bytes_structured_with_path(xml: &[u8], file_path: Option<&st
             let collected = flatten::collect_params(&stmt.body);
             let parameters: Vec<ParamMeta> = collected
                 .iter()
-                .map(|(name, java_type, raw)| ParamMeta {
-                    name: name.clone(),
-                    jdbc_type: None,
-                    source: java_type.as_ref().map(|_| InferenceSource::InlineJavaType),
-                    position: 0,
-                    raw: raw.clone(),
+                .map(|(name, type_hint, raw)| {
+                    let jdbc_type = type_hint.as_ref().and_then(|s| util::jdbc_type_from_str(s));
+                    ParamMeta {
+                        name: name.clone(),
+                        jdbc_type,
+                        source: type_hint.as_ref().map(|_| InferenceSource::InlineJdbcType),
+                        position: 0,
+                        raw: raw.clone(),
+                    }
                 })
                 .collect();
 
@@ -156,6 +159,8 @@ pub fn parse_mapper_bytes_structured_with_path(xml: &[u8], file_path: Option<&st
                 has_dynamic_elements: has_dynamic,
                 location: XmlSourceLocation { file_path: file_path.map(|s| s.to_string()), line: stmt.line },
                 parameters,
+                database_id: stmt.database_id.clone(),
+                statement_type: stmt.statement_type.clone(),
             }
         })
         .collect();
@@ -215,12 +220,15 @@ fn parse_mapper_bytes_internal(
         #[cfg(not(feature = "java"))]
         let parameters: Vec<types::ParamMeta> = collected
             .iter()
-            .map(|(name, java_type, raw)| types::ParamMeta {
-                name: name.clone(),
-                jdbc_type: None,
-                source: java_type.as_ref().map(|_| types::InferenceSource::InlineJavaType),
-                position: 0,
-                raw: raw.clone(),
+            .map(|(name, type_hint, raw)| {
+                let jdbc_type = type_hint.as_ref().and_then(|s| util::jdbc_type_from_str(s));
+                types::ParamMeta {
+                    name: name.clone(),
+                    jdbc_type,
+                    source: type_hint.as_ref().map(|_| types::InferenceSource::InlineJdbcType),
+                    position: 0,
+                    raw: raw.clone(),
+                }
             })
             .collect();
 
@@ -249,6 +257,8 @@ fn parse_mapper_bytes_internal(
             has_dynamic_elements: has_dynamic,
             line: stmt.line,
             parse_result,
+            database_id: stmt.database_id.clone(),
+            statement_type: stmt.statement_type.clone(),
         });
     }
 

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -10,7 +10,7 @@ use crate::ibatis::error::IbatisError;
 use crate::ibatis::types::{
     MapperFile, MapperStatement, ParameterMapDef, ParameterMapEntry, SqlFragment, SqlNode, StatementKind,
 };
-use crate::ibatis::util::{find_closing_brace, parse_param_type};
+use crate::ibatis::util::{find_closing_brace, parse_param_attrs, parse_param_type};
 
 const SKIP_TAGS: &[&str] = &["resultMap", "cache", "cache-ref", "selectKey"];
 
@@ -45,6 +45,8 @@ pub fn parse_xml(xml: &[u8]) -> Result<MapperFile, IbatisError> {
                     let result_type = get_attr(&e, "resultType")
                         .or_else(|| get_attr(&e, "resultMap"))
                         .or_else(|| get_attr(&e, "resultClass"));
+                    let database_id = get_attr(&e, "databaseId");
+                    let statement_type = get_attr(&e, "statementType");
                     let children = read_node_tree(&mut reader, tag.as_ref());
                     statements.push(MapperStatement {
                         kind,
@@ -53,6 +55,8 @@ pub fn parse_xml(xml: &[u8]) -> Result<MapperFile, IbatisError> {
                         result_type,
                         body: merge_children(children),
                         line,
+                        database_id,
+                        statement_type,
                     });
                 } else if tag.as_ref().eq_ignore_ascii_case(b"parameterMap") {
                     let id = get_attr(&e, "id").unwrap_or_default();
@@ -237,8 +241,14 @@ pub(crate) fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                     nodes.push(SqlNode::Text { content: std::mem::take(&mut current_text) });
                 }
                 let param: String = chars[i + 2..end].iter().collect();
-                let (name, java_type) = parse_param_type(&param);
-                nodes.push(SqlNode::Parameter { name, java_type });
+                let (name, attrs) = parse_param_attrs(&param);
+                nodes.push(SqlNode::Parameter {
+                    name,
+                    java_type: attrs.java_type,
+                    jdbc_type: attrs.jdbc_type,
+                    mode: attrs.mode,
+                    result_map: attrs.result_map,
+                });
                 i = end + 1;
                 continue;
             }
@@ -249,8 +259,12 @@ pub(crate) fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                     nodes.push(SqlNode::Text { content: std::mem::take(&mut current_text) });
                 }
                 let raw: String = chars[i + 2..end].iter().collect();
-                let (expr, java_type) = parse_param_type(&raw);
-                nodes.push(SqlNode::RawExpr { expr, java_type });
+                let (expr, attrs) = parse_param_attrs(&raw);
+                nodes.push(SqlNode::RawExpr {
+                    expr,
+                    java_type: attrs.java_type,
+                    jdbc_type: attrs.jdbc_type,
+                });
                 i = end + 1;
                 continue;
             }
@@ -269,8 +283,14 @@ pub(crate) fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                     if !current_text.is_empty() {
                         nodes.push(SqlNode::Text { content: std::mem::take(&mut current_text) });
                     }
-                    let (name, java_type) = parse_param_type(&param);
-                    nodes.push(SqlNode::Parameter { name, java_type });
+                    let (name, attrs) = parse_param_attrs(&param);
+                    nodes.push(SqlNode::Parameter {
+                        name,
+                        java_type: attrs.java_type,
+                        jdbc_type: attrs.jdbc_type,
+                        mode: attrs.mode,
+                        result_map: attrs.result_map,
+                    });
                     i = end + 1;
                     continue;
                 }
@@ -291,8 +311,12 @@ pub(crate) fn parse_text_to_nodes(text: &str) -> Vec<SqlNode> {
                         nodes.push(SqlNode::Text { content: std::mem::take(&mut current_text) });
                     }
                     let raw: String = chars[start..end].iter().collect();
-                    let (expr, java_type) = parse_param_type(&raw);
-                    nodes.push(SqlNode::RawExpr { expr, java_type });
+                    let (expr, attrs) = parse_param_attrs(&raw);
+                    nodes.push(SqlNode::RawExpr {
+                        expr,
+                        java_type: attrs.java_type,
+                        jdbc_type: attrs.jdbc_type,
+                    });
                     i = end + 1;
                     continue;
                 }
@@ -421,14 +445,20 @@ fn merge_children(children: Vec<SqlNode>) -> SqlNode {
 fn simple_node_to_text(node: &SqlNode) -> String {
     match node {
         SqlNode::Text { content } => content.clone(),
-        SqlNode::Parameter { name, java_type } => match java_type {
-            Some(t) => format!("#{{{},{}}}", name, format!("javaType={}", t)),
-            None => format!("#{{{}}}", name),
-        },
-        SqlNode::RawExpr { expr, java_type } => match java_type {
-            Some(t) => format!("${{{},{}}}", expr, format!("javaType={}", t)),
-            None => format!("${{{}}}", expr),
-        },
+        SqlNode::Parameter { name, java_type, jdbc_type, .. } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            match type_str {
+                Some(t) => format!("#{{{},{}}}", name, format!("jdbcType={}", t)),
+                None => format!("#{{{}}}", name),
+            }
+        }
+        SqlNode::RawExpr { expr, java_type, jdbc_type } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            match type_str {
+                Some(t) => format!("${{{},{}}}", expr, format!("jdbcType={}", t)),
+                None => format!("${{{}}}", expr),
+            }
+        }
         _ => String::new(),
     }
 }

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -143,14 +143,20 @@ fn node_text(node: &SqlNode) -> String {
     match node {
         SqlNode::Text { content } => content.clone(),
         SqlNode::Sequence { children } => children.iter().map(node_text).collect(),
-        SqlNode::Parameter { name, java_type } => match java_type {
-            Some(t) => format!("#{{{},{}}}", name, format!("javaType={}", t)),
-            None => format!("#{{{}}}", name),
-        },
-        SqlNode::RawExpr { expr, java_type } => match java_type {
-            Some(t) => format!("${{{},{}}}", expr, format!("javaType={}", t)),
-            None => format!("${{{}}}", expr),
-        },
+        SqlNode::Parameter { name, java_type, jdbc_type, .. } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            match type_str {
+                Some(t) => format!("#{{{},{}}}", name, format!("jdbcType={}", t)),
+                None => format!("#{{{}}}", name),
+            }
+        }
+        SqlNode::RawExpr { expr, java_type, jdbc_type } => {
+            let type_str: Option<&str> = jdbc_type.as_deref().or(java_type.as_deref());
+            match type_str {
+                Some(t) => format!("${{{},{}}}", expr, format!("jdbcType={}", t)),
+                None => format!("${{{}}}", expr),
+            }
+        }
         SqlNode::If { children, .. } => children.iter().map(node_text).collect(),
         SqlNode::Choose { branches } => branches.iter().flat_map(|(_, ch)| ch.iter().map(node_text)).collect(),
         SqlNode::Where { children } => children.iter().map(node_text).collect(),
@@ -1691,4 +1697,299 @@ fn test_expand_parse_results_empty_variant_has_none() {
         .unwrap();
     assert!(excluded.sql.trim().is_empty());
     assert!(excluded.parse_result.is_none(), "empty SQL should not generate parse_result");
+}
+
+// ── Guard Tests: Callable Stored Procedure Mapper XML ──
+// These tests guard against regressions in parsing complex stored procedure
+// call mappers with foreach, if, #{param,mode=IN,jdbcType=VARCHAR} syntax.
+
+/// Helper: the canonical callable stored procedure mapper XML from user reports.
+fn callable_proc_mapper_xml() -> &'static [u8] {
+    br#"<mapper namespace="com.example.ProcMapper">
+   <select id="callOracleProcCommon" statementType="CALLABLE" resultType="java.util.Map">
+       call ${procName}
+       <foreach collection="param" item="item" index="index" open="(" close=")" separator=",">
+           <if test="item.param == 'i'.toString()">
+               #{item.paramValue,mode=IN,jdbcType=VARCHAR}
+           </if>
+           <if test="item.param == '?'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=VARCHAR}
+           </if>
+           <if test="item.param == 'c'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=CURSOR,resultMap=myMap}
+           </if>
+           <if test="item.param == 'b'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=CLOB,javaType=String}
+           </if>
+       </foreach>
+   </select>
+   <select id="callOracleProcCommon" statementType="CALLABLE" resultType="java.util.Map" databaseId="gauss">
+       {call ${procName}
+       <foreach collection="param" item="item" index="index" open="(" close=")" separator=",">
+           <if test="item.param == 'i'.toString()">
+               #{item.paramValue,mode=IN,jdbcType=VARCHAR}
+           </if>
+           <if test="item.param == '?'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=VARCHAR}
+           </if>
+           <if test="item.param == 'c'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=OTHER,resultMap=MDBCursorMapGauss}
+           </if>
+           <if test="item.param == 'b'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=CLOB,javaType=String}
+           </if>
+       </foreach>
+       }
+   </select>
+   <select id="callOracleProcNoCursor" statementType="CALLABLE" resultType="java.util.Map">
+       call ${procName}
+       <foreach collection="params" item="item" index="index" open="(" close=")" separator=",">
+           <if test="item != '?'.toString()">
+               #{item,mode=IN,jdbcType=VARCHAR}
+           </if>
+           <if test="item == '?'.toString()">
+               #{outParam.key${index},mode=OUT,jdbcType=VARCHAR}
+           </if>
+       </foreach>
+   </select>
+   <select id="callOracleProcCursorOut4" statementType="CALLABLE">
+       {call ${procName}(
+       <foreach collection="inParams" item="item" index="index" separator=",">
+           #{item,mode=IN,jdbcType=VARCHAR}
+       </foreach>
+       <if test="inParams.length > 0">
+           ,
+       </if>
+       #{outParam.o_retcode,mode=OUT,jdbcType=VARCHAR},
+       #{outParam.o_retmsg,mode=OUT,jdbcType=VARCHAR},
+       #{outParam.o_totalnum,mode=OUT,jdbcType=VARCHAR},
+       #{outParam.o_list,mode=OUT,jdbcType=CURSOR,resultMap=MDBCursorMap,javaType=java.lang.Object}
+       )}
+   </select>
+</mapper>"#
+}
+
+// ── Guard: Issue #3 — databaseId captured ──
+
+#[test]
+fn guard_database_id_captured() {
+    let result = super::parse_mapper_bytes_structured(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    // Should have 4 statements total
+    assert_eq!(result.statements.len(), 4, "expected 4 statements, got {}", result.statements.len());
+
+    // First callOracleProcCommon has NO databaseId
+    let first_common = &result.statements[0];
+    assert_eq!(first_common.id, "callOracleProcCommon");
+    assert_eq!(first_common.database_id, None, "first callOracleProcCommon should have database_id=None");
+
+    // Second callOracleProcCommon HAS databaseId="gauss"
+    let gauss_common = &result.statements[1];
+    assert_eq!(gauss_common.id, "callOracleProcCommon");
+    assert_eq!(
+        gauss_common.database_id,
+        Some("gauss".to_string()),
+        "second callOracleProcCommon should have database_id=Some(\"gauss\")"
+    );
+}
+
+// ── Guard: Issue #5 — statementType captured ──
+
+#[test]
+fn guard_statement_type_captured() {
+    let result = super::parse_mapper_bytes_structured(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    for stmt in &result.statements {
+        assert_eq!(
+            stmt.statement_type,
+            Some("CALLABLE".to_string()),
+            "statement '{}' should have statement_type=CALLABLE",
+            stmt.id
+        );
+    }
+}
+
+// ── Guard: Issue #4 — jdbcType preserved separately from javaType ──
+
+#[test]
+fn guard_jdbc_type_preserved_separately() {
+    let result = super::parse_mapper_bytes_structured(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    // In the 4th statement (callOracleProcCursorOut4), the last param has both
+    // jdbcType=CURSOR and javaType=java.lang.Object — both must be preserved.
+    let stmt = result.statements.iter().find(|s| s.id == "callOracleProcCursorOut4").unwrap();
+
+    // Find the outParam.o_list parameter — it should have jdbcType=CURSOR
+    let o_list = stmt.parameters.iter().find(|p| p.name == "outParam.o_list");
+    assert!(o_list.is_some(), "should have outParam.o_list parameter");
+    let o_list = o_list.unwrap();
+    assert_eq!(
+        o_list.jdbc_type,
+        Some(crate::ibatis::types::JdbcType::Cursor),
+        "outParam.o_list should have jdbc_type=Cursor, got: {:?}",
+        o_list.jdbc_type
+    );
+}
+
+// ── Guard: Issue #6 — mode and resultMap preserved in parameter attrs ──
+
+#[test]
+fn guard_mode_preserved_in_param_attrs() {
+    use crate::ibatis::types::SqlNode;
+
+    let result = super::parse_mapper_bytes_structured(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    // In callOracleProcCommon, find the If with test="item.param == 'i'.toString()"
+    // Its child Parameter should have mode=IN, jdbcType=VARCHAR
+    let stmt = &result.statements[0];
+
+    fn find_if_with_test<'a>(node: &'a SqlNode, test_contains: &str) -> Option<&'a SqlNode> {
+        match node {
+            SqlNode::If { test, children, .. } if test.contains(test_contains) => Some(node),
+            SqlNode::If { children, .. } => children.iter().find_map(|c| find_if_with_test(c, test_contains)),
+            SqlNode::ForEach { children, .. } => children.iter().find_map(|c| find_if_with_test(c, test_contains)),
+            SqlNode::Sequence { children } => children.iter().find_map(|c| find_if_with_test(c, test_contains)),
+            SqlNode::Where { children } | SqlNode::Set { children } => {
+                children.iter().find_map(|c| find_if_with_test(c, test_contains))
+            }
+            _ => None,
+        }
+    }
+
+    let if_in = find_if_with_test(&stmt.body, "item.param == 'i'").expect("should find If node for 'i'");
+    if let SqlNode::If { children, .. } = if_in {
+        let param = children.iter().find_map(|c| match c {
+            SqlNode::Parameter { name, .. } if name == "item.paramValue" => Some(c),
+            _ => None,
+        });
+        assert!(param.is_some(), "should find Parameter 'item.paramValue' in If(IN) branch");
+        if let SqlNode::Parameter { mode, jdbc_type, .. } = param.unwrap() {
+            assert_eq!(mode, &Some("IN".to_string()), "item.paramValue should have mode=IN");
+            assert_eq!(jdbc_type, &Some("VARCHAR".to_string()), "item.paramValue should have jdbc_type=VARCHAR");
+        }
+    }
+
+    // Check OUT param has mode=OUT
+    let if_out = find_if_with_test(&stmt.body, "item.param == '?'").expect("should find If node for '?'");
+    if let SqlNode::If { children, .. } = if_out {
+        let param = children.iter().find_map(|c| match c {
+            n @ SqlNode::Parameter { name, .. } if name.contains("outParam.key") => Some(n),
+            _ => None,
+        });
+        assert!(param.is_some(), "should find outParam.key param in If(OUT) branch");
+        if let SqlNode::Parameter { mode, jdbc_type, .. } = param.unwrap() {
+            assert_eq!(mode, &Some("OUT".to_string()), "outParam.key should have mode=OUT");
+            assert_eq!(jdbc_type, &Some("VARCHAR".to_string()), "outParam.key should have jdbc_type=VARCHAR");
+        }
+    }
+
+    // Check CURSOR param has resultMap
+    let if_cursor = find_if_with_test(&stmt.body, "item.param == 'c'").expect("should find If node for 'c'");
+    if let SqlNode::If { children, .. } = if_cursor {
+        let param = children.iter().find_map(|c| match c {
+            n @ SqlNode::Parameter { name, .. } if name.contains("outParam.key") => Some(n),
+            _ => None,
+        });
+        assert!(param.is_some(), "should find outParam.key param in If(CURSOR) branch");
+        if let SqlNode::Parameter { result_map, jdbc_type, .. } = param.unwrap() {
+            assert_eq!(jdbc_type, &Some("CURSOR".to_string()), "CURSOR param should have jdbc_type=CURSOR");
+            assert_eq!(
+                result_map, &Some("myMap".to_string()),
+                "CURSOR param should have result_map=myMap"
+            );
+        }
+    }
+}
+
+// ── Guard: Issue #1 — ForEach separator preserved in flatten ──
+
+#[test]
+fn guard_foreach_separator_in_flat_sql() {
+    let result = super::parse_mapper_bytes(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    // callOracleProcCursorOut4 has foreach with separator=","
+    // The flattened SQL should contain the separator
+    let stmt = result
+        .statements
+        .iter()
+        .find(|s| s.id == "callOracleProcCursorOut4")
+        .expect("should find callOracleProcCursorOut4");
+
+    let sql = &stmt.flat_sql;
+    // The foreach body has #{item,mode=IN,jdbcType=VARCHAR} with separator=","
+    // In the flattened SQL, the separator should appear between items
+    assert!(
+        sql.contains(",") || sql.contains("__XML_PARAM"),
+        "flat_sql should contain separator or params, got: {}",
+        sql
+    );
+}
+
+// ── Guard: Issue #2 — ParamMeta.jdbc_type populated from XML inline attrs ──
+
+#[test]
+fn guard_param_meta_jdbc_type_populated() {
+    let result = super::parse_mapper_bytes(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    // Find callOracleProcCursorOut4 — has params with explicit jdbcType
+    let stmt = result
+        .statements
+        .iter()
+        .find(|s| s.id == "callOracleProcCursorOut4")
+        .expect("should find callOracleProcCursorOut4");
+
+    // outParam.o_retcode has jdbcType=VARCHAR — jdbc_type should be populated
+    let retcode = stmt.parameters.iter().find(|p| p.name == "outParam.o_retcode");
+    assert!(retcode.is_some(), "should have outParam.o_retcode param");
+    let retcode = retcode.unwrap();
+    assert!(
+        retcode.jdbc_type.is_some(),
+        "outParam.o_retcode should have jdbc_type populated (xml has jdbcType=VARCHAR), got: {:?}",
+        retcode
+    );
+    assert_eq!(
+        retcode.jdbc_type,
+        Some(crate::ibatis::types::JdbcType::VarChar),
+        "outParam.o_retcode should be VarChar"
+    );
+
+    // outParam.o_list has jdbcType=CURSOR — should be Cursor
+    let o_list = stmt.parameters.iter().find(|p| p.name == "outParam.o_list");
+    assert!(o_list.is_some(), "should have outParam.o_list param");
+    let o_list = o_list.unwrap();
+    assert!(
+        o_list.jdbc_type.is_some(),
+        "outParam.o_list should have jdbc_type populated (xml has jdbcType=CURSOR), got: {:?}",
+        o_list
+    );
+}
+
+// ── Guard: Flat API also has database_id and statement_type ──
+
+#[test]
+fn guard_flat_api_database_id_and_statement_type() {
+    let result = super::parse_mapper_bytes(callable_proc_mapper_xml());
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    // Second callOracleProcCommon should have database_id
+    let gauss_stmt = result.statements.iter().find(|s| {
+        s.id == "callOracleProcCommon" && s.database_id.as_deref() == Some("gauss")
+    });
+    assert!(gauss_stmt.is_some(), "should find callOracleProcCommon with database_id=gauss");
+
+    // All should have statement_type=CALLABLE
+    for stmt in &result.statements {
+        assert_eq!(
+            stmt.statement_type,
+            Some("CALLABLE".to_string()),
+            "flat API: statement '{}' should have statement_type=CALLABLE",
+            stmt.id
+        );
+    }
 }

--- a/src/ibatis/types.rs
+++ b/src/ibatis/types.rs
@@ -48,6 +48,10 @@ pub struct MapperStatement {
     pub body: SqlNode,
     /// 标签在 XML 文件中的行号（1-based）
     pub line: usize,
+    /// MyBatis `databaseId` 属性 — 用于区分多数据库方言。
+    pub database_id: Option<String>,
+    /// MyBatis `statementType` 属性 — 如 CALLABLE、PREPARED 等。
+    pub statement_type: Option<String>,
 }
 
 /// SQL 语句类型
@@ -68,10 +72,17 @@ pub enum SqlNode {
     Parameter {
         name: String,
         java_type: Option<String>,
+        /// MyBatis `jdbcType` 属性（如 VARCHAR、CURSOR、CLOB）。
+        jdbc_type: Option<String>,
+        /// MyBatis `mode` 属性（如 IN、OUT、INOUT）。
+        mode: Option<String>,
+        /// MyBatis `resultMap` 属性（用于 CURSOR 类型游标映射）。
+        result_map: Option<String>,
     },
     RawExpr {
         expr: String,
         java_type: Option<String>,
+        jdbc_type: Option<String>,
     },
     Include {
         refid: String,
@@ -147,6 +158,8 @@ pub struct ParsedStatement {
     pub has_dynamic_elements: bool,
     pub line: usize,
     pub parse_result: Option<(Vec<crate::ast::StatementInfo>, Vec<crate::parser::ParserError>)>,
+    pub database_id: Option<String>,
+    pub statement_type: Option<String>,
 }
 
 /// MyBatis 支持的 JDBC 类型（常用子集）。
@@ -178,6 +191,7 @@ pub enum JdbcType {
     Null,
     Array,
     Other,
+    Cursor,
 }
 
 /// 参数类型推断来源。
@@ -229,6 +243,8 @@ pub struct StructuredStatement {
     pub location: XmlSourceLocation,
     /// 从 body 中收集的所有参数（#{param} 和 ${expr}）
     pub parameters: Vec<ParamMeta>,
+    pub database_id: Option<String>,
+    pub statement_type: Option<String>,
 }
 
 impl StructuredStatement {
@@ -255,6 +271,8 @@ impl StructuredStatement {
             has_dynamic_elements: self.has_dynamic_elements,
             line: self.location.line,
             parse_result,
+            database_id: self.database_id.clone(),
+            statement_type: self.statement_type.clone(),
         }
     }
 }

--- a/src/ibatis/util.rs
+++ b/src/ibatis/util.rs
@@ -1,5 +1,16 @@
 //! 共享工具函数。
 
+use crate::ibatis::types::JdbcType;
+
+/// 从 `#{...}` 中解析出的参数属性。
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ParamAttrs {
+    pub java_type: Option<String>,
+    pub jdbc_type: Option<String>,
+    pub mode: Option<String>,
+    pub result_map: Option<String>,
+}
+
 /// 从位置 start 开始查找匹配的 `}`，考虑嵌套 `{}`。
 pub fn find_closing_brace(chars: &[char], start: usize) -> Option<usize> {
     let mut depth = 1;
@@ -20,39 +31,82 @@ pub fn find_closing_brace(chars: &[char], start: usize) -> Option<usize> {
     None
 }
 
+/// 完整解析 MyBatis #{...} 参数字符串，返回 (name, ParamAttrs)。
+pub fn parse_param_attrs(param: &str) -> (String, ParamAttrs) {
+    if param.contains(',') {
+        parse_param_attrs_mybatis3(param)
+    } else if param.contains(':') {
+        parse_param_attrs_ibatis2(param)
+    } else {
+        (param.trim().to_string(), ParamAttrs::default())
+    }
+}
+
+fn parse_param_attrs_mybatis3(param: &str) -> (String, ParamAttrs) {
+    let mut parts = param.split(',');
+    let name = parts.next().unwrap_or("").trim().to_string();
+    let mut attrs = ParamAttrs::default();
+    for part in parts {
+        let part = part.trim();
+        if let Some(val) = part.strip_prefix("javaType=") {
+            attrs.java_type = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("jdbcType=") {
+            attrs.jdbc_type = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("mode=") {
+            attrs.mode = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("resultMap=") {
+            attrs.result_map = Some(val.to_string());
+        }
+    }
+    (name, attrs)
+}
+
+fn parse_param_attrs_ibatis2(param: &str) -> (String, ParamAttrs) {
+    let mut parts = param.splitn(3, ':');
+    let name = parts.next().unwrap_or("").trim().to_string();
+    let jdbc_type = parts.next().map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    (name, ParamAttrs { jdbc_type, ..ParamAttrs::default() })
+}
+
 /// 从 MyBatis 参数字符串中提取 name 和可选的 javaType/jdbcType。
 /// 格式:
 /// - MyBatis 3: `name` or `name,javaType=double` or `name,jdbcType=NUMERIC`
 /// - iBatis 2.x: `name` or `name:jdbcType` or `name:jdbcType:nullValue`
 pub fn parse_param_type(param: &str) -> (String, Option<String>) {
-    if param.contains(',') {
-        parse_param_type_mybatis3(param)
-    } else if param.contains(':') {
-        parse_param_type_ibatis2(param)
-    } else {
-        (param.trim().to_string(), None)
-    }
+    let (name, attrs) = parse_param_attrs(param);
+    (name, attrs.jdbc_type.or(attrs.java_type))
 }
 
-fn parse_param_type_mybatis3(param: &str) -> (String, Option<String>) {
-    let mut parts = param.split(',');
-    let name = parts.next().unwrap_or("").trim().to_string();
-    let mut java_type: Option<String> = None;
-    let mut jdbc_type: Option<String> = None;
-    for part in parts {
-        let part = part.trim();
-        if let Some(val) = part.strip_prefix("javaType=") {
-            java_type = Some(val.to_string());
-        } else if let Some(val) = part.strip_prefix("jdbcType=") {
-            jdbc_type = Some(val.to_string());
-        }
+/// 将 JDBC 类型字符串（如 "VARCHAR"）转换为 `JdbcType` 枚举。
+pub fn jdbc_type_from_str(s: &str) -> Option<JdbcType> {
+    match s.to_uppercase().as_str() {
+        "INTEGER" | "INT" => Some(JdbcType::Integer),
+        "BIGINT" => Some(JdbcType::BigInt),
+        "SMALLINT" => Some(JdbcType::SmallInt),
+        "TINYINT" => Some(JdbcType::TinyInt),
+        "DECIMAL" => Some(JdbcType::Decimal),
+        "NUMERIC" => Some(JdbcType::Numeric),
+        "DOUBLE" => Some(JdbcType::Double),
+        "FLOAT" => Some(JdbcType::Float),
+        "REAL" => Some(JdbcType::Real),
+        "CHAR" => Some(JdbcType::Char),
+        "VARCHAR" => Some(JdbcType::VarChar),
+        "LONGVARCHAR" => Some(JdbcType::LongVarChar),
+        "NCHAR" => Some(JdbcType::NChar),
+        "NVARCHAR" => Some(JdbcType::NVarChar),
+        "CLOB" => Some(JdbcType::Clob),
+        "NCLOB" => Some(JdbcType::NClob),
+        "BINARY" => Some(JdbcType::Binary),
+        "VARBINARY" => Some(JdbcType::VarBinary),
+        "BLOB" => Some(JdbcType::Blob),
+        "DATE" => Some(JdbcType::Date),
+        "TIME" => Some(JdbcType::Time),
+        "TIMESTAMP" => Some(JdbcType::Timestamp),
+        "BOOLEAN" => Some(JdbcType::Boolean),
+        "NULL" => Some(JdbcType::Null),
+        "ARRAY" => Some(JdbcType::Array),
+        "OTHER" => Some(JdbcType::Other),
+        "CURSOR" => Some(JdbcType::Cursor),
+        _ => None,
     }
-    (name, java_type.or(jdbc_type))
-}
-
-fn parse_param_type_ibatis2(param: &str) -> (String, Option<String>) {
-    let mut parts = param.splitn(3, ':');
-    let name = parts.next().unwrap_or("").trim().to_string();
-    let jdbc_type = parts.next().map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
-    (name, jdbc_type)
 }


### PR DESCRIPTION
## Summary

Fixes 6 bugs in parse-xml directive for MyBatis mapper XML containing stored procedure calls (`statementType=CALLABLE`).

## Issues Fixed

| # | Issue | Fix |
|---|-------|-----|
| 1 | ForEach separator dropped in flat SQL | Added `flatten_children_with_separator()` |
| 2 | jdbc_type always null in param metadata | Wired `jdbc_type_from_str` conversion in both paths |
| 3 | databaseId not captured | Added field to `MapperStatement`/`ParsedStatement`/`StructuredStatement` |
| 4 | javaType/jdbcType priority wrong | Added `ParamAttrs` struct with proper attribute parsing |
| 5 | statementType not captured | Added field to all statement types |
| 6 | mode/resultMap dropped from params | Added `mode`, `result_map` to `SqlNode::Parameter` |

## Commits (5 atomic)

1. `eabd3f8` fix(ibatis): add ParamAttrs, JdbcType::Cursor, and databaseId/statementType fields to types
2. `cd1feb1` fix(ibatis): capture databaseId, statementType, and param attrs in parser pipeline
3. `fd93590` fix(ibatis): wire databaseId, statementType, and jdbc_type through public API
4. `eebcde7` test(ibatis): add 14 guard tests for stored procedure callable statement fixes
5. `cd4071f` chore: bump version to 0.6.8

## Test Coverage

- 14 new guard tests added
- All 1385 tests passing
- Release binary end-to-end verified