### PR TITLE
fix(ibatis): foreach separator bug + include open-close form

### DIFF
--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -65,9 +65,8 @@ pub fn flatten_sql(node: &SqlNode) -> String {
                 suffix_overrides.as_deref(),
             )
         }
-        SqlNode::ForEach { open, separator, close, prepend, children, .. } => {
-            let sep = separator.as_deref().unwrap_or("");
-            let content = flatten_children_with_separator(children, sep);
+        SqlNode::ForEach { open, separator: _, close, prepend, children, .. } => {
+            let content = flatten_children(children);
             let open_str = open.as_deref().unwrap_or("");
             let close_str = close.as_deref().unwrap_or("");
             let body = format!("{}{}{}", open_str, content, close_str);
@@ -84,19 +83,6 @@ pub fn flatten_sql(node: &SqlNode) -> String {
 fn flatten_children(children: &[SqlNode]) -> String {
     let raw: String = children.iter().map(flatten_sql).collect();
     deduplicate_conjunctions(&raw)
-}
-
-/// Flatten children with a separator between non-empty segments.
-/// Used by ForEach to preserve the `separator` attribute.
-fn flatten_children_with_separator(children: &[SqlNode], separator: &str) -> String {
-    let segments: Vec<String> = children
-        .iter()
-        .map(|c| flatten_sql(c))
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
-    let joined = segments.join(separator);
-    deduplicate_conjunctions(&joined)
 }
 
 fn deduplicate_conjunctions(sql: &str) -> String {

--- a/src/ibatis/parser.rs
+++ b/src/ibatis/parser.rs
@@ -403,6 +403,11 @@ fn parse_dynamic_element(
             prepend: get_attr(element, "prepend"),
             children,
         })
+    } else if tag.eq_ignore_ascii_case(b"include") {
+        // <include refid="..."></include> — 开闭形式（自闭合形式在 Event::Empty 分支处理）
+        let refid = get_attr(element, "refid").unwrap_or_default();
+        let _children = read_node_tree(reader, b"include");
+        Some(SqlNode::Include { refid })
     } else if is_ibatis2_conditional(tag) {
         let test = synthesize_ibatis2_test(element);
         let prepend = get_attr(element, "prepend");

--- a/src/ibatis/tests.rs
+++ b/src/ibatis/tests.rs
@@ -190,7 +190,40 @@ fn test_include_parsed_as_node() {
 }
 
 #[test]
-fn test_include_resolved_structurally() {
+fn test_include_open_close_parsed_as_node() {
+    let xml = br#"<mapper namespace="test">
+        <sql id="cols">id, name</sql>
+        <select id="findAll">SELECT <include refid="cols"></include> FROM users</select>
+    </mapper>"#;
+    let mapper = crate::ibatis::parser::parse_xml(xml).unwrap();
+    let stmt = mapper.statements.iter().find(|s| s.id == "findAll").unwrap();
+    if let SqlNode::Sequence { children } = &stmt.body {
+        let include_nodes: Vec<_> = children.iter().filter(|n| matches!(n, SqlNode::Include { .. })).collect();
+        assert_eq!(include_nodes.len(), 1, "expected exactly one Include node");
+        if let SqlNode::Include { refid } = include_nodes[0] {
+            assert_eq!(refid, "cols");
+        }
+    } else {
+        panic!("expected Sequence node, got {:?}", stmt.body);
+    }
+}
+
+#[test]
+fn test_include_open_close_resolved() {
+    let xml = br#"<mapper namespace="test">
+        <sql id="allColumn">id, user_code, area_code</sql>
+        <select id="getList">SELECT <include refid="allColumn"></include> FROM users</select>
+    </mapper>"#;
+    let mapper = crate::ibatis::parser::parse_xml(xml).unwrap();
+    let resolved = crate::ibatis::resolver::resolve_includes(&mapper).unwrap();
+    let stmt = resolved.statements.iter().find(|s| s.id == "getList").unwrap();
+    let content = node_text(&stmt.body);
+    assert!(content.contains("id, user_code, area_code"), "got: {}", content);
+    assert!(!content.contains("<include"), "raw include text should not remain, got: {}", content);
+}
+
+#[test]
+fn test_include_open_close_resolved_structurally() {
     let xml = br#"<mapper namespace="test">
         <sql id="cols">id, name</sql>
         <select id="findAll">SELECT <include refid="cols"/> FROM users</select>


### PR DESCRIPTION
## Changes

### 1. Fix foreach separator corruption in flatten mode

`flatten_sql()` 的 `ForEach` 分支错误地将 `separator` 插入到 foreach body 的**内部子节点**之间（Text、Parameter 等），而非 foreach 的**迭代**之间。

**Before (bug):**
```sql
selectUNION ALL __XML_PARAM_f_id__UNION ALL,UNION ALL __XML_PARAM_f_userCode__UNION ALL,...
```

**After (fix):**
```sql
select __XML_PARAM_f_id__, __XML_PARAM_f_userCode__, ... from dual
```

**Root cause:** `flatten_children_with_separator()` 在 children Vec 的每个元素之间插入 separator。但 foreach 的 children 是 `select #{f.id}, #{f.userCode}, ... from dual` 被拆分后的 Text/Parameter 子节点，separator 被放到了参数之间。

**Fix:** `flatten` 是单次静态展平策略，不重复 foreach body，因此 separator 在此无意义。改用 `flatten_children()`，删除 `flatten_children_with_separator()`。`expand.rs` 中的 `expand_foreach()` 不受影响（已正确处理 separator）。

### 2. Handle open-close `<include refid="..."></include>` form in parser

Parser only handled the self-closing `<include refid="..."/>` form. Added handling for the open-close `<include refid="...">...</include>` form, which some MyBatis mappers use.

## Test Plan

- [x] `cargo test --lib --features ibatis` — 1387 tests pass
- [x] Verified fix with user's original `batchInsertCtrlRecord` mapper XML
- [x] Existing foreach tests continue to pass