### PR TITLE
feat: support ORDER BY clause in DELETE statements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1610,6 +1610,9 @@ pub struct DeleteStatement {
     pub where_clause: Option<Expr>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
+    pub order_by: Option<Vec<OrderByItem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub limit: Option<Expr>,
     pub returning: Vec<SelectTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -785,6 +785,14 @@ fn walk_delete(visitor: &mut dyn Visitor, delete: &DeleteStatement) -> VisitorRe
         }
     }
 
+    if let Some(ref order_by) = delete.order_by {
+        for item in order_by {
+            if walk_expr(visitor, &item.expr) == VisitorResult::Stop {
+                return VisitorResult::Stop;
+            }
+        }
+    }
+
     VisitorResult::Continue
 }
 

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1785,6 +1785,29 @@ impl SqlFormatter {
             parts.push(format!("{} {}", self.kw("WHERE"), self.format_expr(where_clause)));
         }
 
+        if let Some(order_by) = &stmt.order_by {
+            let items: Vec<String> = order_by.iter().map(|item| {
+                let mut s = self.format_expr(&item.expr);
+                match item.asc {
+                    Some(true) => { s.push(' '); s.push_str(&self.kw("ASC")); }
+                    Some(false) => { s.push(' '); s.push_str(&self.kw("DESC")); }
+                    None => {}
+                }
+                if let Some(nf) = item.nulls_first {
+                    s.push(' ');
+                    if nf { s.push_str(&self.kw("NULLS FIRST")); } else { s.push_str(&self.kw("NULLS LAST")); }
+                }
+                if let Some(ref using) = item.using {
+                    s.push(' ');
+                    s.push_str(&self.kw("USING"));
+                    s.push(' ');
+                    s.push_str(&self.format_expr(using));
+                }
+                s
+            }).collect();
+            parts.push(format!("{} {}", self.kw("ORDER BY"), items.join(", ")));
+        }
+
         if let Some(limit) = &stmt.limit {
             parts.push(format!("{} {}", self.kw("LIMIT"), self.format_expr(limit)));
         }

--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
     ConflictAction, ConflictTarget, DeleteStatement, DmlPartitionClause, InsertAllCondition, InsertAllStatement,
     InsertAllTarget, InsertFirstStatement, InsertSource, InsertStatement, MergeAction, MergeStatement, MergeWhenClause,
-    OnConflict, OnDuplicateKeyUpdate, TablePartitionRef, TableRef, UpdateAssignment, UpdateStatement,
+    OnConflict, OnDuplicateKeyUpdate, OrderByItem, TablePartitionRef, TableRef, UpdateAssignment, UpdateStatement,
 };
 use crate::parser::{Parser, ParserError};
 use crate::token::keyword::Keyword;
@@ -456,6 +456,45 @@ impl Parser {
         } else {
             None
         };
+        let order_by = if self.match_keyword(Keyword::ORDER) {
+            self.advance();
+            self.expect_keyword(Keyword::BY)?;
+            let mut items = Vec::new();
+            loop {
+                let expr = self.parse_expr()?;
+                let asc = match self.peek_keyword() {
+                    Some(Keyword::ASC) => {
+                        self.advance();
+                        Some(true)
+                    }
+                    Some(Keyword::DESC) => {
+                        self.advance();
+                        Some(false)
+                    }
+                    _ => None,
+                };
+                let nulls_first = if self.match_keyword(Keyword::NULLS_P) {
+                    self.advance();
+                    if self.match_keyword(Keyword::FIRST_P) {
+                        self.advance();
+                        Some(true)
+                    } else {
+                        self.expect_keyword(Keyword::LAST_P)?;
+                        Some(false)
+                    }
+                } else {
+                    None
+                };
+                items.push(OrderByItem { expr, asc, nulls_first, using: None });
+                if !self.match_token(&Token::Comma) {
+                    break;
+                }
+                self.advance();
+            }
+            Some(items)
+        } else {
+            None
+        };
         let limit = if self.match_keyword(Keyword::LIMIT) {
             self.advance();
             if self.match_keyword(Keyword::ALL) {
@@ -467,6 +506,12 @@ impl Parser {
         } else {
             None
         };
+        if order_by.is_some() && limit.is_none() {
+            self.add_error(ParserError::Warning {
+                message: "DELETE ORDER BY without LIMIT has no effect on row deletion order".to_string(),
+                location: self.prev_location(),
+            });
+        }
         let (returning, into_targets, bulk_collect) = if self.match_keyword(Keyword::RETURNING) {
             self.advance();
             let returning = self.parse_target_list()?;
@@ -495,6 +540,7 @@ impl Parser {
             tables,
             using,
             where_clause,
+            order_by,
             limit,
             returning,
             into_targets,

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -6591,6 +6591,96 @@ fn test_update_hint_roundtrip() {
 }
 
 #[test]
+fn test_delete_order_by_with_limit() {
+    let sql = "DELETE FROM t WHERE status = 0 ORDER BY id LIMIT 10";
+    let stmts = parse(sql);
+    match &stmts[0] {
+        Statement::Delete(s) => {
+            assert!(s.order_by.is_some(), "ORDER BY should be parsed");
+            let items = s.order_by.as_ref().unwrap();
+            assert_eq!(items.len(), 1);
+            assert!(s.limit.is_some(), "LIMIT should be parsed");
+        }
+        other => panic!("expected Delete, got {:?}", other),
+    }
+    // Round-trip
+    let formatter = SqlFormatter::new();
+    let output = formatter.format_statement(&stmts[0]);
+    assert!(output.contains("ORDER BY"), "formatted SQL should contain ORDER BY: {}", output);
+    assert!(output.contains("LIMIT"), "formatted SQL should contain LIMIT: {}", output);
+
+    // Verify JSON round-trip
+    let json = serde_json::to_string(&stmts).unwrap();
+    let restored: Vec<Statement> = serde_json::from_str(&json).unwrap();
+    assert_eq_ignoring_span(&restored[0], &stmts[0]);
+}
+
+#[test]
+fn test_delete_order_by_desc() {
+    let sql = "DELETE FROM t WHERE status = 0 ORDER BY id DESC LIMIT 5";
+    let stmts = parse(sql);
+    match &stmts[0] {
+        Statement::Delete(s) => {
+            let items = s.order_by.as_ref().unwrap();
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0].asc, Some(false));
+        }
+        other => panic!("expected Delete, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_delete_order_by_multi_column() {
+    let sql = "DELETE FROM t WHERE status = 0 ORDER BY status, id ASC LIMIT 100";
+    let stmts = parse(sql);
+    match &stmts[0] {
+        Statement::Delete(s) => {
+            let items = s.order_by.as_ref().unwrap();
+            assert_eq!(items.len(), 2);
+            assert_eq!(items[0].asc, None); // no explicit direction
+            assert_eq!(items[1].asc, Some(true));
+        }
+        other => panic!("expected Delete, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_delete_order_by_without_limit_warns() {
+    let sql = "DELETE FROM t WHERE status = 0 ORDER BY id";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse();
+
+    // Statement should parse successfully
+    match &stmts[0] {
+        Statement::Delete(s) => {
+            assert!(s.order_by.is_some(), "ORDER BY should be parsed");
+            assert!(s.limit.is_none(), "LIMIT should be None");
+        }
+        other => panic!("expected Delete, got {:?}", other),
+    }
+
+    // Should produce a warning about ORDER BY without LIMIT
+    let warnings: Vec<_> = parser.errors().iter().filter(|e| matches!(e, ParserError::Warning { .. })).collect();
+    assert_eq!(warnings.len(), 1, "expected exactly 1 warning, got {:?} errors: {:?}", warnings.len(), parser.errors());
+    if let ParserError::Warning { message, .. } = &warnings[0] {
+        assert!(message.contains("ORDER BY"), "warning should mention ORDER BY: {}", message);
+        assert!(message.contains("LIMIT"), "warning should mention LIMIT: {}", message);
+    }
+}
+
+#[test]
+fn test_delete_order_by_with_limit_no_warning() {
+    let sql = "DELETE FROM t WHERE status = 0 ORDER BY id LIMIT 10";
+    let tokens = Tokenizer::new(sql).tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let _stmts = parser.parse();
+
+    let warnings: Vec<_> = parser.errors().iter().filter(|e| matches!(e, ParserError::Warning { .. })).collect();
+    assert!(warnings.is_empty(), "should have no warnings when ORDER BY is paired with LIMIT, got: {:?}", warnings);
+}
+
+#[test]
 fn test_delete_hint_roundtrip() {
     let sql = "DELETE /*+ indexscan(t1 idx_c1) */ FROM t1 WHERE c1 > 0";
     let stmts = parse(sql);


### PR DESCRIPTION
## Summary

Add support for `DELETE ... ORDER BY ... [LIMIT ...]` syntax per GaussDB/openGauss specification.

## Changes

| Commit | Description |
|--------|-------------|
| `312ea62` | Add `order_by: Option<Vec<OrderByItem>>` field to `DeleteStatement` AST |
| `c34f1e3` | Parse ORDER BY in DELETE (between WHERE and LIMIT), emit warning when LIMIT absent |
| `f3f60c7` | Format ORDER BY output for DELETE, update visitor traversal |
| `d70dc50` | 5 tests covering parsing, round-trip, multi-column, and warning behavior |

## Behavior

```sql
-- ✅ Parsed normally
DELETE FROM t WHERE status = 0 ORDER BY id LIMIT 10

-- ⚠️ Parsed with warning: "DELETE ORDER BY without LIMIT has no effect on row deletion order"
DELETE FROM t WHERE status = 0 ORDER BY id

-- ✅ Supports ASC/DESC/NULLS FIRST/NULLS LAST/multi-column
DELETE FROM t WHERE x = 1 ORDER BY a DESC, b NULLS FIRST LIMIT 100
```

## Test Plan

- 5 new unit tests (1279 total pass, 0 failures)
- Regression tests unchanged (744 parsed OK)
- JSON round-trip verified
- Formatter and validator verified via CLI

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)