### PR TITLE
feat: add SQL anti-pattern lint detection (50 rules, CLI/MCP/HTTP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "axum",
  "clap",
@@ -784,6 +784,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml",
  "tower-http",
  "tree-sitter",
  "tree-sitter-java",
@@ -1180,6 +1181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1381,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1771,6 +1822,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ encoding_rs = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 phf = { version = "0.11", features = ["macros"] }
+toml = { version = "0.8", optional = true }
 
 # Binary-only deps (feature-gated)
 clap = { version = "4", features = ["derive"], optional = true }
@@ -42,7 +43,8 @@ schemars = { version = "1", optional = true }
 
 [features]
 default = []
-cli = ["dep:clap", "dep:walkdir"]
+lint-config = ["dep:toml"]
+cli = ["dep:clap", "dep:walkdir", "lint-config"]
 ibatis = ["dep:quick-xml", "dep:walkdir"]
 java = ["dep:tree-sitter", "dep:tree-sitter-java", "dep:walkdir"]
 serve = ["cli", "dep:axum", "dep:tokio", "dep:tower-http", "dep:utoipa"]

--- a/docs/plans/2026-06-06-sql-lint-warnings.md
+++ b/docs/plans/2026-06-06-sql-lint-warnings.md
@@ -1,0 +1,676 @@
+# SQL Lint / Warning System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 在 parse / parse-java / parse-xml / validate 四个入口中增加 SQL 反模式检测能力，通过分级 Warning 揭示 GaussDB 文档中记载的危险、低效、有隐患的 SQL 写法。
+
+**Architecture:** 新增 `src/linter/` 模块，定义 `SqlWarning` 类型和 `LintRule` trait。每条检测规则实现为一个独立的 `fn check()` 函数（或 Visitor），由 `SqlLinter` 统一调度。所有规则基于已有的 AST + Visitor 基础设施，无需修改解析器核心。通过 CLI `--lint` flag 激活，结果汇入 JSON / CSV / 终端输出。
+
+**Tech Stack:** Rust, 已有 AST (`src/ast/`), 已有 Visitor (`src/ast/visitor.rs`), 已有 Hint 验证 (`src/parser/hint_validator.rs`), 已有函数注册表 (`src/parser/function_registry.rs`), 已有 Schema 加载 (`src/analyzer/schema.rs`)
+
+---
+
+## Background / 背景说明
+
+### 问题
+
+GaussDB 2.23.07.210 产品文档（华为云Stack 8.3.0）中明确记载了大量 SQL "规则"（强制禁止）和"建议"（应优化），涵盖：
+
+- 数据安全风险：`LOCK TABLE` 死锁、`DROP ... CASCADE` 误删、隐式类型转换、unlogged table 数据丢失
+- 性能陷阱：`SELECT *`、`UNION`（非 ALL）、`NOT IN`、标量子查询、`now()` 不可下推、`LIKE '%...'`
+- 低效语法：`UPDATE SET (c1,c2) = (SELECT ...)`、关联子查询、`count(*)` 大表
+- Hint 隐患：未知 Hint 被静默忽略、矛盾 Hint 导致预期外执行计划
+
+开发者在编写 SQL 时往往意识不到这些隐患。现有 parser 只做语法检查，不检测语义级别的反模式。
+
+### 现有基础设施
+
+| 组件 | 位置 | 状态 |
+|---|---|---|
+| AST（180+ 语句类型，完整表达式树） | `src/ast/mod.rs` | ✅ 完整 |
+| Visitor 模式（11 个 hook，完整遍历） | `src/ast/visitor.rs` | ✅ 完整 |
+| Hint 验证（69 个已知 Hint，5 种验证） | `src/parser/hint_validator.rs` | ✅ 已有，产 `ParserError::Warning` |
+| 函数注册表（449 内置函数，参数/类型验证） | `src/parser/function_registry.rs` | ✅ 已有 |
+| Schema 加载（JSON → SchemaMap） | `src/analyzer/schema.rs` | ✅ 已有 |
+| `ParserError::Warning` | `src/parser/mod.rs:22` | ✅ 已有 |
+| validate 命令管道 | `src/bin/ogsql.rs:3264` | ✅ 已有 |
+
+### 设计原则
+
+1. **不破坏现有 API** — `ParseOutput.errors` 语义不变，warnings 作为新字段加入
+2. **每条规则独立可测** — 单个函数，纯输入输出，无全局状态
+3. **可选启用** — `--lint` flag 控制，不影响默认 parse 行为
+4. **分级清晰** — 不使用 "Error"（留给语法错误），用 Prohibition/Performance/Caution/Suggestion 四级
+5. **复用已有验证** — Hint 验证结果转为 `SqlWarning`，不重写
+
+---
+
+## Warning Levels / 级别定义
+
+```rust
+/// SQL 警告严重级别。
+/// 注意：不使用 "Error"，因为该词在 ParserError 中已用于语法级错误。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum WarningLevel {
+    /// 🔴 强烈禁止 — 违反 GaussDB 文档"规则"级要求，可能导致数据安全风险/死锁/数据丢失。
+    ///   例: LOCK TABLE、隐式类型转换、DROP CASCADE
+    Prohibition = 3,
+
+    /// 🟡 性能警告 — 存在可识别的性能隐患，有明确的优化方案。
+    ///   例: UNION → UNION ALL、NOT IN → NOT EXISTS、SELECT *
+    Performance = 2,
+
+    /// 🔵 风险提示 — 语法合法但容易被忽视的隐患，需结合场景判断。
+    ///   例: Hint 被静默忽略、低效 GaussDB 专用语法、UPDATE 无 WHERE
+    Caution = 1,
+
+    /// ⚪ 编码建议 — 不影响正确性，遵循后可提高可维护性和健壮性。
+    ///   例: 用 TRUNCATE 替代 DELETE 全表、LIMIT 1 无 ORDER BY
+    Suggestion = 0,
+}
+```
+
+级别支持排序：`Prohibition > Performance > Caution > Suggestion`。CLI `--min-level` 过滤基于此排序。
+
+---
+
+## Warning Output Type / 输出类型
+
+```rust
+/// 检测结果的可信度
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum Confidence {
+    /// 完整 SQL — 检测结果完全可信
+    Full,
+    /// iBatis/MyBatis 动态 SQL 片段 — 可能因 <if>/<choose> 导致 SQL 不完整，存在误报可能
+    Partial,
+}
+
+/// 单条 SQL 警告。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SqlWarning {
+    /// 严重级别
+    pub level: WarningLevel,
+    /// 规则编号，如 "R001"、"P002"
+    pub rule_id: String,
+    /// 人类可读的规则名称
+    pub rule_name: String,
+    /// 警告描述（含具体 SQL 上下文）
+    pub message: String,
+    /// 优化建议（可选）
+    pub suggestion: Option<String>,
+    /// 源码位置
+    pub location: SourceLocation,
+    /// GaussDB 文档引用（可选）
+    pub gaussdb_ref: Option<String>,
+    /// 检测可信度
+    pub confidence: Confidence,
+}
+```
+
+- `parse` / `validate` 产生的 Warning: `Confidence::Full`
+- `parse-xml` 提取的动态 SQL 产生的 Warning: `Confidence::Partial`
+- `parse-java` 拼接的 SQL 产生的 Warning: `Confidence::Partial`
+- JSON 输出中始终包含 confidence 字段
+- 终端输出中 Partial 级别标注 `[partial]` 标记
+- 可通过 `--min-confidence full` 过滤掉 Partial 结果
+
+---
+
+## Complete Rule Catalog / 完整规则清单
+
+### A. Prohibition（🔴 强烈禁止）— GaussDB 文档"规则"级
+
+共 9 条，8 条纯 AST 可检。
+
+| ID | 规则名 | AST 检测点 | GaussDB 文档 | 需 Schema |
+|---|---|---|---|---|
+| R001 | select-star | `SelectTarget::Star(None)` — 仅无表限定的 `*`，`t.*` 不触发 | SELECT 规范 | 否 |
+| R002 | large-column-sort | SELECT 的 group_by / order_by / distinct / union（非 all）涉及表达式 — 仅提示存在性 | SELECT 规范 | 是(列大小) |
+| R003 | lock-table | `Statement::Lock(_)` | SELECT 规范 | 否 |
+| R004 | drop-cascade | `DropStatement { cascade: true, .. }` | SQL 编写 | 否 |
+| R005 | implicit-type-conversion | WHERE 中类型不一致（需 schema 辅助，暂降级为 Caution） | WHERE 规范 | 是 |
+| R006 | function-on-where-column | WHERE 中 `Expr::FunctionCall` 直接包装 `ColumnRef` 作为过滤条件 | WHERE 规范 | 否 |
+| R007 | like-leading-wildcard | `Expr::Like { pattern: Literal::String(s) if s.starts_with('%'), .. }` | WHERE 规范 | 否 |
+| R008 | same-table-column-compare | WHERE 中 `Expr::BinaryOp` 两边均为 `ColumnRef` 且前缀相同 | WHERE 规范 | 否 |
+| R009 | scalar-subquery-in-select | `Expr::Subquery` 出现在 `SelectTarget::Expr` 中 | SQL 编写 | 否 |
+
+### B. Performance（🟡 性能警告）— 有明确优化方案
+
+共 22 条，18 条纯 AST 可检。
+
+| ID | 规则名 | AST 检测点 | 优化建议 | 需 Schema |
+|---|---|---|---|---|
+| P001 | union-without-all | `SetOperation::Union { all: false, .. }` | 改用 UNION ALL | 否 |
+| P002 | not-in-subquery | `Expr::InSubquery { negated: true, .. }` 及匹配的 `Expr::ScalarSublink` 变体 | 改为 NOT EXISTS | 否 |
+| P003 | in-list-too-large | `Expr::InList { list, .. }` where `list.len() > threshold` | 改用 INNER JOIN | 否 |
+| P004 | or-to-union-all | WHERE 中 `Expr::BinaryOp { op: "OR", .. }` 作为顶层条件 | 纯 OR 改写为 UNION ALL | 否 |
+| P005 | now-function-non-pushable | `Expr::FunctionCall { name: ["now"], .. }` | 用时间宏替代 | 否 |
+| P006 | count-star-large-table | `Expr::FunctionCall { name: ["count"], args: [Star], .. }` | 用 pg_class.reltuples | 否 |
+| P007 | too-many-non-equi-joins | 非等值 `BinaryOp` 数量 > threshold | 优先使用等值查询 | 否 |
+| P008 | group-by-without-hashagg | `group_by` 非空，无 use_hash_agg hint | 考虑调大 work_mem | 否 |
+| P009 | function-instead-of-case | WHERE 中 `FunctionCall` 可替换为 `Case` | 用 CASE 表达式替代 | 否 |
+| P010 | multi-column-update-subquery | `UpdateAssignment { columns: len>1, value: Subquery }` | 改为 UPDATE FROM JOIN | 否 |
+| P011 | correlated-subquery | `Expr::InSubquery` / `Expr::ScalarSublink` / `Expr::Subquery` 中引用外表列（需要遍历子查询的 ColumnRef 并与外层 FROM 表对比） | 改写为等值 JOIN | 否 |
+| P012 | unnecessary-distinct | `distinct: true` 且 SELECT 含唯一列 | 检查去重必要性 | 是 |
+| P013 | cartesian-product | `TableRef::Join { condition: None, .. }` 或多 FROM 无 JOIN | 补充 JOIN 条件 | 否 |
+| P014 | deeply-nested-subquery | `Expr::Subquery` 嵌套深度 > threshold | 拆分为临时表 | 否 |
+| P015 | range-equals-same-value | WHERE 中同一列 `>= val AND <= val` 且值相同 | 简化为 `=` | 否 |
+| P016 | update-from-no-join-condition | `UpdateStatement { from, where_clause: None/无关联 }` | WHERE 中关联 FROM 表 | 否 |
+| P017 | merge-without-unique-index | `MergeStatement { on_condition }` | 确保 ON 有唯一索引 | 是 |
+| P018 | insert-select-no-columns | `InsertStatement { columns: [], source: Select }` | 指定目标列名 | 否 |
+| P019 | multi-table-update | `UpdateStatement { tables: len>1 }` | 拆分为多条单表 UPDATE | 否 |
+| P020 | insert-all-multi-table | `Statement::InsertAll` / `Statement::InsertFirst` | 评估是否可用单条 INSERT...SELECT | 否 |
+| P021 | row-by-row-insert-in-loop | 循环体内含 INSERT 的 `PlStatement::SqlStatement` (Phase 2) | 使用 FORALL 批量操作 | 否 |
+| P022 | explain-in-production | `Statement::Explain` | 不应出现在生产代码中 | 否 |
+
+### C. Caution（🔵 风险提示）— 合法但易忽视
+
+共 16 条，14 条纯 AST 可检。
+
+| ID | 规则名 | AST 检测点 | 说明 | 需 Schema |
+|---|---|---|---|---|
+| C001 | hint-unknown | hints 不在 `KNOWN_HINTS` | **已有 hint_validator.rs** | 否 |
+| C002 | hint-invalid-negation | hint 不支持 no 前缀却使用了 | **已有 hint_validator.rs** | 否 |
+| C003 | hint-missing-args | 需要括号参数的 hint 缺失参数 | **已有 hint_validator.rs** | 否 |
+| C004 | hint-extra-args | 不需要括号的 hint 给了参数 | **已有 hint_validator.rs** | 否 |
+| C005 | hint-contradictory | 同语句中矛盾 hint（同表+跨表全量检测） | **需新增** | 否 |
+| C006 | hint-table-not-in-from | hint 引用的表不在 FROM 子句中 | **需新增** | 否 |
+| C007 | update-without-where | `UpdateStatement.where_clause.is_none()` | 可能是全表更新 | 否 |
+| C008 | delete-without-where | `DeleteStatement.where_clause.is_none()` | 可能是全表删除 | 否 |
+| C009 | insert-no-column-list | `InsertStatement.columns.is_empty()` | 依赖列顺序 | 否 |
+| C010 | unlogged-table | `CreateTableStatement.unlogged == true` | 数据安全风险 | 否 |
+| C011 | goto-statement | `PlStatement::Goto { .. }` | 结构化编程不推荐 | 否 |
+| C012 | execute-concat-sql-injection | `PlStatement::Execute` 中 string_expr 含 `||` 拼接 | SQL 注入风险 | 否 |
+| C013 | exception-swallow | WHEN OTHERS THEN 无 RAISE | 静默吞错 | 否 |
+| C014 | pl-commit-rollback | PL 块中 `Commit` / `Rollback` | 事务控制复杂化 | 否 |
+| C015 | select-for-update-blocking | `LockClause::Update { nowait: false, skip_locked: false, wait: None }` | 可能长时间阻塞 | 否 |
+| C016 | autonomous-transaction | `Pragma { name: "AUTONOMOUS_TRANSACTION" }` | 性能开销大 | 否 |
+
+### D. Suggestion（⚪ 编码建议）
+
+共 8 条，5 条纯 AST 可检。
+
+| ID | 规则名 | AST 检测点 | 建议 | 需 Schema |
+|---|---|---|---|---|
+| S001 | delete-full-table-use-truncate | `DeleteStatement.where_clause.is_none()` | 用 TRUNCATE 释放空间 | 否 |
+| S002 | limit-offset-use-cursor | `SelectStatement.offset.is_some()` | 用游标翻页 | 否 |
+| S003 | index-column-too-wide | VARCHAR(n) n > 50 的列出现在索引中 | 控制索引列长度 | 是 |
+| S004 | analyze-after-bulk-insert | 大量 INSERT 后无 ANALYZE（需上下文） | 防止统计信息不准 | 是 |
+| S005 | prefer-percent-type | `PlDataType::TypeName` 而非 `PercentType` | 用 %TYPE 锚定类型 | 否 |
+| S006 | limit-without-order-by | `limit` 存在但 `order_by` 为空 | 结果不确定 | 否 |
+| S007 | explicit-type-for-literals | WHERE 中 `Literal` 无 `TypeCast` | 避免隐式转换 | 否 |
+| S008 | complex-sql-consider-split | SQL 文本长度 > threshold 或 子查询数 > threshold | 拆分简化 | 否 |
+
+### 汇总
+
+| 级别 | 数量 | 纯 AST | 需 Schema |
+|---|---|---|---|
+| Prohibition | 9 | 8 | 1 |
+| Performance | 22 | 18 | 4 |
+| Caution | 16 | 14 | 2 |
+| Suggestion | 8 | 5 | 3 |
+| **Total** | **55** | **45** | **10** |
+
+---
+
+## Module Structure / 模块结构
+
+```
+src/linter/
+├── mod.rs                    # SqlWarning, WarningLevel, Confidence, LintRule trait, SqlLinter orchestrator
+├── rules_prohibition.rs      # R001-R009
+├── rules_performance.rs      # P001-P022
+├── rules_caution.rs          # C001-C016 (含 Hint 增强规则)
+├── rules_suggestion.rs       # S001-S008
+└── tests.rs                  # 所有规则的单元测试
+```
+
+### SqlLinter 调度器
+
+```rust
+pub struct SqlLinter {
+    rules: Vec<LintRuleEntry>,
+    config: LinterConfig,
+}
+
+pub struct LinterConfig {
+    pub min_level: WarningLevel,      // 最低报告级别
+    pub min_confidence: Confidence,   // 最低可信度 (Full/Partial)
+    pub suppress: Vec<String>,        // 禁用的规则 ID 列表
+    pub in_list_threshold: usize,     // P003 阈值，默认 500
+    pub subquery_depth_limit: usize,  // P014 深度阈值，默认 3
+    pub sql_length_limit: usize,      // S008 SQL 长度阈值，默认 2000
+    pub non_equi_join_limit: usize,   // P007 非等值操作上限，默认 2
+}
+
+pub struct LintRuleEntry {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub level: WarningLevel,
+    /// 对应的语句类型（None = 对所有语句执行）
+    pub stmt_kind: Option<StatementKind>,
+    pub check_fn: fn(&StatementInfo, Option<&SchemaMap>, &LinterConfig, Confidence, &mut Vec<SqlWarning>),
+}
+
+/// 语句类型枚举，用于 SqlLinter 一级分发
+/// 避免每条规则内部重复 match Statement
+pub enum StatementKind {
+    Select, Update, Delete, Insert, Merge, DmlAll, HintOnly,
+    PlBlock, Dml, Ddl, All,
+}
+```
+
+### SqlLinter 一级分发策略
+
+每条规则注册时声明 `stmt_kind`。`SqlLinter.lint()` 遍历语句时，先按 `StatementKind` 分发到匹配的规则组，再将当前 `StatementInfo` 传入规则函数。这样规则函数内部只需直接解构自己关心的子类型，无需写 match 分发：
+
+```rust
+impl SqlLinter {
+    pub fn lint(&self, stmts: &[StatementInfo], schema: Option<&SchemaMap>, confidence: Confidence) -> Vec<SqlWarning> {
+        let mut warnings = Vec::new();
+        for info in stmts {
+            let kind = classify_statement(&info.statement);
+            for rule in &self.rules {
+                if let Some(ref rule_kind) = rule.stmt_kind {
+                    if !rule_kind.matches(kind) { continue; }
+                }
+                if self.config.suppress.contains(&rule.id) { continue; }
+                (rule.check_fn)(info, schema, &self.config, confidence, &mut warnings);
+            }
+        }
+        // 聚合、排序、按级别过滤...
+        warnings
+    }
+}
+```
+
+规则检测有三种实现方式：
+
+1. **直接模式匹配**（最简单）— 直接 match AST 节点，如 R003 `Statement::Lock`
+2. **Visitor 遍历**（中等）— 实现 `Visitor` trait，遍历表达式树收集模式，如 R007 搜索所有 `Expr::Like`
+3. **上下文感知**（较复杂）— 需要理解语句结构上下文，如 R009 需区分"SELECT 列表中的子查询"和"WHERE 中的子查询"
+
+---
+
+## Integration Points / 集成点
+
+### 1. ParseOutput 扩展
+
+```rust
+// src/parser/mod.rs
+pub struct ParseOutput {
+    pub statements: Vec<crate::ast::StatementInfo>,
+    pub errors: Vec<ParserError>,
+    pub comments: Vec<CommentInfo>,
+    // 新增 — 仅当调用方请求 lint 时填充
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<crate::linter::SqlWarning>,
+}
+```
+
+### 2. CLI 入口
+
+```
+ogsql parse       --lint [--min-level <level>] [--min-confidence <level>] [--suppress <ids>] [--lint-config <path>]
+ogsql validate     --lint [--min-level <level>] [--min-confidence <level>] [--suppress <ids>] [--lint-config <path>]
+ogsql parse-xml    --lint [--min-level <level>] [--min-confidence <level>] [--suppress <ids>] [--lint-config <path>]
+ogsql parse-java   --lint [--min-level <level>] [--min-confidence <level>] [--suppress <ids>] [--lint-config <path>]
+```
+
+阈值 CLI 参数（优先级高于配置文件）：
+
+```
+--in-list-threshold <N>         P003 IN 列表上限 (默认 500)
+--subquery-depth-limit <N>      P014 子查询嵌套深度 (默认 3)
+--sql-length-limit <N>          S008 SQL 长度上限 (默认 2000)
+--non-equi-join-limit <N>       P007 非等值操作上限 (默认 2)
+```
+
+### 3. Warning 与 ParserError::Warning 的关系
+
+两套体系并存，各自服务于不同目的：
+
+| 体系 | 类型 | 来源 | 语义 |
+|---|---|---|---|
+| 语法级 | `ParserError::Warning` | hint_validator.rs, function_registry.rs | 解析阶段的语法/语义提示 |
+| 语义级 | `SqlWarning` (新) | linter 模块 | AST 级别的反模式/性能/风险检测 |
+
+- `ParseOutput.errors` 不变，继续包含 `ParserError::Warning`
+- `ParseOutput.warnings` (新) 包含 `SqlWarning`
+- 两者在 JSON 输出中分别呈现为 `errors` 和 `warnings` 数组
+- 两者在终端输出中使用不同的前缀标记：`[W-语法]` vs `[W-P001]`
+- hint_validator 的结果未来可渐进式迁移到 SqlWarning（不阻塞本次实现）
+
+### 4. 多语句 Warning 归属 — 按语句聚合
+
+JSON 输出格式：
+```json
+{
+  "statements": [
+    {
+      "sql_text": "SELECT * FROM t1 UNION SELECT * FROM t2",
+      "statement": { "..." : "..." },
+      "warnings": [
+        { "rule_id": "R001", "level": "prohibition", "confidence": "full", "message": "..." },
+        { "rule_id": "P001", "level": "performance", "confidence": "full", "message": "..." }
+      ]
+    }
+  ],
+  "summary": {
+    "total_warnings": 5,
+    "by_level": { "prohibition": 1, "performance": 2, "caution": 1, "suggestion": 1 },
+    "by_rule": { "R001": 1, "P001": 2, "C007": 1, "S006": 1 }
+  }
+}
+```
+
+终端输出格式：
+```
+── Statement 1 (line 1) ──
+  🔴 R001  SELECT * 违反 GaussDB 编码规范
+          → 明确列出所需字段名
+  🟡 P001  UNION 未使用 ALL，存在不必要的去重排序
+          → 如果确认无重叠，改用 UNION ALL
+
+── Statement 2 (line 5) ──
+  🔵 C007  UPDATE 无 WHERE 子句，可能影响全表数据
+
+── Summary ──
+  Prohibition: 1 | Performance: 1 | Caution: 1 | Suggestion: 0
+  Total: 3 warnings
+```
+
+### 5. 配置文件
+
+查找优先级（高到低）：
+
+1. `--lint-config <path>` — CLI 显式指定
+2. `.ogsql-lint.toml` — 当前工作目录
+3. `~/.config/ogsql/lint.toml` — 用户全局配置（XDG 标准）
+4. 内置默认值
+
+找到配置文件后与 CLI 参数合并，CLI 参数覆盖配置文件中的同名项。
+
+```toml
+# .ogsql-lint.toml
+min_level = "performance"
+min_confidence = "full"
+suppress = ["R001", "S006"]
+
+[thresholds]
+in_list = 500
+subquery_depth = 3
+sql_length = 2000
+non_equi_join = 2
+```
+
+### 6. MCP / HTTP API
+
+- `validate` 工具/端点：新增 `lint: bool`、`min_level: string`、`min_confidence: string` 参数
+- 返回 JSON 中新增 `warnings: SqlWarning[]` 字段
+- 按语句聚合输出
+
+---
+
+## Design Decisions / 设计决策记录
+
+以下 7 项已确认。
+
+### D1: 规则阈值参数化 — CLI 参数 + 配置文件双重支持
+
+阈值参数同时暴露为 CLI 参数和配置文件字段。优先级链：
+
+`CLI --in-list-threshold 300` > `.ogsql-lint.toml` 的 `thresholds.in_list` > 代码内置默认值 (500)
+
+涉及的阈值参数：
+
+| 参数 | CLI flag | 配置文件字段 | 默认值 | 影响规则 |
+|---|---|---|---|---|
+| IN 列表上限 | `--in-list-threshold` | `thresholds.in_list` | 500 | P003 |
+| 子查询嵌套深度 | `--subquery-depth-limit` | `thresholds.subquery_depth` | 3 | P014 |
+| SQL 长度上限 | `--sql-length-limit` | `thresholds.sql_length` | 2000 | S008 |
+| 非等值操作数上限 | `--non-equi-join-limit` | `thresholds.non_equi_join` | 2 | P007 |
+
+### D2: iBatis 动态 SQL — 增加 confidence 字段
+
+`SqlWarning` 结构体包含 `confidence: Confidence` 字段（`Full` / `Partial`）。parse-xml 和 parse-java 产出的 Warning 标记为 `Partial`，parse 和 validate 产出的标记为 `Full`。支持 `--min-confidence full` 过滤。
+
+### D3: Hint 矛盾检测 — 全量检测（同表 + 跨表）
+
+同时检测以下五类矛盾：
+
+| 矛盾类型 | 示例 | 严重性 |
+|---|---|---|
+| 同表正反矛盾 | `hashjoin(t1)` + `nohashjoin(t1)` | 高 |
+| 同表互斥扫描方式 | `tablescan(t1)` + `indexscan(t1)` | 高 |
+| 同表多种 JOIN 方式 | `hashjoin(t1)` + `nestloop(t1)` | 中 |
+| 跨表 leading 冲突 | `leading(t1 t2)` + `leading(t2 t1)` | 中 |
+| Hint 与 GUC 矛盾 | `set(enable_hashjoin off)` + `hashjoin(t1)` | 低 |
+
+实现时复用 `hint_validator.rs` 的 `parse_hint_list()` 解析结果。
+
+### D4: Warning 与 ParserError::Warning — 并存
+
+两套体系并存。语法级 `ParserError::Warning` 由 hint_validator/function_registry 产出，语义级 `SqlWarning` 由 linter 产出。分别位于 `ParseOutput.errors` 和 `ParseOutput.warnings`。
+
+### D5: 多语句 Warning 归属 — 按语句聚合
+
+Warning 按语句分组聚合展示。JSON 中每条语句的 warnings 为数组。终端输出按语句分块显示。末尾附 summary 统计。
+
+### D6: 配置文件路径 — 默认程序内路径 + `--lint-config` 优先
+
+配置文件查找顺序：`--lint-config <path>` > `.ogsql-lint.toml` (CWD) > `~/.config/ogsql/lint.toml` (XDG) > 内置默认值。
+
+### D7: PL/pgSQL 循环内 INSERT 检测 (P021) — 作为 Phase 2 高级规则
+
+P021 归入 Phase 2。需要在 Visitor 遍历 PL 块时维护"是否在循环体内"的上下文栈，复杂度高于简单的 AST 模式匹配。
+
+---
+
+## Implementation Phases / 实施阶段
+
+### Phase 1: 核心框架 + 纯 AST 的 Prohibition/Performance 规则
+
+**范围**: 框架搭建 + 31 条规则（Prohibition R001-R009 + Performance P001-P022，其中 26 条纯 AST 可检、5 条需 Schema 暂降级为纯 AST 有限检测）
+
+**产出**:
+- `src/linter/mod.rs` — 核心类型（`SqlWarning`、`WarningLevel`、`Confidence`、`LintRuleEntry`、`SqlLinter`）+ 调度器
+- `src/linter/rules_prohibition.rs` — R001-R009
+- `src/linter/rules_performance.rs` — P001-P022
+- `src/lib.rs` — 新增 `pub mod linter;`
+- `src/bin/ogsql.rs` — `--lint` / `--min-level` / `--min-confidence` / `--suppress` / 阈值 CLI flags 集成到 validate + parse
+- `src/linter/tests.rs` — 每条规则的单元测试
+
+**预估**: 5-7 天
+
+### Phase 2: Caution/Suggestion 规则 + Hint 增强 + parse-xml/parse-java
+
+**范围**: C001-C016（含 Hint 矛盾检测）+ S001-S008 + parse-xml/parse-java `--lint` 集成
+
+**产出**:
+- `src/linter/rules_caution.rs` — C001-C016
+- `src/linter/rules_suggestion.rs` — S001-S008
+- `src/bin/ogsql.rs` — parse-xml / parse-java 的 `--lint` 集成
+- Hint 矛盾检测（C005）和表名存在性检测（C006）
+- P021 循环内 INSERT 检测
+
+**预估**: 3-4 天
+
+### Phase 3: Schema 依赖规则 + 配置文件 + MCP/HTTP API
+
+**范围**: 10 条需 Schema 的规则 + `.ogsql-lint.toml` 配置文件 + API 集成
+
+**产出**:
+- Schema 辅助检测（R005 隐式转换、P012 不必要 DISTINCT、P017 MERGE 索引等）
+- 配置文件查找、加载、合并逻辑
+- MCP `validate` 工具更新
+- HTTP `/api/validate` 更新
+
+**预估**: 2-3 天
+
+---
+
+## Testing Strategy / 测试策略
+
+### 单元测试
+
+每条规则独立的测试用例，覆盖三种状态：
+
+```rust
+#[test]
+fn r001_select_star_detected() {
+    let stmts = parse("SELECT * FROM t1");
+    let warnings = lint(&stmts, None, &default_config());
+    assert!(warnings.iter().any(|w| w.rule_id == "R001"));
+}
+
+#[test]
+fn r001_table_qualified_star_not_detected() {
+    let stmts = parse("SELECT t1.* FROM t1");
+    let warnings = lint(&stmts, None, &default_config());
+    assert!(!warnings.iter().any(|w| w.rule_id == "R001"));
+}
+
+#[test]
+fn r001_no_warning_on_explicit_cols() {
+    let stmts = parse("SELECT id, name FROM t1");
+    let warnings = lint(&stmts, None, &default_config());
+    assert!(!warnings.iter().any(|w| w.rule_id == "R001"));
+}
+```
+
+### 集成测试
+
+在每个 Phase 结束时，使用项目中已有的回归测试 SQL 文件进行端到端测试：
+
+- 从 `testcases/` 或 `lib/openGauss-server/src/test/regress/sql/` 选取代表性 SQL 文件
+- 以 `--lint` 模式运行 `validate`，验证：
+  1. 不会 panic 或崩溃
+  2. 不会产生假阳性报警（纯语法正确的 SQL 不应触发 Prohibition 级警告）
+  3. 已知反模式用例确实被检出
+- 如果引入 regression 测试中的 SQL 触发大量 Warning（如 `SELECT *` 在测试用例中广泛存在），需评估是否需要调整规则敏感度或降低这些规则的初始级别
+
+### 多规则交互测试
+
+```rust
+#[test]
+fn multiple_rules_same_statement() {
+    // SELECT * + UNION (非 ALL) — 应同时触发 R001 + P001
+    let stmts = parse("SELECT * FROM t1 UNION SELECT * FROM t2");
+    let warnings = lint(&stmts, None, &default_config());
+    assert_eq!(warnings.len(), 2);
+}
+```
+
+### Confidence 传播测试
+
+```rust
+#[test]
+fn confidence_partial_via_xml_source() {
+    // 模拟 parse-xml 场景：confidence = Partial
+    let stmts = parse("SELECT * FROM t WHERE id = #{id}");
+    let warnings = lint_with_confidence(&stmts, Confidence::Partial, &default_config());
+    assert!(warnings.iter().all(|w| w.confidence == Confidence::Partial));
+}
+```
+
+---
+
+## Rule Detection Patterns (Key Examples) / 关键规则检测示例
+
+### R001: SELECT *
+
+```rust
+fn check_select_star(select: &SelectStatement, warnings: &mut Vec<SqlWarning>) {
+    for target in &select.targets {
+        // SelectTarget::Star(Some(table)) = t.* — 限定表的星号不触发
+        // SelectTarget::Star(None) = * — 无表限定的星号才触发
+        if matches!(target, SelectTarget::Star(None)) {
+            warnings.push(SqlWarning {
+                level: WarningLevel::Prohibition,
+                rule_id: "R001".into(),
+                rule_name: "select-star".into(),
+                message: "SELECT * 违反 GaussDB 编码规范：表结构变化时可能导致不兼容".into(),
+                suggestion: Some("明确列出所需字段名".into()),
+                location: /* from span */,
+                gaussdb_ref: Some("开发设计建议 > SELECT 规范".into()),
+                confidence: Confidence::Full,
+            });
+        }
+    }
+}
+```
+
+### P010: Multi-column UPDATE from subquery
+
+```rust
+fn check_multi_col_update_subquery(update: &UpdateStatement, warnings: &mut Vec<SqlWarning>) {
+    for assignment in &update.assignments {
+        if assignment.columns.len() > 1 {
+            if matches!(&assignment.value, Expr::Subquery(_)) {
+                warnings.push(SqlWarning {
+                    level: WarningLevel::Performance,
+                    rule_id: "P010".into(),
+                    rule_name: "multi-column-update-subquery".into(),
+                    message: format!(
+                        "UPDATE SET ({}列) = (SELECT ...) 效率较低",
+                        assignment.columns.len()
+                    ),
+                    suggestion: Some("改用 UPDATE ... FROM ... WHERE ... 的 JOIN 风格".into()),
+                    location: /* from span */,
+                    gaussdb_ref: None,
+                    confidence: Confidence::Full,
+                });
+            }
+        }
+    }
+}
+```
+
+### C005: Contradictory hints
+
+```rust
+fn check_hint_contradictions(hints: &[String], warnings: &mut Vec<SqlWarning>) {
+    // 复用 hint_validator.rs 的 parse_hint_list() 解析
+    let parsed = parse_hint_list_for_conflicts(hints);
+
+    // 检测五类矛盾:
+    // 1. 同表正反: hashjoin(t1) + nohashjoin(t1)
+    // 2. 同表互斥扫描: tablescan(t1) + indexscan(t1)
+    // 3. 同表多种 JOIN: hashjoin(t1) + nestloop(t1)
+    // 4. 跨表 leading 冲突: leading(t1 t2) + leading(t2 t1)
+    // 5. Hint 与 GUC 矛盾: set(enable_hashjoin off) + hashjoin(t1)
+    // ...
+}
+```
+
+### C007: UPDATE without WHERE
+
+```rust
+fn check_update_without_where(update: &UpdateStatement, warnings: &mut Vec<SqlWarning>) {
+    if update.where_clause.is_none() {
+        warnings.push(SqlWarning {
+            level: WarningLevel::Caution,
+            rule_id: "C007".into(),
+            rule_name: "update-without-where".into(),
+            message: "UPDATE 无 WHERE 子句，可能影响全表数据".into(),
+            suggestion: Some("确认是否需要全表更新；若需清空，考虑 TRUNCATE".into()),
+            location: /* from span */,
+            gaussdb_ref: None,
+            confidence: Confidence::Full,
+        });
+    }
+}
+```
+
+---
+
+## References / 参考
+
+- GaussDB 2.23.07.210 文档: `GaussDB-2.23.07.210/term/`
+- GaussDB SQL 查询最佳实践（分布式）: https://support.huaweicloud.com/bestpractice-gaussdb/gaussdb-22-0013.html
+- GaussDB SQL 编写规范: https://support.huaweicloud.com/intl/zh-cn/distributed-devg-v2-gaussdb/gaussdb-12-0052.html
+- GaussDB SELECT 规范: https://support.huaweicloud.com/centralized-devg-v8-gaussdb/gaussdb-42-2082.html
+- GaussDB WHERE 规范: https://support.huaweicloud.com/intl/zh-cn/distributed-devg-v2-gaussdb/gaussdb-12-1204.html
+- GaussDB SQL 语句改写规则: https://support.huaweicloud.com/intl/zh-cn/distributed-devg-v3-gaussdb/gaussdb-12-0270.html

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -65,6 +65,43 @@ struct Cli {
     /// Preserves MyBatis placeholders during formatting and tokenization.
     /// 启用 MyBatis #{param} 和 ${expr} 占位符支持，格式化时保留占位符
     mybatis: bool,
+
+    /// Enable SQL anti-pattern linting on parse/validate output
+    /// 启用 SQL 反模式检测（配合 parse/validate/parse-xml/parse-java 使用）
+    #[arg(long, global = true)]
+    lint: bool,
+
+    /// Minimum warning level to report: prohibition, performance, caution, suggestion
+    /// 最低报告级别（配合 --lint 使用）
+    #[arg(long = "min-level", global = true)]
+    min_level: Option<String>,
+
+    /// Minimum confidence to report: full, partial
+    /// 最低可信度（配合 --lint 使用）
+    #[arg(long = "min-confidence", global = true)]
+    min_confidence: Option<String>,
+
+    /// Suppress specific rule IDs (comma-separated)
+    /// 禁用指定规则（逗号分隔，配合 --lint 使用）
+    #[arg(long = "suppress", global = true, value_delimiter = ',')]
+    suppress: Vec<String>,
+
+    /// P003 IN list size threshold (default: 500)
+    #[arg(long = "in-list-threshold", global = true)]
+    in_list_threshold: Option<usize>,
+
+    /// P014 subquery nesting depth limit (default: 3)
+    #[arg(long = "subquery-depth-limit", global = true)]
+    subquery_depth_limit: Option<usize>,
+
+    /// P007 non-equi join count limit (default: 2)
+    #[arg(long = "non-equi-join-limit", global = true)]
+    non_equi_join_limit: Option<usize>,
+
+    /// Path to .ogsql-lint.toml config file
+    /// 配置文件路径
+    #[arg(long = "lint-config", global = true)]
+    lint_config: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -204,6 +241,114 @@ macro_rules! die {
 }
 
 fn annotate_builtin_functions(_value: &mut serde_json::Value) {}
+
+fn build_lint_config(cli: &Cli) -> ogsql_parser::linter::LintConfig {
+    use ogsql_parser::linter::{Confidence, LintConfig, WarningLevel};
+
+    // 1. Load from config file if specified via --lint-config
+    // 2. Otherwise try standard paths (.ogsql-lint.toml, XDG)
+    // 3. Fall back to defaults
+    let mut config = if let Some(ref path) = cli.lint_config {
+        LintConfig::load_from_file(std::path::Path::new(path))
+            .unwrap_or_else(|e| die!("Error loading lint config '{path}': {e}"))
+    } else {
+        LintConfig::find_and_load().unwrap_or_else(|e| die!("Error searching lint config: {e}")).unwrap_or_default()
+    };
+
+    // CLI overrides take precedence over config file
+    if let Some(ref level) = cli.min_level {
+        config.min_level = match level.to_lowercase().as_str() {
+            "prohibition" => WarningLevel::Prohibition,
+            "performance" => WarningLevel::Performance,
+            "caution" => WarningLevel::Caution,
+            _ => WarningLevel::Suggestion,
+        };
+    }
+    if let Some(ref conf) = cli.min_confidence {
+        config.min_confidence = match conf.to_lowercase().as_str() {
+            "full" => Confidence::Full,
+            _ => Confidence::Partial,
+        };
+    }
+    if !cli.suppress.is_empty() {
+        config.suppress = cli.suppress.clone();
+    }
+    if let Some(t) = cli.in_list_threshold {
+        config.in_list_threshold = t;
+    }
+    if let Some(t) = cli.subquery_depth_limit {
+        config.subquery_depth_limit = t;
+    }
+    if let Some(t) = cli.non_equi_join_limit {
+        config.non_equi_join_limit = t;
+    }
+    config
+}
+
+fn run_lint(
+    stmts: &[ogsql_parser::StatementInfo],
+    confidence: ogsql_parser::linter::Confidence,
+    config: &ogsql_parser::linter::LintConfig,
+) -> Vec<ogsql_parser::linter::SqlWarning> {
+    let linter = ogsql_parser::linter::SqlLinter::with_default_rules(config.clone());
+    linter.lint(stmts, None, confidence)
+}
+
+fn format_warnings_text(warnings: &[ogsql_parser::linter::SqlWarning]) {
+    use ogsql_parser::linter::WarningLevel;
+    for w in warnings {
+        let icon = match w.level {
+            WarningLevel::Prohibition => "\u{1f534}",
+            WarningLevel::Performance => "\u{1f7e1}",
+            WarningLevel::Caution => "\u{1f535}",
+            WarningLevel::Suggestion => "\u{26aa}",
+        };
+        let conf = match w.confidence {
+            ogsql_parser::linter::Confidence::Partial => " [partial]",
+            ogsql_parser::linter::Confidence::Full => "",
+        };
+        eprintln!("  {icon} {} {}{conf}", w.rule_id, w.message);
+        if let Some(ref s) = w.suggestion {
+            eprintln!("          \u{2192} {s}");
+        }
+    }
+}
+
+fn format_warnings_summary(warnings: &[ogsql_parser::linter::SqlWarning]) -> serde_json::Value {
+    ogsql_parser::linter::build_lint_summary(warnings)
+}
+
+#[cfg(feature = "ibatis")]
+fn lint_xml_statements(
+    parsed: &[ogsql_parser::ibatis::types::ParsedStatement],
+    config: &ogsql_parser::linter::LintConfig,
+) -> Vec<ogsql_parser::linter::SqlWarning> {
+    let mut all_warnings = Vec::new();
+    let linter = ogsql_parser::linter::SqlLinter::with_default_rules(config.clone());
+    for stmt in parsed {
+        if let Some((ref stmts, _)) = stmt.parse_result {
+            let mut ws = linter.lint(stmts, None, ogsql_parser::linter::Confidence::Partial);
+            all_warnings.append(&mut ws);
+        }
+    }
+    all_warnings
+}
+
+#[cfg(feature = "java")]
+fn lint_java_extractions(
+    extractions: &[ogsql_parser::java::types::ExtractedSql],
+    config: &ogsql_parser::linter::LintConfig,
+) -> Vec<ogsql_parser::linter::SqlWarning> {
+    let mut all_warnings = Vec::new();
+    let linter = ogsql_parser::linter::SqlLinter::with_default_rules(config.clone());
+    for ext in extractions {
+        if let Some(ref parse_result) = ext.parse_result {
+            let mut ws = linter.lint(&parse_result.statements, None, ogsql_parser::linter::Confidence::Partial);
+            all_warnings.append(&mut ws);
+        }
+    }
+    all_warnings
+}
 
 fn read_input(file: Option<&str>) -> String {
     match file {
@@ -620,6 +765,16 @@ fn cmd_parse_single(cli: &Cli, file_path: Option<&str>, csv: bool, proc_name: Op
         if !output.comments.is_empty() {
             out.as_object_mut().unwrap().insert("comments".to_string(), serde_json::json!(output.comments));
         }
+        if cli.lint {
+            let config = build_lint_config(cli);
+            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config);
+            if !lint_warnings.is_empty() {
+                out.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+                out.as_object_mut()
+                    .unwrap()
+                    .insert("lint_summary".to_string(), format_warnings_summary(&lint_warnings));
+            }
+        }
         println!("{}", serde_json::to_string_pretty(&out).unwrap());
     } else {
         for stmt in &output.statements {
@@ -642,6 +797,14 @@ fn cmd_parse_single(cli: &Cli, file_path: Option<&str>, csv: bool, proc_name: Op
                 for w in &warnings {
                     eprintln!("  {}", w);
                 }
+            }
+        }
+        if cli.lint {
+            let config = build_lint_config(cli);
+            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config);
+            if !lint_warnings.is_empty() {
+                eprintln!("\n── Lint Warnings ({}) ──", lint_warnings.len());
+                format_warnings_text(&lint_warnings);
             }
         }
     }
@@ -3429,6 +3592,13 @@ fn cmd_validate_single(cli: &Cli, file_path: Option<&str>, csv: bool, strict: bo
     let sql = read_input(file_path);
     let (stmts, errors, pkg_errors, var_errors) = validate_sql(&sql, cli.mybatis, &[], strict);
 
+    let lint_warnings = if cli.lint {
+        let config = build_lint_config(cli);
+        run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+    } else {
+        vec![]
+    };
+
     let format_var_err = |ve: &ogsql_parser::UndefinedVariableError| -> String {
         let line_info = ve.location.as_ref().map(|sp| format!(":{}", sp.start.line)).unwrap_or_default();
         let kind_label = match ve.kind {
@@ -3480,6 +3650,10 @@ fn cmd_validate_single(cli: &Cli, file_path: Option<&str>, csv: bool, strict: bo
         if !var_errors.is_empty() {
             out.as_object_mut().unwrap().insert("undefined_variables".to_string(), serde_json::json!(var_errors));
         }
+        if !lint_warnings.is_empty() {
+            out.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+            out.as_object_mut().unwrap().insert("lint_summary".to_string(), format_warnings_summary(&lint_warnings));
+        }
         println!("{}", serde_json::to_string_pretty(&out).unwrap());
     } else {
         let real_errors: Vec<_> = errors.iter().filter(|e| !is_warning(e)).collect();
@@ -3508,9 +3682,21 @@ fn cmd_validate_single(cli: &Cli, file_path: Option<&str>, csv: bool, strict: bo
             for w in &warnings {
                 eprintln!("  warning: {}", w);
             }
-            if cli.verbose {
-                write_error_log(&sql, file_path, &stmts, &real_errors);
+        }
+        if !lint_warnings.is_empty() {
+            eprintln!("\n── Lint Warnings ({}) ──", lint_warnings.len());
+            format_warnings_text(&lint_warnings);
+            eprintln!("\n── Summary ──");
+            let summary = format_warnings_summary(&lint_warnings);
+            for (level, count) in summary.get("by_level").unwrap().as_object().unwrap() {
+                eprintln!("  {}: {}", level, count);
             }
+            eprintln!("  Total: {} lint warnings", lint_warnings.len());
+        }
+        if !real_errors.is_empty() && cli.verbose {
+            write_error_log(&sql, file_path, &stmts, &real_errors);
+        }
+        if !real_errors.is_empty() || !var_errors.is_empty() {
             std::process::exit(1);
         }
     }
@@ -3597,6 +3783,13 @@ fn cmd_validate_files(cli: &Cli, csv: bool, strict: bool) {
             let sql = read_input(Some(file_path.as_str()));
             let (stmts, errors, _pkg_errors, var_errors) = validate_sql(&sql, cli.mybatis, &[], strict);
 
+            let lint_warnings = if cli.lint {
+                let config = build_lint_config(cli);
+                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+            } else {
+                vec![]
+            };
+
             let real_errors: Vec<_> = errors.iter().filter(|e| !is_warning(e)).collect();
             let warnings: Vec<_> = errors.iter().filter(|e| is_warning(e)).collect();
             let has_var_errors = !var_errors.is_empty();
@@ -3621,9 +3814,13 @@ fn cmd_validate_files(cli: &Cli, csv: bool, strict: bool) {
                 for w in &warnings {
                     eprintln!("  warning: {}", w);
                 }
-                if cli.verbose {
-                    write_error_log(&sql, Some(file_path), &stmts, &real_errors);
-                }
+            }
+            if !lint_warnings.is_empty() {
+                eprintln!("\n── Lint Warnings for {} ({}) ──", file_path, lint_warnings.len());
+                format_warnings_text(&lint_warnings);
+            }
+            if !real_errors.is_empty() && cli.verbose {
+                write_error_log(&sql, Some(file_path), &stmts, &real_errors);
             }
         }
         if any_invalid {
@@ -4159,6 +4356,9 @@ mod api {
         /// 仅解析指定的存储过程/函数
         #[serde(default)]
         pub procedure: Option<String>,
+        /// Enable SQL anti-pattern linting
+        #[serde(default)]
+        pub lint: Option<bool>,
     }
 
     #[derive(Deserialize, ToSchema)]
@@ -4331,6 +4531,15 @@ mod api {
         }
         if has_var_errors {
             result.as_object_mut().unwrap().insert("undefined_variables".to_string(), serde_json::json!(var_errors));
+        }
+        if input.lint == Some(true) {
+            let config = ogsql_parser::linter::LintConfig::default();
+            let lint_warnings = super::run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config);
+            result.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+            result
+                .as_object_mut()
+                .unwrap()
+                .insert("lint_summary".to_string(), ogsql_parser::linter::build_lint_summary(&lint_warnings));
         }
         Json(result)
     }
@@ -4641,13 +4850,33 @@ fn cmd_parse_xml_single(cli: &Cli, csv: bool, java_roots: &[std::path::PathBuf])
     #[cfg(not(feature = "java"))]
     let result = ogsql_parser::ibatis::parse_mapper_bytes_with_path(&input, file_opt);
 
+    let lint_warnings = if cli.lint {
+        let config = build_lint_config(cli);
+        lint_xml_statements(&result.statements, &config)
+    } else {
+        vec![]
+    };
+
     if csv {
         output_csv_xml_header();
         output_csv_xml_rows(&result.statements, file_opt.unwrap_or("<stdin>"), ".");
     } else if cli.json {
-        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        let mut out = serde_json::to_string_pretty(&result).unwrap();
+        if !lint_warnings.is_empty() {
+            let mut val: serde_json::Value = serde_json::from_str(&out).unwrap();
+            val.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+            val.as_object_mut().unwrap().insert("lint_summary".to_string(), format_warnings_summary(&lint_warnings));
+            out = serde_json::to_string_pretty(&val).unwrap();
+        }
+        println!("{}", out);
     } else {
         print_xml_text(&result);
+        if !lint_warnings.is_empty() {
+            eprintln!("\n── Lint Warnings ({}) ──", lint_warnings.len());
+            format_warnings_text(&lint_warnings);
+            eprintln!("── Summary ──");
+            eprintln!("  Total: {} warnings", lint_warnings.len());
+        }
     }
 }
 
@@ -4853,6 +5082,20 @@ fn cmd_parse_xml_dir(cli: &Cli, dir_path: &str, csv: bool, java_roots: &[std::pa
             }
         }
         println!("Total: {} statement(s) from {} file(s)", total_mapper, all_results.len());
+
+        if cli.lint {
+            let config = build_lint_config(cli);
+            let mut all_lint: Vec<ogsql_parser::linter::SqlWarning> = Vec::new();
+            for (_file_name, _rel_dir, result) in &all_results {
+                all_lint.extend(lint_xml_statements(&result.statements, &config));
+            }
+            if !all_lint.is_empty() {
+                eprintln!("\n── Lint Warnings ({}) ──", all_lint.len());
+                format_warnings_text(&all_lint);
+                eprintln!("── Summary ──");
+                eprintln!("  Total: {} warnings", all_lint.len());
+            }
+        }
     }
 
     if stats {
@@ -4999,13 +5242,33 @@ fn cmd_parse_java_single(cli: &Cli, extra_sql_methods: &[String], extra_sql_var_
     };
     let result = ogsql_parser::java::extract_sql_from_java(&source, &file_path, &config);
 
+    let lint_warnings = if cli.lint {
+        let config = build_lint_config(cli);
+        lint_java_extractions(&result.extractions, &config)
+    } else {
+        vec![]
+    };
+
     if csv {
         output_csv_java_header();
         output_csv_java_rows(&result.extractions, &file_path, ".");
     } else if cli.json {
-        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        let mut out = serde_json::to_string_pretty(&result).unwrap();
+        if !lint_warnings.is_empty() {
+            let mut val: serde_json::Value = serde_json::from_str(&out).unwrap();
+            val.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+            val.as_object_mut().unwrap().insert("lint_summary".to_string(), format_warnings_summary(&lint_warnings));
+            out = serde_json::to_string_pretty(&val).unwrap();
+        }
+        println!("{}", out);
     } else {
         print_java_text(&result, &file_path);
+        if !lint_warnings.is_empty() {
+            eprintln!("\n── Lint Warnings ({}) ──", lint_warnings.len());
+            format_warnings_text(&lint_warnings);
+            eprintln!("── Summary ──");
+            eprintln!("  Total: {} warnings", lint_warnings.len());
+        }
     }
 }
 
@@ -5194,6 +5457,20 @@ fn cmd_parse_java_dir(
             total += result.extractions.len();
         }
         println!("Total: {} extraction(s) from {} file(s)", total, all_results.len());
+
+        if cli.lint {
+            let config = build_lint_config(cli);
+            let mut all_lint: Vec<ogsql_parser::linter::SqlWarning> = Vec::new();
+            for (_file_name, _rel_dir, result) in &all_results {
+                all_lint.extend(lint_java_extractions(&result.extractions, &config));
+            }
+            if !all_lint.is_empty() {
+                eprintln!("\n── Lint Warnings ({}) ──", all_lint.len());
+                format_warnings_text(&all_lint);
+                eprintln!("── Summary ──");
+                eprintln!("  Total: {} warnings", all_lint.len());
+            }
+        }
     }
 
     if stats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 pub mod analyzer;
 pub mod ast;
 pub mod formatter;
+pub mod linter;
 pub mod parser;
 pub mod token;
 pub mod token_formatter;

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -1,0 +1,700 @@
+mod rules_caution;
+mod rules_performance;
+mod rules_prohibition;
+mod rules_suggestion;
+
+#[cfg(test)]
+mod tests;
+
+use crate::analyzer::schema::SchemaMap;
+use crate::ast::{SelectStatement, Spanned, Statement, StatementInfo};
+use crate::token::SourceLocation;
+#[cfg(feature = "lint-config")]
+use std::path::{Path, PathBuf};
+
+/// SQL warning severity level. "Error" is deliberately NOT used to avoid
+/// confusion with `ParserError` which represents syntax-level errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum WarningLevel {
+    /// Prohibition -- violates GaussDB "rule"-level requirements; may cause data safety risks.
+    Prohibition = 3,
+    /// Performance -- identifiable performance pitfall with a clear optimization path.
+    Performance = 2,
+    /// Caution -- syntactically legal but easy to overlook; requires contextual judgment.
+    Caution = 1,
+    /// Suggestion -- improves maintainability and robustness; does not affect correctness.
+    Suggestion = 0,
+}
+
+impl std::fmt::Display for WarningLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WarningLevel::Prohibition => write!(f, "prohibition"),
+            WarningLevel::Performance => write!(f, "performance"),
+            WarningLevel::Caution => write!(f, "caution"),
+            WarningLevel::Suggestion => write!(f, "suggestion"),
+        }
+    }
+}
+
+/// Detection confidence level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum Confidence {
+    /// Partial confidence (lower value) -- iBatis/MyBatis dynamic SQL.
+    Partial,
+    /// Full confidence (higher value) -- complete SQL.
+    Full,
+}
+
+impl std::fmt::Display for Confidence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Confidence::Full => write!(f, "full"),
+            Confidence::Partial => write!(f, "partial"),
+        }
+    }
+}
+
+/// A single SQL warning produced by the linter.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SqlWarning {
+    /// Severity level.
+    pub level: WarningLevel,
+    /// Rule identifier, e.g. "R001", "P002".
+    pub rule_id: String,
+    /// Human-readable rule name.
+    pub rule_name: String,
+    /// Warning description with SQL context.
+    pub message: String,
+    /// Optimization suggestion (optional).
+    pub suggestion: Option<String>,
+    /// Source location of the offending construct.
+    pub location: SourceLocation,
+    /// GaussDB documentation reference (optional).
+    pub gaussdb_ref: Option<String>,
+    /// Detection confidence.
+    pub confidence: Confidence,
+}
+
+/// Statement category used by `SqlLinter` for first-level dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatementKind {
+    Select,
+    Update,
+    Delete,
+    Insert,
+    Merge,
+    Dml,
+    Ddl,
+    PlBlock,
+    All,
+}
+
+impl StatementKind {
+    /// Returns true if `self` matches `other` considering the broad Dml/Ddl/All categories.
+    pub fn matches(self, other: StatementKind) -> bool {
+        match (self, other) {
+            (StatementKind::All, _) | (_, StatementKind::All) => true,
+            (
+                StatementKind::Dml,
+                StatementKind::Select
+                | StatementKind::Update
+                | StatementKind::Delete
+                | StatementKind::Insert
+                | StatementKind::Merge,
+            ) => true,
+            (StatementKind::Ddl, StatementKind::Ddl) => true,
+            _ => self == other,
+        }
+    }
+}
+
+/// Linter configuration.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LintConfig {
+    pub min_level: WarningLevel,
+    pub min_confidence: Confidence,
+    pub suppress: Vec<String>,
+    /// P003 -- IN list size threshold (default 500).
+    pub in_list_threshold: usize,
+    /// P014 -- subquery nesting depth limit (default 3).
+    pub subquery_depth_limit: usize,
+    /// S008 -- SQL text length limit (default 2000).
+    pub sql_length_limit: usize,
+    /// P007 -- non-equi join count limit (default 2).
+    pub non_equi_join_limit: usize,
+    /// R002 -- GROUP BY column count limit (default 10).
+    pub group_by_column_limit: usize,
+}
+
+impl Default for LintConfig {
+    fn default() -> Self {
+        Self {
+            min_level: WarningLevel::Suggestion,
+            min_confidence: Confidence::Partial,
+            suppress: vec![],
+            in_list_threshold: 500,
+            subquery_depth_limit: 3,
+            sql_length_limit: 2000,
+            non_equi_join_limit: 2,
+            group_by_column_limit: 10,
+        }
+    }
+}
+
+/// TOML config file structure mirroring `LintConfig` with all-optional fields
+/// so that partial configuration files are valid.
+///
+/// # Example
+///
+/// ```toml
+/// # .ogsql-lint.toml
+/// min_level = "caution"
+/// min_confidence = "full"
+/// suppress = ["R001", "S007"]
+/// in_list_threshold = 200
+/// subquery_depth_limit = 5
+/// ```
+#[cfg(feature = "lint-config")]
+#[derive(serde::Deserialize)]
+pub struct LintConfigFile {
+    pub min_level: Option<String>,
+    pub min_confidence: Option<String>,
+    pub suppress: Option<Vec<String>>,
+    pub in_list_threshold: Option<usize>,
+    pub subquery_depth_limit: Option<usize>,
+    pub sql_length_limit: Option<usize>,
+    pub non_equi_join_limit: Option<usize>,
+    pub group_by_column_limit: Option<usize>,
+}
+
+#[cfg(feature = "lint-config")]
+impl LintConfig {
+    /// Parse a TOML string and merge with defaults.
+    /// Unknown TOML fields are silently ignored by serde.
+    pub fn from_toml_str(s: &str) -> Result<Self, String> {
+        let file: LintConfigFile = toml::from_str(s).map_err(|e| format!("invalid TOML config: {e}"))?;
+        let mut config = Self::default();
+        config.merge_file(file);
+        Ok(config)
+    }
+
+    /// Load configuration from a TOML file.
+    pub fn load_from_file(path: &Path) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path).map_err(|e| format!("cannot read '{}': {e}", path.display()))?;
+        Self::from_toml_str(&content)
+    }
+
+    /// Search standard paths for a lint config file and return the first found.
+    ///
+    /// Search order:
+    /// 1. `.ogsql-lint.toml` in the current working directory
+    /// 2. `~/.config/ogsql/lint.toml` (XDG convention)
+    ///
+    /// Returns `Ok(None)` when no config file is found.
+    pub fn find_and_load() -> Result<Option<Self>, String> {
+        let cwd = std::env::current_dir().map_err(|e| format!("cannot get cwd: {e}"))?;
+        let local = cwd.join(".ogsql-lint.toml");
+        if local.is_file() {
+            return Self::load_from_file(&local).map(Some);
+        }
+
+        let xdg_base = std::env::var("XDG_CONFIG_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| std::env::var("HOME").ok().map(|h| PathBuf::from(h).join(".config")));
+        if let Some(base) = xdg_base {
+            let xdg = base.join("ogsql").join("lint.toml");
+            if xdg.is_file() {
+                return Self::load_from_file(&xdg).map(Some);
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Apply values from a `LintConfigFile` onto `self`.
+    /// Only fields that are `Some` in the file override the current value.
+    pub fn merge_file(&mut self, file: LintConfigFile) {
+        if let Some(ref level) = file.min_level {
+            self.min_level = match level.to_lowercase().as_str() {
+                "prohibition" => WarningLevel::Prohibition,
+                "performance" => WarningLevel::Performance,
+                "caution" => WarningLevel::Caution,
+                _ => WarningLevel::Suggestion,
+            };
+        }
+        if let Some(ref conf) = file.min_confidence {
+            self.min_confidence = match conf.to_lowercase().as_str() {
+                "full" => Confidence::Full,
+                _ => Confidence::Partial,
+            };
+        }
+        if let Some(suppress) = file.suppress {
+            self.suppress = suppress;
+        }
+        if let Some(v) = file.in_list_threshold {
+            self.in_list_threshold = v;
+        }
+        if let Some(v) = file.subquery_depth_limit {
+            self.subquery_depth_limit = v;
+        }
+        if let Some(v) = file.sql_length_limit {
+            self.sql_length_limit = v;
+        }
+        if let Some(v) = file.non_equi_join_limit {
+            self.non_equi_join_limit = v;
+        }
+        if let Some(v) = file.group_by_column_limit {
+            self.group_by_column_limit = v;
+        }
+    }
+}
+
+/// A single registered rule.
+pub struct LintRuleEntry {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub level: WarningLevel,
+    pub stmt_kind: StatementKind,
+    pub check_fn: fn(&[StatementInfo], Option<&SchemaMap>, &LintConfig, Confidence, &mut Vec<SqlWarning>),
+}
+
+/// Build a JSON summary of lint warnings, grouped by level and rule.
+pub fn build_lint_summary(warnings: &[SqlWarning]) -> serde_json::Value {
+    let mut by_level = std::collections::BTreeMap::new();
+    let mut by_rule = std::collections::BTreeMap::new();
+    for w in warnings {
+        *by_level.entry(format!("{}", w.level)).or_insert(0usize) += 1;
+        *by_rule.entry(w.rule_id.clone()).or_insert(0usize) += 1;
+    }
+    serde_json::json!({
+        "total": warnings.len(),
+        "by_level": by_level,
+        "by_rule": by_rule,
+    })
+}
+
+pub(crate) fn loc_from_spanned<T>(spanned: &Spanned<T>, fallback: SourceLocation) -> SourceLocation {
+    spanned.span.as_ref().map_or(fallback, |s| s.start)
+}
+
+/// SQL linter orchestrator. Registers rules and dispatches them.
+pub struct SqlLinter {
+    rules: Vec<LintRuleEntry>,
+    config: LintConfig,
+}
+
+impl SqlLinter {
+    pub fn new(config: LintConfig) -> Self {
+        Self { rules: vec![], config }
+    }
+
+    /// Create a linter with all Phase 1 rules registered.
+    pub fn with_default_rules(config: LintConfig) -> Self {
+        let mut linter = Self::new(config);
+        rules_prohibition::register(&mut linter);
+        rules_performance::register(&mut linter);
+        rules_caution::register(&mut linter);
+        rules_suggestion::register(&mut linter);
+        linter
+    }
+
+    pub fn register(&mut self, rule: LintRuleEntry) {
+        self.rules.push(rule);
+    }
+
+    /// Run all registered rules against the given statements.
+    pub fn lint(&self, stmts: &[StatementInfo], schema: Option<&SchemaMap>, confidence: Confidence) -> Vec<SqlWarning> {
+        let mut warnings = Vec::new();
+        if confidence < self.config.min_confidence {
+            return warnings;
+        }
+
+        for info in stmts {
+            let kind = classify_statement(&info.statement);
+            for rule in &self.rules {
+                if !rule.stmt_kind.matches(kind) {
+                    continue;
+                }
+                if self.config.suppress.iter().any(|s| s == rule.id) {
+                    continue;
+                }
+                if rule.level < self.config.min_level {
+                    continue;
+                }
+                (rule.check_fn)(stmts, schema, &self.config, confidence, &mut warnings);
+            }
+        }
+
+        // Sort by severity (highest first), then by rule_id for stable output.
+        warnings.sort_by(|a, b| b.level.cmp(&a.level).then_with(|| a.rule_id.cmp(&b.rule_id)));
+        warnings
+    }
+
+    #[allow(dead_code)]
+    pub fn config(&self) -> &LintConfig {
+        &self.config
+    }
+}
+
+fn classify_statement(stmt: &Statement) -> StatementKind {
+    match stmt {
+        Statement::Select(_) => StatementKind::Select,
+        Statement::Insert(_) | Statement::Replace(_) => StatementKind::Insert,
+        Statement::InsertAll(_) | Statement::InsertFirst(_) => StatementKind::Insert,
+        Statement::Update(_) => StatementKind::Update,
+        Statement::Delete(_) => StatementKind::Delete,
+        Statement::Merge(_) => StatementKind::Merge,
+        Statement::Values(_) => StatementKind::Select,
+        Statement::AnonyBlock(_) | Statement::Do(_) => StatementKind::PlBlock,
+        Statement::Lock(_) => StatementKind::All, // LockStatement is its own category
+        Statement::Drop(_) => StatementKind::Ddl,
+        Statement::Explain(_) => StatementKind::All,
+        Statement::Truncate(_)
+        | Statement::CreateTable(_)
+        | Statement::CreateTableAs(_)
+        | Statement::AlterTable(_)
+        | Statement::AlterTablespace(_)
+        | Statement::CreateIndex(_)
+        | Statement::CreateGlobalIndex(_)
+        | Statement::CreateSchema(_)
+        | Statement::CreateDatabase(_)
+        | Statement::CreateDatabaseLink(_)
+        | Statement::CreateTablespace(_)
+        | Statement::CreateFunction(_)
+        | Statement::CreateProcedure(_)
+        | Statement::CreateType(_)
+        | Statement::AlterIndex(_)
+        | Statement::CreatePackage(_)
+        | Statement::CreateView(_)
+        | Statement::CreateMaterializedView(_)
+        | Statement::CreateSequence(_)
+        | Statement::CreateTrigger(_)
+        | Statement::CreateExtension(_)
+        | Statement::CreateRole(_)
+        | Statement::CreateUser(_)
+        | Statement::CreateGroup(_)
+        | Statement::Grant(_)
+        | Statement::Revoke(_)
+        | Statement::Transaction(_)
+        | Statement::Copy(_)
+        | Statement::Vacuum(_)
+        | Statement::VariableSet(_)
+        | Statement::VariableShow(_)
+        | Statement::VariableReset(_)
+        | Statement::Call(_)
+        | Statement::Comment(_)
+        | Statement::AlterFunction(_)
+        | Statement::AlterProcedure(_)
+        | Statement::AlterSchema(_)
+        | Statement::AlterDatabase(_)
+        | Statement::AlterRole(_)
+        | Statement::AlterUser(_)
+        | Statement::AlterGroup(_)
+        | Statement::CreateAggregate(_)
+        | Statement::CreateOperator(_)
+        | Statement::AlterSequence(_)
+        | Statement::AlterExtension(_)
+        | Statement::AlterView(_)
+        | Statement::AlterTrigger(_)
+        | Statement::CreateCast(_)
+        | Statement::CreateConversion(_)
+        | Statement::CreateDomain(_)
+        | Statement::AlterDomain(_)
+        | Statement::CreateForeignTable(_)
+        | Statement::CreateForeignServer(_)
+        | Statement::CreateFdw(_)
+        | Statement::CreatePublication(_)
+        | Statement::CreateSubscription(_)
+        | Statement::CreateSynonym(_)
+        | Statement::CreateModel(_)
+        | Statement::CreateAm(_)
+        | Statement::CreateDirectory(_)
+        | Statement::CreateNode(_)
+        | Statement::CreateNodeGroup(_)
+        | Statement::CreateResourcePool(_)
+        | Statement::CreateWorkloadGroup(_)
+        | Statement::CreateAuditPolicy(_)
+        | Statement::CreateMaskingPolicy(_)
+        | Statement::CreateRlsPolicy(_)
+        | Statement::CreateDataSource(_)
+        | Statement::CreateEvent(_)
+        | Statement::CreateOpClass(_)
+        | Statement::CreateOpFamily(_)
+        | Statement::CreateLanguage(_)
+        | Statement::CreateWeakPasswordDictionaryWithValues(_)
+        | Statement::AlterNode(_)
+        | Statement::AlterNodeGroup(_)
+        | Statement::AlterResourcePool(_)
+        | Statement::AlterWorkloadGroup(_)
+        | Statement::AlterAuditPolicy(_)
+        | Statement::AlterMaskingPolicy(_)
+        | Statement::AlterRlsPolicy(_)
+        | Statement::AlterDataSource(_)
+        | Statement::AlterEvent(_)
+        | Statement::AlterOpFamily(_)
+        | Statement::AlterOperator(_)
+        | Statement::AlterMaterializedView(_)
+        | Statement::AlterGlobalConfig(_)
+        | Statement::RefreshMaterializedView(_)
+        | Statement::Reindex(_)
+        | Statement::Analyze(_)
+        | Statement::Cluster(_)
+        | Statement::AlterDefaultPrivileges(_)
+        | Statement::CreateUserMapping(_)
+        | Statement::AlterUserMapping(_)
+        | Statement::DropUserMapping(_)
+        | Statement::AlterCompositeType(_)
+        | Statement::AlterForeignTable(_)
+        | Statement::AlterForeignServer(_)
+        | Statement::AlterFdw(_)
+        | Statement::AlterPublication(_)
+        | Statement::AlterSubscription(_)
+        | Statement::AlterSynonym(_)
+        | Statement::AlterDatabaseLink(_)
+        | Statement::AlterDirectory(_)
+        | Statement::AlterLanguage(_)
+        | Statement::AlterLargeObject(_)
+        | Statement::AlterPackage(_)
+        | Statement::AlterSession(_)
+        | Statement::AlterSystemKillSession(_)
+        | Statement::CreateStream(_)
+        | Statement::CreatePolicyLabel(_)
+        | Statement::AlterPolicyLabel(_)
+        | Statement::DropPolicyLabel(_)
+        | Statement::GrantRole(_)
+        | Statement::RevokeRole(_)
+        | Statement::AlterCoordinator(_)
+        | Statement::AlterAppWorkloadGroupMapping(_)
+        | Statement::AlterTextSearchConfig(_)
+        | Statement::AlterTextSearchDict(_)
+        | Statement::CreateTextSearchConfig(_)
+        | Statement::CreateTextSearchDict(_)
+        | Statement::AlterTextSearchConfigFull(_)
+        | Statement::AlterTextSearchDictFull(_)
+        | Statement::CreateAppWorkloadGroupMapping(_)
+        | Statement::DropAppWorkloadGroupMapping(_)
+        | Statement::Rule(_)
+        | Statement::DropRule(_)
+        | Statement::CreatePackageBody(_)
+        | Statement::RemovePackage(_)
+        | Statement::Shutdown(_)
+        | Statement::Barrier(_)
+        | Statement::Purge(_)
+        | Statement::TimeCapsule(_)
+        | Statement::Snapshot(_)
+        | Statement::Shrink(_)
+        | Statement::Verify(_)
+        | Statement::CleanConn(_)
+        | Statement::Compile(_)
+        | Statement::SecLabel(_)
+        | Statement::CreateKey(_)
+        | Statement::CreateContQuery(_)
+        | Statement::ExpdpDatabase(_)
+        | Statement::ExpdpTable(_)
+        | Statement::ImpdpDatabase(_)
+        | Statement::ImpdpTable(_)
+        | Statement::ReassignOwned(_)
+        | Statement::Move(_)
+        | Statement::LockBuckets(_)
+        | Statement::MarkBuckets(_)
+        | Statement::SetSessionAuthorization(_)
+        | Statement::PredictBy(_) => StatementKind::Ddl,
+        Statement::Empty | Statement::Checkpoint | Statement::Abort => StatementKind::All,
+        _ => StatementKind::All,
+    }
+}
+
+/// Helper to construct a `SqlWarning`.
+pub fn make_warning(
+    level: WarningLevel,
+    rule_id: &str,
+    rule_name: &str,
+    message: String,
+    suggestion: Option<&str>,
+    location: SourceLocation,
+    gaussdb_ref: Option<&str>,
+    confidence: Confidence,
+) -> SqlWarning {
+    SqlWarning {
+        level,
+        rule_id: rule_id.to_string(),
+        rule_name: rule_name.to_string(),
+        message,
+        suggestion: suggestion.map(|s| s.to_string()),
+        location,
+        gaussdb_ref: gaussdb_ref.map(|s| s.to_string()),
+        confidence,
+    }
+}
+
+/// Recursively walk an expression tree, calling `f` on every `Expr` node.
+/// Stops if `f` returns `false`.
+pub fn walk_expr(expr: &crate::ast::Expr, f: &mut dyn FnMut(&crate::ast::Expr) -> bool) {
+    if !f(expr) {
+        return;
+    }
+    use crate::ast::Expr;
+    match expr {
+        Expr::BinaryOp { left, right, .. } => {
+            walk_expr(left, f);
+            walk_expr(right, f);
+        }
+        Expr::UnaryOp { expr, .. } => walk_expr(expr, f),
+        Expr::Like { expr, pattern, escape, .. } => {
+            walk_expr(expr, f);
+            walk_expr(pattern, f);
+            if let Some(e) = escape {
+                walk_expr(e, f);
+            }
+        }
+        Expr::FunctionCall { args, over, filter, within_group, .. } => {
+            for a in args {
+                walk_expr(a, f);
+            }
+            if let Some(o) = over {
+                for e in &o.partition_by {
+                    walk_expr(e, f);
+                }
+                for item in &o.order_by {
+                    walk_expr(&item.expr, f);
+                }
+            }
+            if let Some(fe) = filter {
+                walk_expr(fe, f);
+            }
+            for item in within_group {
+                walk_expr(&item.expr, f);
+            }
+        }
+        Expr::Case { operand, whens, else_expr } => {
+            if let Some(o) = operand {
+                walk_expr(o, f);
+            }
+            for w in whens {
+                walk_expr(&w.condition, f);
+                walk_expr(&w.result, f);
+            }
+            if let Some(e) = else_expr {
+                walk_expr(e, f);
+            }
+        }
+        Expr::Between { expr, low, high, .. } => {
+            walk_expr(expr, f);
+            walk_expr(low, f);
+            walk_expr(high, f);
+        }
+        Expr::InList { expr, list, .. } => {
+            walk_expr(expr, f);
+            for e in list {
+                walk_expr(e, f);
+            }
+        }
+        Expr::InSubquery { expr, .. } => {
+            walk_expr(expr, f);
+        }
+        Expr::Subquery(_) | Expr::Exists(_) => {}
+        Expr::ScalarSublink { expr, .. } => {
+            walk_expr(expr, f);
+        }
+        Expr::IsNull { expr, .. } => walk_expr(expr, f),
+        Expr::IsBoolean { expr, .. } => walk_expr(expr, f),
+        Expr::TypeCast { expr, .. } => walk_expr(expr, f),
+        Expr::Treat { expr, .. } => walk_expr(expr, f),
+        Expr::CollationFor { expr } => walk_expr(expr, f),
+        Expr::Array(exprs) => {
+            for e in exprs {
+                walk_expr(e, f);
+            }
+        }
+        Expr::Subscript { object, lower, upper, .. } => {
+            walk_expr(object, f);
+            if let Some(l) = lower {
+                walk_expr(l, f);
+            }
+            if let Some(u) = upper {
+                walk_expr(u, f);
+            }
+        }
+        Expr::FieldAccess { object, .. } => walk_expr(object, f),
+        Expr::Parenthesized(e) => walk_expr(e, f),
+        Expr::RowConstructor(exprs) => {
+            for e in exprs {
+                walk_expr(e, f);
+            }
+        }
+        Expr::Prior(e) => walk_expr(e, f),
+        Expr::SpecialFunction { args, .. } => {
+            for a in args {
+                walk_expr(a, f);
+            }
+        }
+        Expr::CurrentOf { .. }
+        | Expr::PredictBy { .. }
+        | Expr::SysDate
+        | Expr::SequenceValue { .. }
+        | Expr::CursorAttribute { .. }
+        | Expr::PlVariable(_)
+        | Expr::Literal(_)
+        | Expr::ColumnRef(_)
+        | Expr::QualifiedStar(_)
+        | Expr::Parameter(_)
+        | Expr::MyBatisParam(_)
+        | Expr::MyBatisRawExpr(_)
+        | Expr::Default => {}
+        Expr::XmlElement { .. } => {}
+        Expr::XmlConcat(exprs) => {
+            for e in exprs {
+                walk_expr(e, f);
+            }
+        }
+        Expr::XmlForest(items) => {
+            for item in items {
+                walk_expr(&item.expr, f);
+            }
+        }
+        Expr::XmlParse { expr, .. } => walk_expr(expr, f),
+        Expr::XmlPi { content, .. } => {
+            if let Some(c) = content {
+                walk_expr(c, f);
+            }
+        }
+        Expr::XmlRoot { expr, version, .. } => {
+            walk_expr(expr, f);
+            if let Some(v) = version {
+                walk_expr(v, f);
+            }
+        }
+        Expr::XmlSerialize { expr, .. } => walk_expr(expr, f),
+    }
+}
+
+/// Walk all expressions in a `SelectStatement`.
+pub fn walk_select_exprs(select: &SelectStatement, f: &mut dyn FnMut(&crate::ast::Expr) -> bool) {
+    use crate::ast::SelectTarget;
+    for target in &select.targets {
+        if let SelectTarget::Expr(e, _) = target {
+            walk_expr(e, f);
+        }
+    }
+    if let Some(ref e) = select.where_clause {
+        walk_expr(e, f);
+    }
+    if let Some(ref e) = select.having {
+        walk_expr(e, f);
+    }
+    for item in &select.order_by {
+        walk_expr(&item.expr, f);
+    }
+    for gb in &select.group_by {
+        if let crate::ast::GroupByItem::Expr(e) = gb {
+            walk_expr(e, f);
+        }
+    }
+}
+
+/// Get source location from a `StatementInfo`.
+pub fn stmt_location(info: &StatementInfo) -> SourceLocation {
+    SourceLocation { line: info.start_line, column: info.start_col, offset: 0 }
+}

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -125,6 +125,8 @@ pub struct LintConfig {
     pub non_equi_join_limit: usize,
     /// R002 -- GROUP BY column count limit (default 10).
     pub group_by_column_limit: usize,
+    /// C018 -- max INSERT VALUES rows per statement (default 100).
+    pub max_insert_values_rows: usize,
 }
 
 impl Default for LintConfig {
@@ -138,6 +140,7 @@ impl Default for LintConfig {
             sql_length_limit: 2000,
             non_equi_join_limit: 2,
             group_by_column_limit: 10,
+            max_insert_values_rows: 100,
         }
     }
 }
@@ -166,6 +169,7 @@ pub struct LintConfigFile {
     pub sql_length_limit: Option<usize>,
     pub non_equi_join_limit: Option<usize>,
     pub group_by_column_limit: Option<usize>,
+    pub max_insert_values_rows: Option<usize>,
 }
 
 #[cfg(feature = "lint-config")]
@@ -247,6 +251,9 @@ impl LintConfig {
         }
         if let Some(v) = file.group_by_column_limit {
             self.group_by_column_limit = v;
+        }
+        if let Some(v) = file.max_insert_values_rows {
+            self.max_insert_values_rows = v;
         }
     }
 }

--- a/src/linter/rules_caution.rs
+++ b/src/linter/rules_caution.rs
@@ -1,5 +1,5 @@
 use crate::ast::plpgsql::{PlBlock, PlDeclaration, PlStatement, RaiseLevel};
-use crate::ast::{Expr, LockClause, Statement, StatementInfo};
+use crate::ast::{Expr, InsertSource, LockClause, Statement, StatementInfo};
 use crate::linter::{
     loc_from_spanned, make_warning, stmt_location, walk_expr, Confidence, LintConfig, LintRuleEntry, SqlLinter,
     SqlWarning, StatementKind, WarningLevel,
@@ -105,6 +105,13 @@ pub fn register(linter: &mut SqlLinter) {
             level: WarningLevel::Caution,
             stmt_kind: StatementKind::PlBlock,
             check_fn: check_c017,
+        },
+        LintRuleEntry {
+            id: "C018",
+            name: "excessive-insert-values",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Insert,
+            check_fn: check_c018,
         },
     ];
     for rule in rules {
@@ -1091,4 +1098,39 @@ fn has_reraise(s: &PlStatement) -> bool {
         s,
         PlStatement::Raise(r) if r.level.is_none() || matches!(r.level, Some(RaiseLevel::Exception))
     )
+}
+
+// ── C018: Excessive INSERT VALUES rows ──
+
+fn check_c018(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Statement::Insert(insert) = &info.statement {
+            if let InsertSource::Values(values) = &insert.source {
+                let n = values.len();
+                if n > config.max_insert_values_rows {
+                    warnings.push(make_warning(
+                        WarningLevel::Caution,
+                        "C018",
+                        "excessive-insert-values",
+                        format!(
+                            "INSERT VALUES \u{5305}\u{542b} {n} \u{4e2a}\u{5143}\u{7ec4}\u{ff0c}\u{5927}\u{6279}\u{91cf}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{957f}\u{4e8b}\u{52a1}\u{3001}\u{9501}\u{7ade}\u{4e89}\u{548c}\u{56de}\u{6eda}\u{4ee3}\u{4ef7}\u{8fc7}\u{9ad8}\u{3002}\u{5efa}\u{8bae}\u{6bcf}\u{6279}\u{63d2}\u{5165} {}\u{2014}{}\u{884c}\u{ff0c}\u{6216}\u{4f7f}\u{7528} COPY",
+                            config.max_insert_values_rows / 5,
+                            config.max_insert_values_rows
+                        ),
+                        Some("\u{62c6}\u{5206}\u{4e3a}\u{66f4}\u{5c0f}\u{6279}\u{6b21}\u{63d2}\u{5165}\u{4ee5}\u{51cf}\u{5c11}\u{9501}\u{6301}\u{6709}\u{65f6}\u{95f4}"),
+                        loc,
+                        None,
+                        confidence,
+                    ));
+                }
+            }
+        }
+    }
 }

--- a/src/linter/rules_caution.rs
+++ b/src/linter/rules_caution.rs
@@ -1,0 +1,987 @@
+use crate::ast::plpgsql::{PlBlock, PlDeclaration, PlStatement, RaiseLevel};
+use crate::ast::{Expr, LockClause, Statement, StatementInfo};
+use crate::linter::{
+    loc_from_spanned, make_warning, stmt_location, walk_expr, Confidence, LintConfig, LintRuleEntry, SqlLinter,
+    SqlWarning, StatementKind, WarningLevel,
+};
+use crate::parser::hint_validator::KNOWN_HINTS;
+
+pub fn register(linter: &mut SqlLinter) {
+    let rules: Vec<LintRuleEntry> = vec![
+        LintRuleEntry {
+            id: "C001",
+            name: "hint-unknown",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_c001,
+        },
+        LintRuleEntry {
+            id: "C005",
+            name: "hint-contradictory",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_c005,
+        },
+        LintRuleEntry {
+            id: "C006",
+            name: "hint-table-not-in-from",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_c006,
+        },
+        LintRuleEntry {
+            id: "C007",
+            name: "update-without-where",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Update,
+            check_fn: check_c007,
+        },
+        LintRuleEntry {
+            id: "C008",
+            name: "delete-without-where",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Delete,
+            check_fn: check_c008,
+        },
+        LintRuleEntry {
+            id: "C009",
+            name: "insert-no-column-list",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Insert,
+            check_fn: check_c009,
+        },
+        LintRuleEntry {
+            id: "C010",
+            name: "unlogged-table",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Ddl,
+            check_fn: check_c010,
+        },
+        LintRuleEntry {
+            id: "C011",
+            name: "goto-statement",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_c011,
+        },
+        LintRuleEntry {
+            id: "C012",
+            name: "execute-concat-sql-injection",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_c012,
+        },
+        LintRuleEntry {
+            id: "C013",
+            name: "exception-swallow",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_c013,
+        },
+        LintRuleEntry {
+            id: "C014",
+            name: "pl-commit-rollback",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_c014,
+        },
+        LintRuleEntry {
+            id: "C015",
+            name: "select-for-update-blocking",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_c015,
+        },
+        LintRuleEntry {
+            id: "C016",
+            name: "autonomous-transaction",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_c016,
+        },
+    ];
+    for rule in rules {
+        linter.register(rule);
+    }
+}
+
+/// Extract hints from a statement (SELECT, INSERT, UPDATE, DELETE).
+fn extract_hints(stmt: &Statement) -> Vec<&String> {
+    match stmt {
+        Statement::Select(s) => s.hints.iter().collect(),
+        Statement::Insert(s) => s.hints.iter().collect(),
+        Statement::Update(s) => s.hints.iter().collect(),
+        Statement::Delete(s) => s.hints.iter().collect(),
+        _ => vec![],
+    }
+}
+
+// ── C001: Unknown hint ──
+
+fn check_c001(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        for hint in extract_hints(&info.statement) {
+            let parsed = parse_hint_names(hint);
+            for name in parsed {
+                let lower = name.to_lowercase();
+                let base = lower.strip_prefix("no_").or_else(|| lower.strip_prefix("no"));
+                let known = KNOWN_HINTS.contains(&lower.as_str()) || base.is_some_and(|b| KNOWN_HINTS.contains(&b));
+                if !known {
+                    warnings.push(make_warning(
+                        WarningLevel::Caution,
+                        "C001",
+                        "hint-unknown",
+                        format!("Hint '{name}' \u{4e0d}\u{5728} GaussDB \u{5df2}\u{77e5} Hint \u{5217}\u{8868}\u{4e2d}\u{ff0c}\u{5c06}\u{88ab}\u{9759}\u{9ed8}\u{5ffd}\u{7565}"),
+                        Some("\u{68c0}\u{67e5} Hint \u{62fc}\u{5199}\u{662f}\u{5426}\u{6b63}\u{786e}"),
+                        loc,
+                        Some("Hint \u{4f7f}\u{7528}\u{89c4}\u{8303}"),
+                        confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Parse a hint string (the content inside /*+ ... */) into individual hint names.
+fn parse_hint_names(hint: &str) -> Vec<&str> {
+    // Split by whitespace and parentheses, take the first token of each segment
+    let mut names = Vec::new();
+    for segment in hint.split_whitespace() {
+        // Remove parenthesized arguments: "hashjoin(t1)" → "hashjoin"
+        let name = segment.split('(').next().unwrap_or(segment);
+        if !name.is_empty() {
+            names.push(name);
+        }
+    }
+    names
+}
+
+// ── C005: Contradictory hints ──
+
+fn check_c005(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    let contradictory_pairs: &[(&str, &str)] = &[
+        ("tablescan", "indexscan"),
+        ("tablescan", "indexonlyscan"),
+        ("tablescan", "bitmapscan"),
+        ("indexscan", "indexonlyscan"),
+        ("nestloop", "hashjoin"),
+        ("nestloop", "mergejoin"),
+        ("hashjoin", "mergejoin"),
+        ("use_hash_agg", "use_sort_agg"),
+        ("expand_sublink", "no_expand_sublink"),
+        ("expand_subquery", "no_expand_subquery"),
+        ("gather", "redistribute"),
+    ];
+
+    for info in stmts {
+        let loc = stmt_location(info);
+        for hint in extract_hints(&info.statement) {
+            let resolved = resolve_hints(hint);
+            let mut seen = std::collections::HashSet::new();
+            for (name, _) in &resolved {
+                let lower = name.to_lowercase();
+                if seen.contains(&lower) {
+                    continue;
+                }
+                let has_pos = resolved.iter().any(|(n, neg)| n == &lower && !neg);
+                let has_neg = resolved.iter().any(|(n, neg)| n == &lower && *neg);
+                if has_pos && has_neg {
+                    warnings.push(make_warning(
+                        WarningLevel::Caution,
+                        "C005",
+                        "hint-contradictory",
+                        format!(
+                            "Hint \u{77db}\u{76fe}: '{lower}' \u{4e0e} 'no_{lower}' \u{540c}\u{65f6}\u{5b58}\u{5728}"
+                        ),
+                        Some("\u{79fb}\u{9664}\u{77db}\u{76fe}\u{7684} Hint"),
+                        loc,
+                        None,
+                        confidence,
+                    ));
+                    seen.insert(lower);
+                }
+            }
+
+            // Check mutually exclusive pairs
+            for (a, b) in contradictory_pairs {
+                let has_a = resolved.iter().any(|(n, _)| n == a);
+                let has_b = resolved.iter().any(|(n, _)| n == b);
+                if has_a && has_b {
+                    warnings.push(make_warning(
+                        WarningLevel::Caution,
+                        "C005",
+                        "hint-contradictory",
+                        format!("Hint \u{4e92}\u{65a5}: '{a}' \u{4e0e} '{b}' \u{4e0d}\u{5e94}\u{540c}\u{65f6}\u{5b58}\u{5728}"),
+                        Some("\u{53ea}\u{4fdd}\u{7559}\u{4e00}\u{4e2a}\u{626b}\u{63cf}\u{65b9}\u{5f0f}/\u{8fde}\u{63a5}\u{65b9}\u{5f0f}\u{7684} Hint"),
+                        loc,
+                        None,
+                        confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Parse a hint string into (name, is_negated) pairs.
+fn resolve_hints(hint: &str) -> Vec<(String, bool)> {
+    let names = parse_hint_names(hint);
+    names
+        .into_iter()
+        .map(|name| {
+            let lower = name.to_lowercase();
+            if let Some(base) = lower.strip_prefix("no_") {
+                if KNOWN_HINTS.contains(&base) {
+                    return (base.to_string(), true);
+                }
+            }
+            if lower.starts_with("no") && lower.len() > 2 {
+                let base = &lower[2..];
+                if KNOWN_HINTS.contains(&base) {
+                    return (base.to_string(), true);
+                }
+            }
+            (lower, false)
+        })
+        .collect()
+}
+
+// ── C006: Hint table not in FROM ──
+
+fn check_c006(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let from_tables = collect_from_table_names(&info.statement);
+        if from_tables.is_empty() {
+            continue;
+        }
+        for hint in extract_hints(&info.statement) {
+            let hint_tables = extract_hint_table_refs(hint);
+            for ht in hint_tables {
+                let lower = ht.to_lowercase();
+                if !from_tables.contains(&lower) {
+                    warnings.push(make_warning(
+                        WarningLevel::Caution,
+                        "C006",
+                        "hint-table-not-in-from",
+                        format!("Hint \u{5f15}\u{7528}\u{7684}\u{8868} '{ht}' \u{4e0d}\u{5728} FROM \u{5b50}\u{53e5}\u{4e2d}"),
+                        Some("\u{68c0}\u{67e5} Hint \u{4e2d}\u{7684}\u{8868}\u{540d}\u{662f}\u{5426}\u{4e0e} FROM \u{5b50}\u{53e5}\u{4e00}\u{81f4}"),
+                        loc,
+                        None,
+                        confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn collect_from_table_names(stmt: &Statement) -> Vec<String> {
+    use crate::ast::TableRef;
+    let mut tables = Vec::new();
+    let from: &[TableRef] = match stmt {
+        Statement::Select(s) => &s.from,
+        Statement::Update(s) => {
+            for t in &s.tables {
+                if let TableRef::Table { name, alias, .. } = t {
+                    tables.push(name.last().cloned().unwrap_or_default().to_lowercase());
+                    if let Some(a) = alias {
+                        tables.push(a.to_lowercase());
+                    }
+                }
+            }
+            &s.from
+        }
+        Statement::Delete(s) => {
+            for t in &s.tables {
+                if let TableRef::Table { name, alias, .. } = t {
+                    tables.push(name.last().cloned().unwrap_or_default().to_lowercase());
+                    if let Some(a) = alias {
+                        tables.push(a.to_lowercase());
+                    }
+                }
+            }
+            &s.using
+        }
+        _ => return tables,
+    };
+    collect_table_names_from(from, &mut tables);
+    tables
+}
+
+fn collect_table_names_from(from: &[crate::ast::TableRef], tables: &mut Vec<String>) {
+    use crate::ast::TableRef;
+    for t in from {
+        match t {
+            TableRef::Table { name, alias, .. } => {
+                tables.push(name.last().cloned().unwrap_or_default().to_lowercase());
+                if let Some(a) = alias {
+                    tables.push(a.to_lowercase());
+                }
+            }
+            TableRef::Join { left, right, .. } => {
+                collect_table_names_from(std::slice::from_ref(left), tables);
+                collect_table_names_from(std::slice::from_ref(right), tables);
+            }
+            TableRef::Subquery { alias, .. } => {
+                if let Some(a) = alias {
+                    tables.push(a.to_lowercase());
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Extract table name references from hints that take table arguments.
+fn extract_hint_table_refs(hint: &str) -> Vec<&str> {
+    let mut tables = Vec::new();
+    for segment in hint.split_whitespace() {
+        // "hashjoin(t1)" → extract "t1"
+        if let Some(start) = segment.find('(') {
+            if let Some(end) = segment.rfind(')') {
+                let args = &segment[start + 1..end];
+                for arg in args.split(',') {
+                    let trimmed = arg.trim();
+                    // Skip @queryblock prefixes like @sel$1
+                    let name = if trimmed.starts_with('@') {
+                        if let Some(space_pos) = trimmed.find(char::is_whitespace) {
+                            trimmed[space_pos..].trim()
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        trimmed
+                    };
+                    if !name.is_empty() {
+                        tables.push(name);
+                    }
+                }
+            }
+        }
+    }
+    tables
+}
+
+// ── C007: UPDATE without WHERE ──
+
+fn check_c007(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Update(s) = &info.statement {
+            if s.where_clause.is_none() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C007",
+                    "update-without-where",
+                    "UPDATE \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{53ef}\u{80fd}\u{5f71}\u{54cd}\u{5168}\u{8868}\u{6570}\u{636e}".into(),
+                    Some("\u{786e}\u{8ba4}\u{662f}\u{5426}\u{771f}\u{7684}\u{9700}\u{8981}\u{66f4}\u{65b0}\u{5168}\u{8868}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── C008: DELETE without WHERE ──
+
+fn check_c008(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Delete(s) = &info.statement {
+            if s.where_clause.is_none() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C008",
+                    "delete-without-where",
+                    "DELETE \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{5c06}\u{5220}\u{9664}\u{5168}\u{8868}\u{6570}\u{636e}".into(),
+                    Some("\u{786e}\u{8ba4}\u{662f}\u{5426}\u{5e94}\u{4f7f}\u{7528} TRUNCATE \u{6216}\u{6dfb}\u{52a0} WHERE \u{6761}\u{4ef6}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── C009: INSERT without column list ──
+
+fn check_c009(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Insert(s) = &info.statement {
+            if s.columns.is_empty() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C009",
+                    "insert-no-column-list",
+                    "INSERT \u{672a}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{ff0c}\u{4f9d}\u{8d56}\u{8868}\u{5b9a}\u{4e49}\u{987a}\u{5e8f}".into(),
+                    Some("\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{4ee5}\u{907f}\u{514d}\u{8868}\u{7ed3}\u{6784}\u{53d8}\u{5316}\u{5bfc}\u{81f4}\u{6570}\u{636e}\u{9519}\u{8bef}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── C010: Unlogged table ──
+
+fn check_c010(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        match &info.statement {
+            Statement::CreateTable(s) if s.unlogged => {
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C010",
+                    "unlogged-table",
+                    "UNLOGGED TABLE \u{5728}\u{6545}\u{969c}\u{6062}\u{590d}\u{65f6}\u{6570}\u{636e}\u{4f1a}\u{4e22}\u{5931}".into(),
+                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{8868}\u{66ff}\u{4ee3}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+            Statement::CreateTableAs(s) if s.unlogged => {
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C010",
+                    "unlogged-table",
+                    "UNLOGGED TABLE AS \u{5728}\u{6545}\u{969c}\u{6062}\u{590d}\u{65f6}\u{6570}\u{636e}\u{4f1a}\u{4e22}\u{5931}".into(),
+                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{8868}\u{66ff}\u{4ee3}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── C011: GOTO statement ──
+
+fn check_c011(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_block_for_goto(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C011",
+                "goto-statement",
+                "PL/pgSQL \u{4e2d}\u{4f7f}\u{7528}\u{4e86} GOTO \u{8bed}\u{53e5}\u{ff0c}\u{4e0d}\u{7b26}\u{5408}\u{7ed3}\u{6784}\u{5316}\u{7f16}\u{7a0b}\u{5efa}\u{8bae}".into(),
+                Some("\u{4f7f}\u{7528} IF/EXIT/CONTINUE \u{66ff}\u{4ee3} GOTO"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_block_for_goto(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_pl_stmts_for_goto(&block.body, found);
+    if let Some(ref exc) = block.exception_block {
+        for handler in &exc.handlers {
+            check_pl_stmts_for_goto(&handler.statements, found);
+        }
+    }
+}
+
+fn check_pl_stmts_for_goto(stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in stmts {
+        match s {
+            PlStatement::Goto { .. } => {
+                *found = true;
+                return;
+            }
+            PlStatement::Block(b) => {
+                check_pl_stmts_for_goto(&b.body, found);
+                if let Some(ref exc) = b.exception_block {
+                    for handler in &exc.handlers {
+                        check_pl_stmts_for_goto(&handler.statements, found);
+                    }
+                }
+            }
+            PlStatement::If(i) => {
+                check_pl_stmts_for_goto(&i.then_stmts, found);
+                for e in &i.elsifs {
+                    check_pl_stmts_for_goto(&e.stmts, found);
+                }
+                check_pl_stmts_for_goto(&i.else_stmts, found);
+            }
+            PlStatement::Case(c) => {
+                for w in &c.whens {
+                    check_pl_stmts_for_goto(&w.stmts, found);
+                }
+                check_pl_stmts_for_goto(&c.else_stmts, found);
+            }
+            PlStatement::Loop(l) => check_pl_stmts_for_goto(&l.body, found),
+            PlStatement::While(w) => check_pl_stmts_for_goto(&w.body, found),
+            PlStatement::For(f) => check_pl_stmts_for_goto(&f.body, found),
+            PlStatement::ForEach(f) => check_pl_stmts_for_goto(&f.body, found),
+            _ => {}
+        }
+        if *found {
+            return;
+        }
+    }
+}
+
+// ── C012: EXECUTE with string concatenation (SQL injection risk) ──
+
+fn check_c012(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_execute_concat(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C012",
+                "execute-concat-sql-injection",
+                "EXECUTE IMMEDIATE \u{4e2d}\u{4f7f}\u{7528}\u{5b57}\u{7b26}\u{4e32}\u{62fc}\u{63a5}\u{ff0c}\u{53ef}\u{80fd}\u{5b58}\u{5728} SQL \u{6ce8}\u{5165}\u{98ce}\u{9669}".into(),
+                Some("\u{4f7f}\u{7528} USING \u{53c2}\u{6570}\u{5316}\u{67e5}\u{8be2}\u{66ff}\u{4ee3}\u{5b57}\u{7b26}\u{4e32}\u{62fc}\u{63a5}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_execute_concat(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_pl_stmts_for_execute_concat(&block.body, found);
+}
+
+fn check_pl_stmts_for_execute_concat(stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in stmts {
+        match s {
+            PlStatement::Execute(e) => {
+                if has_string_concat(&e.string_expr) {
+                    *found = true;
+                    return;
+                }
+            }
+            PlStatement::Block(b) => {
+                check_pl_stmts_for_execute_concat(&b.body, found);
+            }
+            PlStatement::If(i) => {
+                check_pl_stmts_for_execute_concat(&i.then_stmts, found);
+                for e in &i.elsifs {
+                    check_pl_stmts_for_execute_concat(&e.stmts, found);
+                }
+                check_pl_stmts_for_execute_concat(&i.else_stmts, found);
+            }
+            PlStatement::Case(c) => {
+                for w in &c.whens {
+                    check_pl_stmts_for_execute_concat(&w.stmts, found);
+                }
+                check_pl_stmts_for_execute_concat(&c.else_stmts, found);
+            }
+            PlStatement::Loop(l) => check_pl_stmts_for_execute_concat(&l.body, found),
+            PlStatement::While(w) => check_pl_stmts_for_execute_concat(&w.body, found),
+            PlStatement::For(f) => check_pl_stmts_for_execute_concat(&f.body, found),
+            PlStatement::ForEach(f) => check_pl_stmts_for_execute_concat(&f.body, found),
+            _ => {}
+        }
+        if *found {
+            return;
+        }
+    }
+}
+
+fn has_string_concat(expr: &Expr) -> bool {
+    let mut found = false;
+    walk_expr(expr, &mut |e| {
+        if found {
+            return false;
+        }
+        if let Expr::BinaryOp { op, .. } = e {
+            if op == "||" {
+                found = true;
+                return false;
+            }
+        }
+        true
+    });
+    found
+}
+
+// ── C013: Exception handler swallows errors ──
+
+fn check_c013(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_exception_swallow(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C013",
+                "exception-swallow",
+                "WHEN OTHERS THEN \u{5f02}\u{5e38}\u{5904}\u{7406}\u{4e2d}\u{672a}\u{91cd}\u{65b0}\u{629b}\u{51fa}\u{5f02}\u{5e38}\u{ff0c}\u{53ef}\u{80fd}\u{9759}\u{9ed8}\u{541e}\u{9519}".into(),
+                Some("\u{5728} WHEN OTHERS \u{5904}\u{7406}\u{4e2d}\u{6dfb}\u{52a0} RAISE \u{91cd}\u{65b0}\u{629b}\u{51fa}\u{5f02}\u{5e38}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_exception_swallow(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_block_for_swallow(block, found);
+}
+
+fn check_block_for_swallow(block: &PlBlock, found: &mut bool) {
+    if *found {
+        return;
+    }
+    if let Some(ref exc) = block.exception_block {
+        for handler in &exc.handlers {
+            if handler.conditions.iter().any(|c| c.eq_ignore_ascii_case("others")) {
+                if !handler.statements.iter().any(has_raise) {
+                    *found = true;
+                    return;
+                }
+            }
+        }
+    }
+    // Recurse into nested blocks
+    check_pl_stmts_for_swallow(&block.body, found);
+}
+
+fn check_pl_stmts_for_swallow(stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in stmts {
+        match s {
+            PlStatement::Block(b) => check_block_for_swallow(b, found),
+            PlStatement::If(i) => {
+                check_pl_stmts_for_swallow(&i.then_stmts, found);
+                for e in &i.elsifs {
+                    check_pl_stmts_for_swallow(&e.stmts, found);
+                }
+                check_pl_stmts_for_swallow(&i.else_stmts, found);
+            }
+            PlStatement::Case(c) => {
+                for w in &c.whens {
+                    check_pl_stmts_for_swallow(&w.stmts, found);
+                }
+                check_pl_stmts_for_swallow(&c.else_stmts, found);
+            }
+            PlStatement::Loop(l) => check_pl_stmts_for_swallow(&l.body, found),
+            PlStatement::While(w) => check_pl_stmts_for_swallow(&w.body, found),
+            PlStatement::For(f) => check_pl_stmts_for_swallow(&f.body, found),
+            _ => {}
+        }
+        if *found {
+            return;
+        }
+    }
+}
+
+fn has_raise(s: &PlStatement) -> bool {
+    matches!(s, PlStatement::Raise(r) if r.level.as_ref().is_none_or(|l| !matches!(l, RaiseLevel::Debug | RaiseLevel::Log)))
+}
+
+// ── C014: PL block COMMIT/ROLLBACK ──
+
+fn check_c014(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_commit_rollback(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C014",
+                "pl-commit-rollback",
+                "PL/pgSQL \u{5757}\u{4e2d}\u{5305}\u{542b} COMMIT/ROLLBACK\u{ff0c}\u{53ef}\u{80fd}\u{590d}\u{6742}\u{5316}\u{4e8b}\u{52a1}\u{63a7}\u{5236}".into(),
+                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{5c06}\u{4e8b}\u{52a1}\u{63a7}\u{5236}\u{4ea4}\u{7ed9}\u{5916}\u{5c42}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_commit_rollback(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_pl_stmts_for_commit_rollback(&block.body, found);
+}
+
+fn check_pl_stmts_for_commit_rollback(pl_stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in pl_stmts {
+        match s {
+            PlStatement::Commit { .. } | PlStatement::Rollback { .. } => {
+                *found = true;
+                return;
+            }
+            PlStatement::Block(b) => {
+                check_pl_stmts_for_commit_rollback(&b.body, found);
+            }
+            PlStatement::If(i) => {
+                check_pl_stmts_for_commit_rollback(&i.then_stmts, found);
+                for e in &i.elsifs {
+                    check_pl_stmts_for_commit_rollback(&e.stmts, found);
+                }
+                check_pl_stmts_for_commit_rollback(&i.else_stmts, found);
+            }
+            PlStatement::Case(c) => {
+                for w in &c.whens {
+                    check_pl_stmts_for_commit_rollback(&w.stmts, found);
+                }
+                check_pl_stmts_for_commit_rollback(&c.else_stmts, found);
+            }
+            PlStatement::Loop(l) => check_pl_stmts_for_commit_rollback(&l.body, found),
+            PlStatement::While(w) => check_pl_stmts_for_commit_rollback(&w.body, found),
+            PlStatement::For(f) => check_pl_stmts_for_commit_rollback(&f.body, found),
+            _ => {}
+        }
+        if *found {
+            return;
+        }
+    }
+}
+
+// ── C015: SELECT FOR UPDATE blocking ──
+
+fn check_c015(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            if let Some(ref lock) = s.lock_clause {
+                let is_blocking = match lock {
+                    LockClause::Update { nowait: false, skip_locked: false, wait, .. }
+                    | LockClause::Share { nowait: false, skip_locked: false, wait, .. }
+                    | LockClause::NoKeyUpdate { nowait: false, skip_locked: false, wait, .. }
+                    | LockClause::KeyShare { nowait: false, skip_locked: false, wait, .. } => wait.is_none(),
+                    _ => false,
+                };
+                if is_blocking {
+                    let loc = loc_from_spanned(s, stmt_location(info));
+                    warnings.push(make_warning(
+                        WarningLevel::Caution,
+                        "C015",
+                        "select-for-update-blocking",
+                        "SELECT ... FOR UPDATE \u{672a}\u{4f7f}\u{7528} NOWAIT/SKIP LOCKED\u{ff0c}\u{53ef}\u{80fd}\u{957f}\u{65f6}\u{95f4}\u{963b}\u{585e}".into(),
+                        Some("\u{8003}\u{8651}\u{4f7f}\u{7528} NOWAIT \u{6216} SKIP LOCKED"),
+                        loc,
+                        None,
+                        confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// ── C016: Autonomous transaction pragma ──
+
+fn check_c016(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_autonomous(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C016",
+                "autonomous-transaction",
+                "PRAGMA AUTONOMOUS_TRANSACTION \u{4f1a}\u{521b}\u{5efa}\u{72ec}\u{7acb}\u{4e8b}\u{52a1}\u{ff0c}\u{6027}\u{80fd}\u{5f00}\u{9500}\u{8f83}\u{5927}".into(),
+                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{771f}\u{7684}\u{9700}\u{8981}\u{72ec}\u{7acb}\u{4e8b}\u{52a1}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_autonomous(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_pl_decls_for_autonomous(&block.declarations, found);
+    if !*found {
+        check_pl_stmts_for_autonomous(&block.body, found);
+    }
+}
+
+fn check_pl_decls_for_autonomous(decls: &[PlDeclaration], found: &mut bool) {
+    for d in decls {
+        if let PlDeclaration::Pragma { name, .. } = d {
+            if name.eq_ignore_ascii_case("AUTONOMOUS_TRANSACTION") {
+                *found = true;
+                return;
+            }
+        }
+    }
+}
+
+fn check_pl_stmts_for_autonomous(pl_stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in pl_stmts {
+        if let PlStatement::Block(b) = s {
+            check_pl_decls_for_autonomous(&b.declarations, found);
+            if !*found {
+                check_pl_stmts_for_autonomous(&b.body, found);
+            }
+        }
+        if *found {
+            return;
+        }
+    }
+}

--- a/src/linter/rules_caution.rs
+++ b/src/linter/rules_caution.rs
@@ -99,6 +99,13 @@ pub fn register(linter: &mut SqlLinter) {
             stmt_kind: StatementKind::PlBlock,
             check_fn: check_c016,
         },
+        LintRuleEntry {
+            id: "C017",
+            name: "raise-in-exception-clears-variables",
+            level: WarningLevel::Caution,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_c017,
+        },
     ];
     for rule in rules {
         linter.register(rule);
@@ -984,4 +991,104 @@ fn check_pl_stmts_for_autonomous(pl_stmts: &[PlStatement], found: &mut bool) {
             return;
         }
     }
+}
+
+// ── C017: RAISE in EXCEPTION clears variables ──
+
+fn check_c017(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_raise_in_exception(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C017",
+                "raise-in-exception-clears-variables",
+                "RAISE \u{5728} EXCEPTION \u{5757}\u{4e2d}\u{4f1a}\u{6e05}\u{7a7a}\u{6240}\u{6709}\u{5c40}\u{90e8}\u{53d8}\u{91cf}\u{503c}\u{ff08}\u{5305}\u{62ec} OUT \u{53c2}\u{6570}\u{ff09}\u{ff0c}\u{5bfc}\u{81f4}\u{8c03}\u{7528}\u{65b9}\u{65e0}\u{6cd5}\u{83b7}\u{53d6}\u{9519}\u{8bef}\u{4fe1}\u{606f}".into(),
+                Some("\u{4f7f}\u{7528} RAISE INFO \u{4f20}\u{9012}\u{5177}\u{4f53}\u{9519}\u{8bef}\u{4fe1}\u{606f}\u{ff0c}\u{6216}\u{5728} RAISE \u{524d}\u{5c06}\u{8f93}\u{51fa}\u{503c}\u{4fdd}\u{5b58}\u{5230}\u{4e34}\u{65f6}\u{8868}/\u{5168}\u{5c40}\u{53d8}\u{91cf}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_raise_in_exception(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_exception_block_for_reraise(block, found);
+}
+
+fn check_exception_block_for_reraise(block: &PlBlock, found: &mut bool) {
+    if *found {
+        return;
+    }
+    if let Some(ref exc) = block.exception_block {
+        for handler in &exc.handlers {
+            if handler.statements.iter().any(has_reraise) {
+                *found = true;
+                return;
+            }
+        }
+    }
+    // Recurse into nested blocks
+    check_pl_stmts_for_reraise(&block.body, found);
+}
+
+fn check_pl_stmts_for_reraise(stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in stmts {
+        match s {
+            PlStatement::Block(b) => check_exception_block_for_reraise(b, found),
+            PlStatement::If(i) => {
+                check_pl_stmts_for_reraise(&i.then_stmts, found);
+                for e in &i.elsifs {
+                    check_pl_stmts_for_reraise(&e.stmts, found);
+                }
+                check_pl_stmts_for_reraise(&i.else_stmts, found);
+            }
+            PlStatement::Case(c) => {
+                for w in &c.whens {
+                    check_pl_stmts_for_reraise(&w.stmts, found);
+                }
+                check_pl_stmts_for_reraise(&c.else_stmts, found);
+            }
+            PlStatement::Loop(l) => check_pl_stmts_for_reraise(&l.body, found),
+            PlStatement::While(w) => check_pl_stmts_for_reraise(&w.body, found),
+            PlStatement::For(f) => check_pl_stmts_for_reraise(&f.body, found),
+            PlStatement::ForEach(f) => check_pl_stmts_for_reraise(&f.body, found),
+            _ => {}
+        }
+        if *found {
+            return;
+        }
+    }
+}
+
+/// Returns true if the statement is a re-raise (bare RAISE or RAISE EXCEPTION).
+/// These propagate the exception and clear local variables in GaussDB.
+fn has_reraise(s: &PlStatement) -> bool {
+    matches!(
+        s,
+        PlStatement::Raise(r) if r.level.is_none() || matches!(r.level, Some(RaiseLevel::Exception))
+    )
 }

--- a/src/linter/rules_performance.rs
+++ b/src/linter/rules_performance.rs
@@ -1,0 +1,1159 @@
+use crate::ast::plpgsql::PlStatement;
+use crate::ast::{Expr, InsertSource, SelectTarget, SetOperation, Statement, StatementInfo, TableRef};
+use crate::linter::{
+    loc_from_spanned, make_warning, stmt_location, walk_expr, walk_select_exprs, Confidence, LintConfig, LintRuleEntry,
+    SqlLinter, SqlWarning, StatementKind, WarningLevel,
+};
+
+pub fn register(linter: &mut SqlLinter) {
+    let rules: Vec<LintRuleEntry> = vec![
+        LintRuleEntry {
+            id: "P001",
+            name: "union-without-all",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_p001,
+        },
+        LintRuleEntry {
+            id: "P002",
+            name: "not-in-subquery",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p002,
+        },
+        LintRuleEntry {
+            id: "P003",
+            name: "in-list-too-large",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p003,
+        },
+        LintRuleEntry {
+            id: "P004",
+            name: "or-to-union-all",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p004,
+        },
+        LintRuleEntry {
+            id: "P005",
+            name: "now-function-non-pushable",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p005,
+        },
+        LintRuleEntry {
+            id: "P006",
+            name: "count-star-large-table",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_p006,
+        },
+        LintRuleEntry {
+            id: "P007",
+            name: "too-many-non-equi-joins",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_p007,
+        },
+        LintRuleEntry {
+            id: "P008",
+            name: "group-by-without-hashagg",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_p008,
+        },
+        LintRuleEntry {
+            id: "P009",
+            name: "function-instead-of-case",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p009,
+        },
+        LintRuleEntry {
+            id: "P010",
+            name: "multi-column-update-subquery",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Update,
+            check_fn: check_p010,
+        },
+        LintRuleEntry {
+            id: "P011",
+            name: "correlated-subquery",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p011,
+        },
+        LintRuleEntry {
+            id: "P012",
+            name: "unnecessary-distinct",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_p012,
+        },
+        LintRuleEntry {
+            id: "P013",
+            name: "cartesian-product",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_p013,
+        },
+        LintRuleEntry {
+            id: "P014",
+            name: "deeply-nested-subquery",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p014,
+        },
+        LintRuleEntry {
+            id: "P015",
+            name: "range-equals-same-value",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_p015,
+        },
+        LintRuleEntry {
+            id: "P016",
+            name: "update-from-no-join-condition",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Update,
+            check_fn: check_p016,
+        },
+        LintRuleEntry {
+            id: "P017",
+            name: "merge-without-unique-index",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Merge,
+            check_fn: check_p017,
+        },
+        LintRuleEntry {
+            id: "P018",
+            name: "insert-select-no-columns",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Insert,
+            check_fn: check_p018,
+        },
+        LintRuleEntry {
+            id: "P019",
+            name: "multi-table-update",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::Update,
+            check_fn: check_p019,
+        },
+        LintRuleEntry {
+            id: "P020",
+            name: "insert-all-multi-table",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::All,
+            check_fn: check_p020,
+        },
+        LintRuleEntry {
+            id: "P021",
+            name: "row-by-row-insert-in-loop",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_p021,
+        },
+        LintRuleEntry {
+            id: "P022",
+            name: "explain-in-production",
+            level: WarningLevel::Performance,
+            stmt_kind: StatementKind::All,
+            check_fn: check_p022,
+        },
+    ];
+    for rule in rules {
+        linter.register(rule);
+    }
+}
+
+fn extract_where(stmt: &Statement) -> Option<&Expr> {
+    match stmt {
+        Statement::Select(s) => s.where_clause.as_ref(),
+        Statement::Update(s) => s.where_clause.as_ref(),
+        Statement::Delete(s) => s.where_clause.as_ref(),
+        _ => None,
+    }
+}
+
+// P001: UNION without ALL
+fn check_p001(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            check_select_union(s, loc, confidence, warnings);
+        }
+    }
+}
+
+fn check_select_union(
+    select: &crate::ast::SelectStatement,
+    loc: crate::token::SourceLocation,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    if let Some(ref set_op) = select.set_operation {
+        match set_op {
+            SetOperation::Union { all: false, .. } => {
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P001", "union-without-all",
+                    "UNION \u{672a}\u{4f7f}\u{7528} ALL\u{ff0c}\u{5b58}\u{5728}\u{4e0d}\u{5fc5}\u{8981}\u{7684}\u{53bb}\u{91cd}\u{6392}\u{5e8f}".into(),
+                    Some("\u{5982}\u{679c}\u{786e}\u{8ba4}\u{65e0}\u{91cd}\u{53e0}\u{ff0c}\u{6539}\u{7528} UNION ALL"), loc,
+                    None, confidence,
+                ));
+            }
+            _ => {}
+        }
+    }
+    if let Some(ref set_op) = select.set_operation {
+        match set_op {
+            SetOperation::Union { right, .. } => {
+                check_select_union(right, loc, confidence, warnings);
+            }
+            SetOperation::Intersect { right, .. } => {
+                check_select_union(right, loc, confidence, warnings);
+            }
+            SetOperation::Except { right, .. } => {
+                check_select_union(right, loc, confidence, warnings);
+            }
+        }
+    }
+    if let Some(ref w) = select.with {
+        for cte in &w.ctes {
+            check_select_union(&cte.query, loc, confidence, warnings);
+        }
+    }
+}
+
+// P002: NOT IN (subquery) -- use NOT EXISTS instead
+fn check_p002(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where(&info.statement) {
+            walk_expr(where_clause, &mut |e| match e {
+                Expr::InSubquery { negated: true, .. } => {
+                    warnings.push(make_warning(
+                            WarningLevel::Performance, "P002", "not-in-subquery",
+                            "NOT IN (\u{5b50}\u{67e5}\u{8be2}) \u{6027}\u{80fd}\u{8f83}\u{5dee}\u{ff0c}\u{5e76}\u{4e14} NULL \u{503c}\u{4f1a}\u{5bfc}\u{81f4}\u{7ed3}\u{679c}\u{4e0d}\u{7b26}\u{9884}\u{671f}".into(),
+                            Some("\u{6539}\u{4e3a} NOT EXISTS"), loc,
+                            None, confidence,
+                        ));
+                    false
+                }
+                Expr::ScalarSublink { op, sublink_type, .. } => {
+                    let is_not_in = op == "<>" || op == "!=" || op == "NOT IN";
+                    if is_not_in && matches!(sublink_type, crate::ast::ScalarSublinkType::All) {
+                        warnings.push(make_warning(
+                                WarningLevel::Performance, "P002", "not-in-subquery",
+                                "\u{6807}\u{91cf}\u{5b50}\u{94fe}\u{63a5} NOT IN/<> ALL \u{6a21}\u{5f0f}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}".into(),
+                                Some("\u{6539}\u{4e3a} NOT EXISTS"), loc,
+                                None, confidence,
+                            ));
+                    }
+                    true
+                }
+                Expr::InList { negated: true, list, .. } if list.len() > 10 => {
+                    warnings.push(make_warning(
+                            WarningLevel::Performance, "P002", "not-in-subquery",
+                            format!("NOT IN \u{5217}\u{8868}\u{542b} {} \u{4e2a}\u{503c}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}", list.len()),
+                            Some("\u{6539}\u{4e3a} NOT EXISTS \u{6216} LEFT JOIN ... WHERE ... IS NULL"), loc,
+                            None, confidence,
+                        ));
+                    true
+                }
+                _ => true,
+            });
+        }
+    }
+}
+
+// P003: IN list too large
+fn check_p003(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where(&info.statement) {
+            walk_expr(where_clause, &mut |e| {
+                if let Expr::InList { list, .. } = e {
+                    if list.len() > config.in_list_threshold {
+                        warnings.push(make_warning(
+                            WarningLevel::Performance, "P003", "in-list-too-large",
+                            format!("IN \u{5217}\u{8868}\u{542b} {} \u{4e2a}\u{503c}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{5bfc}\u{81f4}\u{89e3}\u{6790}\u{7f13}\u{6162}", list.len(), config.in_list_threshold),
+                            Some("\u{6539}\u{7528} INNER JOIN \u{6216}\u{4e34}\u{65f6}\u{8868}"), loc,
+                            None, confidence,
+                        ));
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+
+// P004: OR as top-level WHERE condition
+fn check_p004(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where(&info.statement) {
+            if let Expr::BinaryOp { op, .. } = where_clause {
+                if op.eq_ignore_ascii_case("OR") {
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "P004", "or-to-union-all",
+                        "WHERE \u{9876}\u{5c42}\u{4e3a} OR \u{6761}\u{4ef6}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{4f18}\u{5316}\u{5668}\u{653e}\u{5f03}\u{7d22}\u{5f15}".into(),
+                        Some("\u{8003}\u{8651}\u{5c06} OR \u{6539}\u{5199}\u{4e3a} UNION ALL"), loc,
+                        None, confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// P005: now() function -- non-pushable in distributed queries
+fn check_p005(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut check_fn = |e: &Expr| {
+            if let Expr::FunctionCall { name, .. } = e {
+                let fn_name = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                if fn_name == "now" || fn_name == "current_timestamp" || fn_name == "sysdate" {
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "P005", "now-function-non-pushable",
+                        format!("\u{51fd}\u{6570} {fn_name}() \u{4e0d}\u{53ef}\u{4e0b}\u{63a8}\u{ff0c}\u{5c06}\u{5bfc}\u{81f4}\u{5206}\u{5e03}\u{5f0f}\u{67e5}\u{8be2}\u{6027}\u{80fd}\u{4e0b}\u{964d}"),
+                        Some("\u{7528}\u{65f6}\u{95f4}\u{5b8f}\u{6216}\u{53c2}\u{6570}\u{5316}\u{67e5}\u{8be2}\u{66ff}\u{4ee3}"), loc,
+                        Some("SQL \u{67e5}\u{8be2}\u{6700}\u{4f73}\u{5b9e}\u{8df5}"), confidence,
+                    ));
+                }
+            }
+        };
+        match &info.statement {
+            Statement::Select(s) => walk_select_exprs(s, &mut |e| {
+                check_fn(e);
+                true
+            }),
+            Statement::Update(s) => {
+                for a in &s.assignments {
+                    walk_expr(&a.value, &mut |e| {
+                        check_fn(e);
+                        true
+                    });
+                }
+                if let Some(ref w) = s.where_clause {
+                    walk_expr(w, &mut |e| {
+                        check_fn(e);
+                        true
+                    });
+                }
+            }
+            Statement::Delete(s) => {
+                if let Some(ref w) = s.where_clause {
+                    walk_expr(w, &mut |e| {
+                        check_fn(e);
+                        true
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// P006: COUNT(*) on large table
+fn check_p006(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            walk_select_exprs(s, &mut |e| {
+                if let Expr::FunctionCall { name, args, .. } = e {
+                    let fn_name = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                    if fn_name == "count" {
+                        let is_star = args.iter().any(|a| {
+                            matches!(a, Expr::ColumnRef(n) if n.len() == 1 && n[0] == "*")
+                                || matches!(a, Expr::QualifiedStar(_))
+                        });
+                        if is_star || args.is_empty() {
+                            warnings.push(make_warning(
+                                WarningLevel::Performance, "P006", "count-star-large-table",
+                                "COUNT(*) \u{5728}\u{5927}\u{8868}\u{4e0a}\u{6027}\u{80fd}\u{8f83}\u{5dee}".into(),
+                                Some("\u{8003}\u{8651}\u{4f7f}\u{7528} pg_class.reltuples \u{6216}\u{8fd1}\u{4f3c}\u{7edf}\u{8ba1}\u{4fe1}\u{606f}"), loc,
+                                None, confidence,
+                            ));
+                        }
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+
+// P007: Too many non-equi joins
+fn check_p007(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            let mut count = 0usize;
+            count_non_equi_joins_in_from(&s.from, &mut count);
+            if count > config.non_equi_join_limit {
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P007", "too-many-non-equi-joins",
+                    format!("\u{975e}\u{7b49}\u{503c} JOIN \u{6761}\u{4ef6} {count} \u{4e2a}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}", config.non_equi_join_limit),
+                    Some("\u{4f18}\u{5148}\u{4f7f}\u{7528}\u{7b49}\u{503c}\u{67e5}\u{8be2}"), loc,
+                    None, confidence,
+                ));
+            }
+        }
+    }
+}
+
+fn count_non_equi_joins_in_from(from: &[TableRef], count: &mut usize) {
+    for t in from {
+        if let TableRef::Join { condition, .. } = t {
+            if let Some(cond) = condition {
+                count_non_equi_in_expr(cond, count);
+            }
+        }
+    }
+}
+
+fn count_non_equi_in_expr(expr: &Expr, count: &mut usize) {
+    if let Expr::BinaryOp { op, left, right, .. } = expr {
+        let is_equi = op == "=" || op.eq_ignore_ascii_case("is") || op.eq_ignore_ascii_case("is not");
+        if !is_equi {
+            *count += 1;
+        }
+        count_non_equi_in_expr(left, count);
+        count_non_equi_in_expr(right, count);
+    }
+}
+
+// P008: GROUP BY without hash_agg hint
+fn check_p008(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            if !s.group_by.is_empty() {
+                let has_hashagg = s
+                    .hints
+                    .iter()
+                    .any(|h| h.to_lowercase().contains("hashagg") || h.to_lowercase().contains("use_hash_agg"));
+                if !has_hashagg {
+                    let loc = loc_from_spanned(s, stmt_location(info));
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "P008", "group-by-without-hashagg",
+                        "GROUP BY \u{64cd}\u{4f5c}\u{672a}\u{4f7f}\u{7528} hash_agg \u{63d0}\u{793a}\u{ff0c}\u{53ef}\u{80fd}\u{9700}\u{8981}\u{8c03}\u{5927} work_mem".into(),
+                        Some("\u{8003}\u{8651}\u{6dfb}\u{52a0} /*+ hash_agg */ \u{63d0}\u{793a}\u{6216}\u{8c03}\u{5927} work_mem"), loc,
+                        None, confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// P010: Multi-column UPDATE from subquery
+fn check_p010(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Update(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            for assignment in &s.assignments {
+                if assignment.columns.len() > 1 {
+                    if matches!(&assignment.value, Expr::Subquery(_)) {
+                        warnings.push(make_warning(
+                            WarningLevel::Performance,
+                            "P010",
+                            "multi-column-update-subquery",
+                            format!(
+                                "UPDATE SET ({}\u{5217}) = (SELECT ...) \u{6548}\u{7387}\u{8f83}\u{4f4e}",
+                                assignment.columns.len()
+                            ),
+                            Some("\u{6539}\u{7528} UPDATE ... FROM ... WHERE ... \u{7684} JOIN \u{98ce}\u{683c}"),
+                            loc,
+                            None,
+                            confidence,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+// P011: Correlated subquery (basic AST-only detection)
+fn check_p011(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let outer_tables = collect_from_tables(&info.statement);
+        if outer_tables.is_empty() {
+            continue;
+        }
+        if let Some(where_clause) = extract_where(&info.statement) {
+            let mut found = false;
+            walk_expr(where_clause, &mut |e| {
+                if found {
+                    return false;
+                }
+                match e {
+                    Expr::InSubquery { subquery, .. } | Expr::Exists(subquery) | Expr::Subquery(subquery) => {
+                        if has_correlated_ref(&subquery.where_clause, &outer_tables) {
+                            found = true;
+                            return false;
+                        }
+                    }
+                    Expr::ScalarSublink { subquery, .. } => {
+                        if has_correlated_ref(&subquery.where_clause, &outer_tables) {
+                            found = true;
+                            return false;
+                        }
+                    }
+                    _ => {}
+                }
+                true
+            });
+            if found {
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P011", "correlated-subquery",
+                    "\u{5173}\u{8054}\u{5b50}\u{67e5}\u{8be2}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6bcf}\u{884c}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
+                    Some("\u{6539}\u{5199}\u{4e3a}\u{7b49}\u{503c} JOIN"), loc,
+                    None, confidence,
+                ));
+            }
+        }
+    }
+}
+
+fn collect_from_tables(stmt: &Statement) -> Vec<String> {
+    let mut tables = Vec::new();
+    match stmt {
+        Statement::Select(s) => collect_table_names(&s.from, &mut tables),
+        Statement::Update(s) => {
+            collect_table_names(&s.tables, &mut tables);
+            collect_table_names(&s.from, &mut tables);
+        }
+        Statement::Delete(s) => {
+            collect_table_names(&s.tables, &mut tables);
+        }
+        _ => {}
+    }
+    tables
+}
+
+fn collect_table_names(from: &[TableRef], tables: &mut Vec<String>) {
+    for t in from {
+        match t {
+            TableRef::Table { name, alias, .. } => {
+                let tbl_name = name.last().cloned().unwrap_or_default();
+                tables.push(tbl_name.to_lowercase());
+                if let Some(a) = alias {
+                    tables.push(a.to_lowercase());
+                }
+            }
+            TableRef::Join { left, right, .. } => {
+                collect_table_names(std::slice::from_ref(left), tables);
+                collect_table_names(std::slice::from_ref(right), tables);
+            }
+            TableRef::Subquery { alias, .. } => {
+                if let Some(a) = alias {
+                    tables.push(a.to_lowercase());
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn has_correlated_ref(expr: &Option<Expr>, outer_tables: &[String]) -> bool {
+    let Some(expr) = expr else { return false };
+    let mut found = false;
+    walk_expr(expr, &mut |e| {
+        if found {
+            return false;
+        }
+        if let Expr::ColumnRef(name) = e {
+            if name.len() >= 2 {
+                let table_part = &name[0];
+                if outer_tables.contains(&table_part.to_lowercase()) {
+                    found = true;
+                    return false;
+                }
+            }
+        }
+        true
+    });
+    found
+}
+
+// P012: Unnecessary DISTINCT (basic -- warns on all DISTINCT)
+fn check_p012(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            if s.distinct {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P012", "unnecessary-distinct",
+                    "DISTINCT \u{5b58}\u{5728}\u{ff0c}\u{9700}\u{7ed3}\u{5408}\u{552f}\u{4e00}\u{952e}\u{5224}\u{65ad}\u{662f}\u{5426}\u{5fc5}\u{8981}\u{ff08}\u{9700} schema \u{4fe1}\u{606f}\u{8fdb}\u{4e00}\u{6b65}\u{786e}\u{8ba4}\u{ff09}".into(),
+                    Some("\u{68c0}\u{67e5}\u{53bb}\u{91cd}\u{5fc5}\u{8981}\u{6027}\u{ff0c}\u{5982}\u{679c}\u{5df2}\u{542b}\u{552f}\u{4e00}\u{5217}\u{5219}\u{53ef}\u{79fb}\u{9664}"), loc,
+                    None, confidence,
+                ));
+            }
+        }
+    }
+}
+
+// P013: Cartesian product (CROSS JOIN or missing join condition)
+fn check_p013(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            check_cartesian_in_from(&s.from, loc, confidence, warnings);
+        }
+    }
+}
+
+fn check_cartesian_in_from(
+    from: &[TableRef],
+    loc: crate::token::SourceLocation,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for t in from {
+        if let TableRef::Join { condition: None, natural: false, using_columns, join_type, .. } = t {
+            if using_columns.is_empty() {
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P013", "cartesian-product",
+                    match join_type {
+                        crate::ast::JoinType::Cross => "CROSS JOIN \u{4ea7}\u{751f}\u{7b1b}\u{5361}\u{5c14}\u{79ef}".into(),
+                        _ => "JOIN \u{7f3a}\u{5c11}\u{8fde}\u{63a5}\u{6761}\u{4ef6}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{7b1b}\u{5361}\u{5c14}\u{79ef}".into(),
+                    },
+                    Some("\u{8865}\u{5145} JOIN \u{6761}\u{4ef6}\u{6216}\u{786e}\u{8ba4}\u{4e3a} CROSS JOIN"), loc,
+                    None, confidence,
+                ));
+            }
+        }
+        match t {
+            TableRef::Join { left, right, .. } => {
+                check_cartesian_in_from(std::slice::from_ref(left), loc, confidence, warnings);
+                check_cartesian_in_from(std::slice::from_ref(right), loc, confidence, warnings);
+            }
+            TableRef::Subquery { query, .. } => {
+                check_cartesian_in_from(&query.from, loc, confidence, warnings);
+            }
+            _ => {}
+        }
+    }
+}
+
+// P014: Deeply nested subquery
+fn check_p014(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let max_depth = match &info.statement {
+            Statement::Select(s) => subquery_depth_select(s),
+            Statement::Update(u) => {
+                let mut d = 0;
+                for a in &u.assignments {
+                    d = d.max(subquery_depth_expr(&a.value));
+                }
+                if let Some(ref w) = u.where_clause {
+                    d = d.max(subquery_depth_expr(w));
+                }
+                d
+            }
+            Statement::Delete(de) => {
+                if let Some(ref w) = de.where_clause {
+                    subquery_depth_expr(w)
+                } else {
+                    0
+                }
+            }
+            _ => 0,
+        };
+        if max_depth >= config.subquery_depth_limit {
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P014", "deeply-nested-subquery",
+                format!("\u{5b50}\u{67e5}\u{8be2}\u{5d4c}\u{5957}\u{6df1}\u{5ea6} {max_depth} \u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{6027}\u{80fd}\u{53ef}\u{80fd}\u{8f83}\u{5dee}", config.subquery_depth_limit),
+                Some("\u{62c6}\u{5206}\u{4e3a}\u{4e34}\u{65f6}\u{8868}\u{6216} CTE"), loc,
+                None, confidence,
+            ));
+        }
+    }
+}
+
+fn subquery_depth_select(s: &crate::ast::SelectStatement) -> usize {
+    let mut max_d = 0;
+    for t in &s.targets {
+        if let SelectTarget::Expr(e, _) = t {
+            max_d = max_d.max(subquery_depth_expr(e));
+        }
+    }
+    if let Some(ref w) = s.where_clause {
+        max_d = max_d.max(subquery_depth_expr(w));
+    }
+    if let Some(ref h) = s.having {
+        max_d = max_d.max(subquery_depth_expr(h));
+    }
+    if let Some(ref so) = s.set_operation {
+        let inner = match so {
+            SetOperation::Union { right, .. }
+            | SetOperation::Intersect { right, .. }
+            | SetOperation::Except { right, .. } => subquery_depth_select(right),
+        };
+        max_d = max_d.max(inner);
+    }
+    if let Some(ref w) = s.with {
+        for cte in &w.ctes {
+            max_d = max_d.max(subquery_depth_select(&cte.query));
+        }
+    }
+    for t in &s.from {
+        max_d = max_d.max(subquery_depth_from(t));
+    }
+    max_d
+}
+
+fn subquery_depth_from(t: &TableRef) -> usize {
+    match t {
+        TableRef::Subquery { query, .. } => 1 + subquery_depth_select(query),
+        TableRef::Join { left, right, condition, .. } => {
+            let l = subquery_depth_from(left);
+            let r = subquery_depth_from(right);
+            let c = condition.as_ref().map_or(0, subquery_depth_expr);
+            l.max(r).max(c)
+        }
+        _ => 0,
+    }
+}
+
+fn subquery_depth_expr(expr: &Expr) -> usize {
+    match expr {
+        Expr::Subquery(s) | Expr::Exists(s) => 1 + subquery_depth_select(s),
+        Expr::InSubquery { subquery, .. } => 1 + subquery_depth_select(subquery),
+        Expr::ScalarSublink { subquery, .. } => 1 + subquery_depth_select(subquery),
+        Expr::BinaryOp { left, right, .. } => subquery_depth_expr(left).max(subquery_depth_expr(right)),
+        Expr::UnaryOp { expr, .. } => subquery_depth_expr(expr),
+        Expr::FunctionCall { args, over, filter, within_group, .. } => {
+            let mut d = 0;
+            for a in args {
+                d = d.max(subquery_depth_expr(a));
+            }
+            if let Some(o) = over {
+                for e in &o.partition_by {
+                    d = d.max(subquery_depth_expr(e));
+                }
+            }
+            if let Some(f) = filter {
+                d = d.max(subquery_depth_expr(f));
+            }
+            for item in within_group {
+                d = d.max(subquery_depth_expr(&item.expr));
+            }
+            d
+        }
+        Expr::Case { operand, whens, else_expr } => {
+            let mut d = 0;
+            if let Some(o) = operand {
+                d = d.max(subquery_depth_expr(o));
+            }
+            for w in whens {
+                d = d.max(subquery_depth_expr(&w.condition)).max(subquery_depth_expr(&w.result));
+            }
+            if let Some(e) = else_expr {
+                d = d.max(subquery_depth_expr(e));
+            }
+            d
+        }
+        Expr::Parenthesized(e) => subquery_depth_expr(e),
+        _ => 0,
+    }
+}
+
+// P015: Range equals same value (col >= x AND col <= x where x == x)
+fn check_p015(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where(&info.statement) {
+            walk_expr(where_clause, &mut |e| {
+                if let Expr::Between { low, high, negated: false, .. } = e {
+                    if literals_equal(low, high) {
+                        warnings.push(make_warning(
+                            WarningLevel::Performance, "P015", "range-equals-same-value",
+                            "BETWEEN \u{4e0a}\u{4e0b}\u{754c}\u{76f8}\u{540c}\u{ff0c}\u{5e94}\u{7b80}\u{5316}\u{4e3a} \u{7b49}\u{4e8e}\u{6761}\u{4ef6}".into(),
+                            Some("\u{7b80}\u{5316}\u{4e3a} ="), loc,
+                            None, confidence,
+                        ));
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+
+fn literals_equal(a: &Expr, b: &Expr) -> bool {
+    match (a, b) {
+        (Expr::Literal(l), Expr::Literal(r)) => l == r,
+        _ => false,
+    }
+}
+
+// P016: UPDATE FROM without join condition in WHERE
+fn check_p016(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Update(s) = &info.statement {
+            if !s.from.is_empty() && s.where_clause.is_none() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P016", "update-from-no-join-condition",
+                    "UPDATE FROM \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{7b1b}\u{5361}\u{5c14}\u{79ef}\u{66f4}\u{65b0}".into(),
+                    Some("WHERE \u{4e2d}\u{5173}\u{8054} FROM \u{8868}"), loc,
+                    None, confidence,
+                ));
+            }
+        }
+    }
+}
+
+// P017: MERGE without unique index (basic -- always warns)
+fn check_p017(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Merge(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P017", "merge-without-unique-index",
+                "MERGE \u{8bed}\u{53e5} ON \u{6761}\u{4ef6}\u{9700}\u{8981}\u{552f}\u{4e00}\u{7d22}\u{5f15}\u{4fdd}\u{8bc1}\u{786e}\u{5b9a}\u{6027}\u{ff08}\u{9700} schema \u{4fe1}\u{606f}\u{786e}\u{8ba4}\u{ff09}".into(),
+                Some("\u{786e}\u{4fdd} ON \u{6761}\u{4ef6}\u{5217}\u{6709}\u{552f}\u{4e00}\u{7d22}\u{5f15}"), loc,
+                None, confidence,
+            ));
+        }
+    }
+}
+
+// P018: INSERT SELECT without column list
+fn check_p018(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Insert(s) = &info.statement {
+            if s.columns.is_empty() {
+                if matches!(&s.source, InsertSource::Select(_)) {
+                    let loc = loc_from_spanned(s, stmt_location(info));
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "P018", "insert-select-no-columns",
+                        "INSERT INTO ... SELECT \u{672a}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{ff0c}\u{4f9d}\u{8d56}\u{5217}\u{987a}\u{5e8f}".into(),
+                        Some("\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}"), loc,
+                        None, confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// P019: Multi-table UPDATE
+fn check_p019(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Update(s) = &info.statement {
+            if s.tables.len() > 1 {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P019", "multi-table-update",
+                    format!("\u{591a}\u{8868} UPDATE \u{5305}\u{542b} {} \u{4e2a}\u{8868}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{975e}\u{9884}\u{671f}\u{7ed3}\u{679c}", s.tables.len()),
+                    Some("\u{62c6}\u{5206}\u{4e3a}\u{591a}\u{6761}\u{5355}\u{8868} UPDATE"), loc,
+                    None, confidence,
+                ));
+            }
+        }
+    }
+}
+
+// P020: INSERT ALL / INSERT FIRST multi-table
+fn check_p020(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        match &info.statement {
+            Statement::InsertAll(s) => {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P020", "insert-all-multi-table",
+                    "INSERT ALL \u{591a}\u{8868}\u{63d2}\u{5165}\u{ff0c}\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT".into(),
+                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT \u{66ff}\u{4ee3}"), loc,
+                    None, confidence,
+                ));
+            }
+            Statement::InsertFirst(s) => {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P020", "insert-all-multi-table",
+                    "INSERT FIRST \u{591a}\u{8868}\u{63d2}\u{5165}\u{ff0c}\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT".into(),
+                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT \u{66ff}\u{4ee3}"), loc,
+                    None, confidence,
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+// P022: EXPLAIN in production code
+fn check_p022(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Explain(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P022", "explain-in-production",
+                "EXPLAIN \u{8bed}\u{53e5}\u{4e0d}\u{5e94}\u{51fa}\u{73b0}\u{5728}\u{751f}\u{4ea7}\u{4ee3}\u{7801}\u{4e2d}".into(),
+                Some("\u{79fb}\u{9664} EXPLAIN \u{6216}\u{4ec5}\u{7528}\u{4e8e}\u{8c03}\u{8bd5}"), loc,
+                None, confidence,
+            ));
+        }
+    }
+}
+
+// ── P009: Function that should be CASE ──
+
+const CASE_REPLACEABLE_FUNCTIONS: &[&str] = &["nvl", "nvl2", "decode", "iif"];
+
+fn check_p009(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where(&info.statement) {
+            walk_expr(where_clause, &mut |e| {
+                if let Expr::FunctionCall { name, .. } = e {
+                    if let Some(fn_name) = name.last() {
+                        let lower = fn_name.to_lowercase();
+                        if CASE_REPLACEABLE_FUNCTIONS.contains(&lower.as_str()) {
+                            warnings.push(make_warning(
+                                WarningLevel::Performance,
+                                "P009",
+                                "function-instead-of-case",
+                                format!("\u{51fd}\u{6570} {fn_name}() \u{53ef}\u{4ee5}\u{7528} CASE \u{8868}\u{8fbe}\u{5f0f}\u{66ff}\u{4ee3}\u{ff0c}\u{53ef}\u{80fd}\u{66f4}\u{9ad8}\u{6548}"),
+                                Some("\u{4f7f}\u{7528} CASE WHEN ... THEN ... ELSE ... END \u{66ff}\u{4ee3}"),
+                                loc,
+                                None,
+                                confidence,
+                            ));
+                            return false;
+                        }
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+
+// ── P021: Row-by-row INSERT in PL/pgSQL loop ──
+
+fn check_p021(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_loop_insert(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Performance,
+                "P021",
+                "row-by-row-insert-in-loop",
+                "\u{5faa}\u{73af}\u{4f53}\u{5185}\u{5305}\u{542b} INSERT\u{ff0c}\u{5e94}\u{4f7f}\u{7528} FORALL \u{6279}\u{91cf}\u{64cd}\u{4f5c}\u{66ff}\u{4ee3}".into(),
+                Some("\u{4f7f}\u{7528} FORALL \u{6279}\u{91cf}\u{63d2}\u{5165}\u{6216} INSERT ... SELECT \u{66ff}\u{4ee3}\u{5faa}\u{73af} INSERT"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_loop_insert(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_pl_stmts_for_loop_insert(&block.body, found, false);
+}
+
+fn check_pl_stmts_for_loop_insert(pl_stmts: &[crate::ast::plpgsql::PlStatement], found: &mut bool, inside_loop: bool) {
+    if *found {
+        return;
+    }
+    for s in pl_stmts {
+        match s {
+            PlStatement::Loop(l) => {
+                check_pl_stmts_for_loop_insert(&l.body, found, true);
+            }
+            PlStatement::While(w) => {
+                check_pl_stmts_for_loop_insert(&w.body, found, true);
+            }
+            PlStatement::For(f) => {
+                check_pl_stmts_for_loop_insert(&f.body, found, true);
+            }
+            PlStatement::ForEach(f) => {
+                check_pl_stmts_for_loop_insert(&f.body, found, true);
+            }
+            PlStatement::SqlStatement { statement, .. } if inside_loop => {
+                if matches!(statement.as_ref(), Statement::Insert(_)) {
+                    *found = true;
+                    return;
+                }
+            }
+            PlStatement::Sql(_) if inside_loop => {
+                // Raw SQL string — check if it looks like INSERT
+                // (best-effort for unparsed SQL)
+            }
+            PlStatement::Block(b) => {
+                check_pl_stmts_for_loop_insert(&b.body, found, inside_loop);
+            }
+            PlStatement::If(i) => {
+                check_pl_stmts_for_loop_insert(&i.then_stmts, found, inside_loop);
+                for e in &i.elsifs {
+                    check_pl_stmts_for_loop_insert(&e.stmts, found, inside_loop);
+                }
+                check_pl_stmts_for_loop_insert(&i.else_stmts, found, inside_loop);
+            }
+            PlStatement::Case(c) => {
+                for w in &c.whens {
+                    check_pl_stmts_for_loop_insert(&w.stmts, found, inside_loop);
+                }
+                check_pl_stmts_for_loop_insert(&c.else_stmts, found, inside_loop);
+            }
+            _ => {}
+        }
+        if *found {
+            return;
+        }
+    }
+}

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -1,0 +1,386 @@
+use crate::ast::{Expr, SelectTarget, Statement, StatementInfo};
+use crate::linter::{
+    loc_from_spanned, make_warning, stmt_location, walk_expr, Confidence, LintConfig, LintRuleEntry, SqlLinter,
+    SqlWarning, StatementKind, WarningLevel,
+};
+
+pub fn register(linter: &mut SqlLinter) {
+    let rules: Vec<LintRuleEntry> = vec![
+        LintRuleEntry {
+            id: "R001",
+            name: "select-star",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_r001,
+        },
+        LintRuleEntry {
+            id: "R002",
+            name: "large-column-sort",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_r002,
+        },
+        LintRuleEntry {
+            id: "R003",
+            name: "lock-table",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::All,
+            check_fn: check_r003,
+        },
+        LintRuleEntry {
+            id: "R004",
+            name: "drop-cascade",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::All,
+            check_fn: check_r004,
+        },
+        LintRuleEntry {
+            id: "R005",
+            name: "implicit-type-conversion",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_r005,
+        },
+        LintRuleEntry {
+            id: "R006",
+            name: "function-on-where-column",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_r006,
+        },
+        LintRuleEntry {
+            id: "R007",
+            name: "like-leading-wildcard",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_r007,
+        },
+        LintRuleEntry {
+            id: "R008",
+            name: "same-table-column-compare",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_r008,
+        },
+        LintRuleEntry {
+            id: "R009",
+            name: "scalar-subquery-in-select",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_r009,
+        },
+    ];
+    for rule in rules {
+        linter.register(rule);
+    }
+}
+
+// R001: SELECT * (unqualified)
+fn check_r001(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            for target in &s.targets {
+                if let SelectTarget::Star(None) = target {
+                    warnings.push(make_warning(
+                        WarningLevel::Prohibition, "R001", "select-star",
+                        "SELECT * \u{8fdd}\u{53cd} GaussDB \u{7f16}\u{7801}\u{89c4}\u{8303}\u{ff1a}\u{8868}\u{7ed3}\u{6784}\u{53d8}\u{5316}\u{65f6}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{4e0d}\u{517c}\u{5bb9}".into(),
+                        Some("\u{660e}\u{786e}\u{5217}\u{51fa}\u{6240}\u{9700}\u{5b57}\u{6bb5}\u{540d}"), loc,
+                        Some("\u{5f00}\u{53d1}\u{8bbe}\u{8ba1}\u{5efa}\u{8bae} > SELECT \u{89c4}\u{8303}"), confidence,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// R002: Large column sort / group by / distinct
+fn check_r002(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            let group_count = s.group_by.len();
+            let order_count = s.order_by.len();
+            if group_count > config.group_by_column_limit {
+                warnings.push(make_warning(
+                    WarningLevel::Prohibition, "R002", "large-column-sort",
+                    format!("GROUP BY \u{5305}\u{542b} {group_count} \u{4e2a}\u{8868}\u{8fbe}\u{5f0f}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {} \u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6027}\u{80fd}\u{95ee}\u{9898}", config.group_by_column_limit),
+                    Some("\u{7b80}\u{5316} GROUP BY\u{ff0c}\u{51cf}\u{5c11}\u{5206}\u{7ec4}\u{5217}\u{6570}\u{91cf}"), loc,
+                    Some("SELECT \u{89c4}\u{8303}"), confidence,
+                ));
+            }
+            if order_count > config.group_by_column_limit {
+                warnings.push(make_warning(
+                    WarningLevel::Prohibition, "R002", "large-column-sort",
+                    format!("ORDER BY \u{5305}\u{542b} {order_count} \u{4e2a}\u{8868}\u{8fbe}\u{5f0f}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {} \u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6027}\u{80fd}\u{95ee}\u{9898}", config.group_by_column_limit),
+                    Some("\u{7b80}\u{5316} ORDER BY\u{ff0c}\u{51cf}\u{5c11}\u{6392}\u{5e8f}\u{5217}\u{6570}\u{91cf}"), loc,
+                    Some("SELECT \u{89c4}\u{8303}"), confidence,
+                ));
+            }
+        }
+    }
+}
+
+// R003: LOCK TABLE
+fn check_r003(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Lock(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            warnings.push(make_warning(
+                WarningLevel::Prohibition, "R003", "lock-table",
+                "LOCK TABLE \u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6b7b}\u{9501}\u{98ce}\u{9669}".into(),
+                Some("\u{907f}\u{514d}\u{5728}\u{4e8b}\u{52a1}\u{4e2d}\u{4f7f}\u{7528} LOCK TABLE\u{ff0c}\u{4f18}\u{5148}\u{4f7f}\u{7528} SELECT ... FOR UPDATE"), loc,
+                Some("SELECT \u{89c4}\u{8303}"), confidence,
+            ));
+        }
+    }
+}
+
+// R004: DROP ... CASCADE
+fn check_r004(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Drop(s) = &info.statement {
+            if s.cascade {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                let obj_type = object_type_str(&s.object_type);
+                warnings.push(make_warning(
+                    WarningLevel::Prohibition,
+                    "R004",
+                    "drop-cascade",
+                    format!("DROP {obj_type} CASCADE \u{53ef}\u{80fd}\u{8bef}\u{5220}\u{4f9d}\u{8d56}\u{5bf9}\u{8c61}"),
+                    Some("\u{786e}\u{8ba4}\u{4f9d}\u{8d56}\u{5173}\u{7cfb}\u{540e}\u{518d}\u{4f7f}\u{7528} CASCADE"),
+                    loc,
+                    Some("SQL \u{7f16}\u{5199}"),
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+fn object_type_str(ot: &crate::ast::ObjectType) -> &'static str {
+    use crate::ast::ObjectType;
+    match ot {
+        ObjectType::Table => "TABLE",
+        ObjectType::Index => "INDEX",
+        ObjectType::Sequence => "SEQUENCE",
+        ObjectType::View => "VIEW",
+        ObjectType::Schema => "SCHEMA",
+        ObjectType::Database => "DATABASE",
+        ObjectType::Tablespace => "TABLESPACE",
+        ObjectType::Function => "FUNCTION",
+        ObjectType::Procedure => "PROCEDURE",
+        ObjectType::Trigger => "TRIGGER",
+        ObjectType::Extension => "EXTENSION",
+        _ => "OBJECT",
+    }
+}
+
+// R005: Implicit type conversion (basic AST-only version)
+fn check_r005(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where_clause(&info.statement) {
+            let mut found = false;
+            walk_expr(where_clause, &mut |e| {
+                if found {
+                    return false;
+                }
+                if let Expr::BinaryOp { left, right, .. } = e {
+                    let l_lit = matches!(**left, Expr::Literal(_));
+                    let r_lit = matches!(**right, Expr::Literal(_));
+                    let l_col = matches!(**left, Expr::ColumnRef(_));
+                    let r_col = matches!(**right, Expr::ColumnRef(_));
+                    if (l_lit && r_col) || (l_col && r_lit) {
+                        found = true;
+                        return false;
+                    }
+                }
+                true
+            });
+            if found {
+                warnings.push(make_warning(
+                    WarningLevel::Prohibition, "R005", "implicit-type-conversion",
+                    "WHERE \u{4e2d}\u{53ef}\u{80fd}\u{5b58}\u{5728}\u{9690}\u{5f0f}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff08}\u{9700}\u{7ed3}\u{5408}\u{5b57}\u{6bb5}\u{7c7b}\u{578b}\u{786e}\u{8ba4}\u{ff09}".into(),
+                    Some("\u{663e}\u{5f0f}\u{6dfb}\u{52a0}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff0c}\u{907f}\u{514d}\u{9690}\u{5f0f}\u{8f6c}\u{6362}\u{5bfc}\u{81f4}\u{7d22}\u{5f15}\u{5931}\u{6548}"), loc,
+                    Some("WHERE \u{89c4}\u{8303}"), confidence,
+                ));
+            }
+        }
+    }
+}
+
+// R006: Function wrapping column in WHERE (index-killing pattern)
+fn check_r006(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where_clause(&info.statement) {
+            let mut found = false;
+            walk_expr(where_clause, &mut |e| {
+                if found {
+                    return false;
+                }
+                if let Expr::FunctionCall { args, .. } = e {
+                    for arg in args {
+                        if let Expr::ColumnRef(_) = arg {
+                            found = true;
+                            return false;
+                        }
+                    }
+                }
+                true
+            });
+            if found {
+                warnings.push(make_warning(
+                    WarningLevel::Prohibition, "R006", "function-on-where-column",
+                    "WHERE \u{4e2d}\u{5bf9}\u{5217}\u{4f7f}\u{7528}\u{51fd}\u{6570}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{7d22}\u{5f15}\u{5931}\u{6548}".into(),
+                    Some("\u{5c06}\u{51fd}\u{6570}\u{8fd0}\u{7b97}\u{79fb}\u{5230}\u{7b49}\u{53f7}\u{53e6}\u{4e00}\u{4fa7}\u{6216}\u{4f7f}\u{7528}\u{51fd}\u{6570}\u{7d22}\u{5f15}"), loc,
+                    Some("WHERE \u{89c4}\u{8303}"), confidence,
+                ));
+            }
+        }
+    }
+}
+
+// R007: LIKE with leading wildcard
+fn check_r007(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where_clause(&info.statement) {
+            walk_expr(where_clause, &mut |e| {
+                if let Expr::Like { pattern, negated: false, .. } = e {
+                    if let Expr::Literal(crate::ast::Literal::String(s)) = pattern.as_ref() {
+                        if s.starts_with('%') || s.starts_with('_') {
+                            warnings.push(make_warning(
+                                WarningLevel::Prohibition, "R007", "like-leading-wildcard",
+                                format!("LIKE '\u{524d}\u{5bfc}\u{901a}\u{914d}\u{7b26} {s}' \u{5c06}\u{5bfc}\u{81f4}\u{65e0}\u{6cd5}\u{4f7f}\u{7528}\u{7d22}\u{5f15}\u{ff0c}\u{89e6}\u{53d1}\u{5168}\u{8868}\u{626b}\u{63cf}"),
+                                Some("\u{907f}\u{514d}\u{4ee5}\u{901a}\u{914d}\u{7b26}\u{5f00}\u{5934}\u{7684} LIKE \u{6a21}\u{5f0f}"), loc,
+                                Some("WHERE \u{89c4}\u{8303}"), confidence,
+                            ));
+                        }
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+
+// R008: Same-table column comparison in WHERE
+fn check_r008(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where_clause(&info.statement) {
+            walk_expr(where_clause, &mut |e| {
+                if let Expr::BinaryOp { left, right, .. } = e {
+                    if let (Expr::ColumnRef(l), Expr::ColumnRef(r)) = (left.as_ref(), right.as_ref()) {
+                        if l.len() >= 2 && r.len() >= 2 && l[0] == r[0] {
+                            warnings.push(make_warning(
+                                WarningLevel::Prohibition, "R008", "same-table-column-compare",
+                                format!("\u{540c}\u{8868}\u{5217}\u{6bd4}\u{8f83}: {}.{} \u{4e0e} {}.{}\u{ff0c}\u{53ef}\u{80fd}\u{672a}\u{6b63}\u{786e}\u{4f7f}\u{7528}\u{7d22}\u{5f15}", l[0], l.last().unwrap_or(&"".into()), r[0], r.last().unwrap_or(&"".into())),
+                                Some("\u{68c0}\u{67e5}\u{662f}\u{5426}\u{5e94}\u{4f7f}\u{7528}\u{4e0d}\u{540c}\u{8868}\u{7684}\u{5217}\u{8fdb}\u{884c}\u{6bd4}\u{8f83}"), loc,
+                                Some("WHERE \u{89c4}\u{8303}"), confidence,
+                            ));
+                        }
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+
+// R009: Scalar subquery in SELECT target list
+fn check_r009(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let loc = loc_from_spanned(s, stmt_location(info));
+            for target in &s.targets {
+                if let SelectTarget::Expr(e, _) = target {
+                    let mut found = false;
+                    walk_expr(e, &mut |inner| {
+                        if found {
+                            return false;
+                        }
+                        if matches!(inner, Expr::Subquery(_)) {
+                            found = true;
+                            return false;
+                        }
+                        true
+                    });
+                    if found {
+                        warnings.push(make_warning(
+                            WarningLevel::Prohibition, "R009", "scalar-subquery-in-select",
+                            "SELECT \u{5217}\u{4e2d}\u{5305}\u{542b}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}\u{ff0c}\u{6bcf}\u{884c}\u{90fd}\u{4f1a}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
+                            Some("\u{6539}\u{7528} JOIN \u{66ff}\u{4ee3}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}"), loc,
+                            Some("SQL \u{7f16}\u{5199}"), confidence,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn extract_where_clause(stmt: &Statement) -> Option<&Expr> {
+    match stmt {
+        Statement::Select(s) => s.where_clause.as_ref(),
+        Statement::Update(s) => s.where_clause.as_ref(),
+        Statement::Delete(s) => s.where_clause.as_ref(),
+        _ => None,
+    }
+}

--- a/src/linter/rules_suggestion.rs
+++ b/src/linter/rules_suggestion.rs
@@ -1,0 +1,333 @@
+use crate::ast::plpgsql::{PlDataType, PlDeclaration, PlStatement};
+use crate::ast::{Expr, Statement, StatementInfo};
+use crate::linter::{
+    loc_from_spanned, make_warning, stmt_location, walk_expr, Confidence, LintConfig, LintRuleEntry, SqlLinter,
+    SqlWarning, StatementKind, WarningLevel,
+};
+
+pub fn register(linter: &mut SqlLinter) {
+    let rules: Vec<LintRuleEntry> = vec![
+        LintRuleEntry {
+            id: "S001",
+            name: "delete-full-table-use-truncate",
+            level: WarningLevel::Suggestion,
+            stmt_kind: StatementKind::Delete,
+            check_fn: check_s001,
+        },
+        LintRuleEntry {
+            id: "S002",
+            name: "limit-offset-use-cursor",
+            level: WarningLevel::Suggestion,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_s002,
+        },
+        LintRuleEntry {
+            id: "S005",
+            name: "prefer-percent-type",
+            level: WarningLevel::Suggestion,
+            stmt_kind: StatementKind::PlBlock,
+            check_fn: check_s005,
+        },
+        LintRuleEntry {
+            id: "S006",
+            name: "limit-without-order-by",
+            level: WarningLevel::Suggestion,
+            stmt_kind: StatementKind::Select,
+            check_fn: check_s006,
+        },
+        LintRuleEntry {
+            id: "S007",
+            name: "explicit-type-for-literals",
+            level: WarningLevel::Suggestion,
+            stmt_kind: StatementKind::Dml,
+            check_fn: check_s007,
+        },
+        LintRuleEntry {
+            id: "S008",
+            name: "complex-sql-consider-split",
+            level: WarningLevel::Suggestion,
+            stmt_kind: StatementKind::All,
+            check_fn: check_s008,
+        },
+    ];
+    for rule in rules {
+        linter.register(rule);
+    }
+}
+
+// ── S001: DELETE full table → use TRUNCATE ──
+
+fn check_s001(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Delete(s) = &info.statement {
+            if s.where_clause.is_none() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Suggestion,
+                    "S001",
+                    "delete-full-table-use-truncate",
+                    "DELETE \u{5168}\u{8868}\u{53ef}\u{7528} TRUNCATE \u{66ff}\u{4ee3}\u{ff0c}\u{91ca}\u{653e}\u{7a7a}\u{95f4}\u{66f4}\u{5feb}".into(),
+                    Some("\u{4f7f}\u{7528} TRUNCATE TABLE \u{66ff}\u{4ee3} DELETE \u{65e0} WHERE"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── S002: LIMIT + OFFSET → use cursor ──
+
+fn check_s002(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            if s.offset.is_some() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Suggestion,
+                    "S002",
+                    "limit-offset-use-cursor",
+                    "OFFSET \u{5206}\u{9875}\u{5728}\u{5927}\u{504f}\u{79fb}\u{65f6}\u{6027}\u{80fd}\u{8f83}\u{5dee}"
+                        .into(),
+                    Some(
+                        "\u{8003}\u{8651}\u{4f7f}\u{7528}\u{6e38}\u{6807}\u{7ffb}\u{9875}\u{66ff}\u{4ee3} LIMIT/OFFSET",
+                    ),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── S005: Prefer %TYPE anchored types ──
+
+fn check_s005(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let mut found = false;
+        walk_pl_for_type_name(&info.statement, &mut found);
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Suggestion,
+                "S005",
+                "prefer-percent-type",
+                "PL/pgSQL \u{53d8}\u{91cf}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{7c7b}\u{578b}\u{800c}\u{975e} %TYPE/%ROWTYPE \u{951a}\u{5b9a}".into(),
+                Some("\u{4f7f}\u{7528} table.column%TYPE \u{6216} table%ROWTYPE \u{951a}\u{5b9a}\u{7c7b}\u{578b}\u{4ee5}\u{63d0}\u{9ad8}\u{53ef}\u{7ef4}\u{62a4}\u{6027}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}
+
+fn walk_pl_for_type_name(stmt: &Statement, found: &mut bool) {
+    let block = match stmt {
+        Statement::AnonyBlock(b) => &b.block,
+        Statement::Do(d) => {
+            if let Some(ref block) = d.block {
+                block
+            } else {
+                return;
+            }
+        }
+        _ => return,
+    };
+    check_decls_for_type_name(&block.declarations, found);
+    if !*found {
+        check_pl_stmts_for_type_name(&block.body, found);
+    }
+}
+
+fn check_decls_for_type_name(decls: &[PlDeclaration], found: &mut bool) {
+    for d in decls {
+        if let PlDeclaration::Variable(v) = d {
+            if let PlDataType::TypeName(name) = &v.data_type {
+                let lower = name.to_lowercase();
+                let is_simple = [
+                    "integer",
+                    "int",
+                    "bigint",
+                    "smallint",
+                    "serial",
+                    "bigserial",
+                    "text",
+                    "varchar",
+                    "char",
+                    "character",
+                    "boolean",
+                    "bool",
+                    "numeric",
+                    "decimal",
+                    "real",
+                    "double precision",
+                    "float",
+                    "date",
+                    "timestamp",
+                    "timestamptz",
+                    "time",
+                    "timetz",
+                    "interval",
+                    "bytea",
+                    "uuid",
+                    "json",
+                    "jsonb",
+                ]
+                .contains(&lower.as_str());
+                if !is_simple {
+                    *found = true;
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn check_pl_stmts_for_type_name(pl_stmts: &[PlStatement], found: &mut bool) {
+    if *found {
+        return;
+    }
+    for s in pl_stmts {
+        if let PlStatement::Block(b) = s {
+            check_decls_for_type_name(&b.declarations, found);
+            if !*found {
+                check_pl_stmts_for_type_name(&b.body, found);
+            }
+        }
+        if *found {
+            return;
+        }
+    }
+}
+
+// ── S006: LIMIT without ORDER BY ──
+
+fn check_s006(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if let Statement::Select(s) = &info.statement {
+            let has_limit = s.limit.is_some() || s.fetch.is_some() || matches!(&s.fetch, Some(f) if f.count.is_some());
+            if has_limit && s.order_by.is_empty() {
+                let loc = loc_from_spanned(s, stmt_location(info));
+                warnings.push(make_warning(
+                    WarningLevel::Suggestion,
+                    "S006",
+                    "limit-without-order-by",
+                    "LIMIT \u{65e0} ORDER BY\u{ff0c}\u{7ed3}\u{679c}\u{987a}\u{5e8f}\u{4e0d}\u{786e}\u{5b9a}".into(),
+                    Some("\u{6dfb}\u{52a0} ORDER BY \u{4fdd}\u{8bc1}\u{7ed3}\u{679c}\u{786e}\u{5b9a}\u{6027}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── S007: Explicit type for literals in WHERE ──
+
+fn check_s007(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        let where_clause = match &info.statement {
+            Statement::Select(s) => s.where_clause.as_ref(),
+            Statement::Update(s) => s.where_clause.as_ref(),
+            Statement::Delete(s) => s.where_clause.as_ref(),
+            _ => None,
+        };
+        if let Some(where_clause) = where_clause {
+            let mut found = false;
+            walk_expr(where_clause, &mut |e| {
+                if found {
+                    return false;
+                }
+                if let Expr::BinaryOp { left, right, op, .. } = e {
+                    let is_compare = matches!(op.as_str(), "=" | "<>" | "!=" | ">" | "<" | ">=" | "<=");
+                    if is_compare {
+                        let l_untyped = matches!(left.as_ref(), Expr::Literal(crate::ast::Literal::String(_)));
+                        let r_untyped = matches!(right.as_ref(), Expr::Literal(crate::ast::Literal::String(_)));
+                        if l_untyped || r_untyped {
+                            found = true;
+                            return false;
+                        }
+                    }
+                }
+                true
+            });
+            if found {
+                warnings.push(make_warning(
+                    WarningLevel::Suggestion,
+                    "S007",
+                    "explicit-type-for-literals",
+                    "WHERE \u{4e2d}\u{5b57}\u{7b26}\u{4e32}\u{5e38}\u{91cf}\u{672a}\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{7c7b}\u{578b}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{9690}\u{5f0f}\u{8f6c}\u{6362}".into(),
+                    Some("\u{4f7f}\u{7528}\u{663e}\u{5f0f}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff1a} 'val'::type \u{6216} CAST('val' AS type)"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+            }
+        }
+    }
+}
+
+// ── S008: Complex SQL — consider splitting ──
+
+fn check_s008(
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        if info.sql_text.len() > config.sql_length_limit {
+            let loc = stmt_location(info);
+            warnings.push(make_warning(
+                WarningLevel::Suggestion,
+                "S008",
+                "complex-sql-consider-split",
+                format!(
+                    "SQL \u{6587}\u{672c}\u{957f}\u{5ea6} {} \u{5b57}\u{7b26}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{5efa}\u{8bae}\u{62c6}\u{5206}\u{7b80}\u{5316}",
+                    info.sql_text.len(),
+                    config.sql_length_limit
+                ),
+                Some("\u{5c06}\u{590d}\u{6742} SQL \u{62c6}\u{5206}\u{4e3a}\u{591a}\u{4e2a}\u{7b80}\u{5355}\u{67e5}\u{8be2}\u{6216}\u{4f7f}\u{7528} CTE"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+    }
+}

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -1,0 +1,822 @@
+use crate::linter::{Confidence, LintConfig, SqlLinter, WarningLevel};
+use crate::parser::Parser;
+
+fn parse(sql: &str) -> Vec<crate::ast::StatementInfo> {
+    let (stmts, _) = Parser::parse_sql(sql);
+    stmts
+}
+
+fn lint(stmts: &[crate::ast::StatementInfo]) -> Vec<crate::linter::SqlWarning> {
+    let linter = SqlLinter::with_default_rules(LintConfig::default());
+    linter.lint(stmts, None, Confidence::Full)
+}
+
+fn lint_confidence(stmts: &[crate::ast::StatementInfo], confidence: Confidence) -> Vec<crate::linter::SqlWarning> {
+    let linter = SqlLinter::with_default_rules(LintConfig::default());
+    linter.lint(stmts, None, confidence)
+}
+
+fn lint_min_level(stmts: &[crate::ast::StatementInfo], level: WarningLevel) -> Vec<crate::linter::SqlWarning> {
+    let config = LintConfig { min_level: level, ..LintConfig::default() };
+    let linter = SqlLinter::with_default_rules(config);
+    linter.lint(stmts, None, Confidence::Full)
+}
+
+fn has_rule(warnings: &[crate::linter::SqlWarning], rule_id: &str) -> bool {
+    warnings.iter().any(|w| w.rule_id == rule_id)
+}
+
+// ── R001: SELECT * ──
+
+#[test]
+fn r001_unqualified_star() {
+    let stmts = parse("SELECT * FROM t1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R001"), "expected R001 for SELECT *");
+}
+
+#[test]
+fn r001_qualified_star_not_triggered() {
+    let stmts = parse("SELECT t1.* FROM t1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R001"), "t1.* should not trigger R001");
+}
+
+#[test]
+fn r001_explicit_columns_not_triggered() {
+    let stmts = parse("SELECT id, name FROM t1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R001"));
+}
+
+// ── R002: Large column sort ──
+
+#[test]
+fn r002_large_group_by() {
+    let sql = "SELECT a,b,c,d,e,f,g,h,i,j,k FROM t1 GROUP BY a,b,c,d,e,f,g,h,i,j,k";
+    let stmts = parse(sql);
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R002"), "expected R002 for GROUP BY with 11 columns");
+}
+
+#[test]
+fn r002_small_group_by_not_triggered() {
+    let stmts = parse("SELECT a, b FROM t1 GROUP BY a, b");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R002"));
+}
+
+// ── R003: LOCK TABLE ──
+
+#[test]
+fn r003_lock_table() {
+    let stmts = parse("LOCK TABLE t1 IN EXCLUSIVE MODE");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R003"), "expected R003 for LOCK TABLE");
+}
+
+// ── R004: DROP CASCADE ──
+
+#[test]
+fn r004_drop_cascade() {
+    let stmts = parse("DROP TABLE t1 CASCADE");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R004"), "expected R004 for DROP CASCADE");
+}
+
+#[test]
+fn r004_drop_no_cascade_not_triggered() {
+    let stmts = parse("DROP TABLE t1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R004"));
+}
+
+// ── R005: Implicit type conversion ──
+
+#[test]
+fn r005_literal_column_comparison() {
+    let stmts = parse("SELECT * FROM t WHERE name = 'abc'");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R005"), "expected R005 for literal-column comparison");
+}
+
+#[test]
+fn r005_both_columns_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE a = b");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R005"), "col=col should not trigger R005");
+}
+
+// ── R006: Function on WHERE column ──
+
+#[test]
+fn r006_function_on_column() {
+    let stmts = parse("SELECT * FROM t WHERE LENGTH(name) > 5");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R006"), "expected R006 for LENGTH(col) in WHERE");
+}
+
+#[test]
+fn r006_plain_column_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE name = 'abc'");
+    // R005 may trigger, but R006 should not
+    assert!(!has_rule(&lint(&stmts), "R006"));
+}
+
+// ── R007: LIKE leading wildcard ──
+
+#[test]
+fn r007_leading_percent() {
+    let stmts = parse("SELECT * FROM t WHERE name LIKE '%abc'");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R007"), "expected R007 for LIKE '%...'");
+}
+
+#[test]
+fn r007_trailing_wildcard_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE name LIKE 'abc%'");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R007"), "LIKE 'abc%' should not trigger R007");
+}
+
+// ── R008: Same-table column compare ──
+
+#[test]
+fn r008_same_table_columns() {
+    let stmts = parse("SELECT * FROM t WHERE t.a > t.b");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R008"), "expected R008 for t.a > t.b");
+}
+
+#[test]
+fn r008_different_tables_not_triggered() {
+    let stmts = parse("SELECT * FROM t1 JOIN t2 ON t1.id = t2.id WHERE t1.a > t2.b");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R008"));
+}
+
+// ── R009: Scalar subquery in SELECT ──
+
+#[test]
+fn r009_subquery_in_select() {
+    let stmts = parse("SELECT (SELECT MAX(id) FROM t2) FROM t1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R009"), "expected R009 for scalar subquery in SELECT");
+}
+
+#[test]
+fn r009_subquery_in_where_not_triggered() {
+    let stmts = parse("SELECT * FROM t1 WHERE id IN (SELECT id FROM t2)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R009"), "subquery in WHERE should not trigger R009");
+}
+
+// ── P001: UNION without ALL ──
+
+#[test]
+fn p001_union_without_all() {
+    let stmts = parse("SELECT id FROM t1 UNION SELECT id FROM t2");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P001"), "expected P001 for UNION without ALL");
+}
+
+#[test]
+fn p001_union_all_not_triggered() {
+    let stmts = parse("SELECT id FROM t1 UNION ALL SELECT id FROM t2");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P001"));
+}
+
+// ── P002: NOT IN subquery ──
+
+#[test]
+fn p002_not_in_subquery() {
+    let stmts = parse("SELECT * FROM t WHERE id NOT IN (SELECT id FROM t2)");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P002"), "expected P002 for NOT IN (subquery)");
+}
+
+#[test]
+fn p002_in_subquery_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE id IN (SELECT id FROM t2)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P002"));
+}
+
+// ── P003: IN list too large ──
+
+#[test]
+fn p003_large_in_list() {
+    let values: Vec<&str> = (1..=600).map(|_| "1").collect();
+    let sql = format!("SELECT * FROM t WHERE id IN ({})", values.join(","));
+    let stmts = parse(&sql);
+    let config = LintConfig { in_list_threshold: 500, ..LintConfig::default() };
+    let linter = SqlLinter::with_default_rules(config);
+    let w = linter.lint(&stmts, None, Confidence::Full);
+    assert!(has_rule(&w, "P003"), "expected P003 for IN list > 500");
+}
+
+#[test]
+fn p003_small_in_list_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE id IN (1, 2, 3)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P003"));
+}
+
+// ── P004: OR as top-level WHERE ──
+
+#[test]
+fn p004_or_top_level() {
+    let stmts = parse("SELECT * FROM t WHERE a = 1 OR b = 2");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P004"), "expected P004 for top-level OR");
+}
+
+#[test]
+fn p004_or_inside_and_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE c = 1 AND (a = 1 OR b = 2)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P004"), "OR inside AND should not trigger P004");
+}
+
+// ── P005: now() function ──
+
+#[test]
+fn p005_now_function() {
+    let stmts = parse("SELECT * FROM t WHERE created > now()");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P005"), "expected P005 for now()");
+}
+
+#[test]
+fn p005_other_function_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE name = UPPER('abc')");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P005"));
+}
+
+// ── P006: COUNT(*) ──
+
+#[test]
+fn p006_count_star() {
+    let stmts = parse("SELECT COUNT(*) FROM t");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P006"), "expected P006 for COUNT(*)");
+}
+
+#[test]
+fn p006_count_column_not_triggered() {
+    let stmts = parse("SELECT COUNT(id) FROM t");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P006"));
+}
+
+// ── P009: Function that should be CASE ──
+
+#[test]
+fn p009_nvl_in_where() {
+    let stmts = parse("SELECT * FROM t WHERE NVL(status, 0) = 1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P009"), "expected P009 for NVL in WHERE");
+}
+
+#[test]
+fn p009_decode_in_where() {
+    let stmts = parse("SELECT * FROM t WHERE DECODE(code, 1, 'A', 'B') = 'A'");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P009"), "expected P009 for DECODE in WHERE");
+}
+
+#[test]
+fn p009_coalesce_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE COALESCE(status, 0) = 1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P009"), "COALESCE should not trigger P009");
+}
+
+// ── P010: Multi-column UPDATE from subquery ──
+
+#[test]
+fn p010_multi_col_update_subquery() {
+    let stmts = parse("UPDATE t SET (a, b) = (SELECT x, y FROM t2)");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P010"), "expected P010 for multi-col UPDATE subquery");
+}
+
+#[test]
+fn p010_single_col_not_triggered() {
+    let stmts = parse("UPDATE t SET a = (SELECT x FROM t2)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P010"));
+}
+
+// ── P012: Unnecessary DISTINCT ──
+
+#[test]
+fn p012_distinct() {
+    let stmts = parse("SELECT DISTINCT a, b FROM t");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P012"), "expected P012 for DISTINCT");
+}
+
+#[test]
+fn p012_no_distinct_not_triggered() {
+    let stmts = parse("SELECT a, b FROM t");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P012"));
+}
+
+// ── P013: Cartesian product ──
+
+#[test]
+fn p013_cross_join() {
+    let stmts = parse("SELECT * FROM t1 CROSS JOIN t2");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P013"), "expected P013 for CROSS JOIN");
+}
+
+// ── P014: Deeply nested subquery ──
+
+#[test]
+fn p014_deep_nesting() {
+    let sql = "SELECT * FROM t WHERE id IN (SELECT id FROM t2 WHERE id IN (SELECT id FROM t3 WHERE id IN (SELECT id FROM t4)))";
+    let stmts = parse(sql);
+    let config = LintConfig { subquery_depth_limit: 3, ..LintConfig::default() };
+    let linter = SqlLinter::with_default_rules(config);
+    let w = linter.lint(&stmts, None, Confidence::Full);
+    assert!(has_rule(&w, "P014"), "expected P014 for deeply nested subquery");
+}
+
+// ── P015: Range equals same value ──
+
+#[test]
+fn p015_between_same() {
+    let stmts = parse("SELECT * FROM t WHERE a BETWEEN 5 AND 5");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P015"), "expected P015 for BETWEEN 5 AND 5");
+}
+
+#[test]
+fn p015_between_different_not_triggered() {
+    let stmts = parse("SELECT * FROM t WHERE a BETWEEN 1 AND 10");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P015"));
+}
+
+// ── P016: UPDATE FROM without join condition ──
+
+#[test]
+fn p016_update_from_no_where() {
+    let stmts = parse("UPDATE t SET a = t2.b FROM t2");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P016"), "expected P016 for UPDATE FROM without WHERE");
+}
+
+#[test]
+fn p016_update_from_with_where_not_triggered() {
+    let stmts = parse("UPDATE t SET a = t2.b FROM t2 WHERE t.id = t2.id");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P016"));
+}
+
+// ── P017: MERGE ──
+
+#[test]
+fn p017_merge() {
+    let sql = "MERGE INTO target t USING source s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.a = s.a";
+    let stmts = parse(sql);
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P017"), "expected P017 for MERGE");
+}
+
+// ── P018: INSERT SELECT without columns ──
+
+#[test]
+fn p018_insert_select_no_columns() {
+    let stmts = parse("INSERT INTO t SELECT * FROM t2");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P018"), "expected P018 for INSERT SELECT without columns");
+}
+
+#[test]
+fn p018_insert_select_with_columns_not_triggered() {
+    let stmts = parse("INSERT INTO t (a, b) SELECT x, y FROM t2");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P018"));
+}
+
+// ── P022: EXPLAIN in production ──
+
+#[test]
+fn p022_explain() {
+    let stmts = parse("EXPLAIN SELECT * FROM t");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P022"), "expected P022 for EXPLAIN");
+}
+
+// ── P021: Row-by-row INSERT in loop ──
+
+#[test]
+fn p021_insert_in_loop() {
+    let stmts = parse("DO $$ BEGIN FOR i IN 1..10 LOOP INSERT INTO t VALUES (i); END LOOP; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "P021"), "expected P021 for INSERT in loop");
+}
+
+#[test]
+fn p021_insert_outside_loop_not_triggered() {
+    let stmts = parse("DO $$ BEGIN INSERT INTO t VALUES (1); END $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "P021"), "INSERT outside loop should not trigger P021");
+}
+
+// ── Confidence propagation ──
+
+#[test]
+fn confidence_partial_propagated() {
+    let stmts = parse("SELECT * FROM t1");
+    let w = lint_confidence(&stmts, Confidence::Partial);
+    assert!(w.iter().all(|w| w.confidence == Confidence::Partial));
+}
+
+#[test]
+fn confidence_full_propagated() {
+    let stmts = parse("SELECT * FROM t1");
+    let w = lint_confidence(&stmts, Confidence::Full);
+    assert!(w.iter().all(|w| w.confidence == Confidence::Full));
+}
+
+// ── Min level filter ──
+
+#[test]
+fn min_level_prohibition_filters_lower() {
+    let stmts = parse("SELECT DISTINCT a FROM t");
+    let w = lint_min_level(&stmts, WarningLevel::Prohibition);
+    assert!(!has_rule(&w, "P012"), "P012 (Performance) should be filtered by min_level=Prohibition");
+}
+
+// ── Suppress rule ──
+
+#[test]
+fn suppress_rule() {
+    let config = LintConfig { suppress: vec!["R001".into()], ..LintConfig::default() };
+    let linter = SqlLinter::with_default_rules(config);
+    let stmts = parse("SELECT * FROM t");
+    let w = linter.lint(&stmts, None, Confidence::Full);
+    assert!(!has_rule(&w, "R001"), "R001 should be suppressed");
+}
+
+// ── Multiple rules on same statement ──
+
+#[test]
+fn multiple_rules_same_statement() {
+    let stmts = parse("SELECT * FROM t1 UNION SELECT * FROM t2");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R001"), "expected R001 for SELECT *");
+    assert!(has_rule(&w, "P001"), "expected P001 for UNION");
+}
+
+// ── No warnings on clean SQL ──
+
+#[test]
+fn no_warnings_clean_sql() {
+    let stmts = parse("SELECT id, name FROM users WHERE status = 'active' ORDER BY id");
+    let w = lint(&stmts);
+    // R005 may trigger for literal-column comparison, filter it out
+    let non_known: Vec<_> = w.iter().filter(|w| w.rule_id != "R005" && w.rule_id != "S007").collect();
+    assert!(non_known.is_empty(), "clean SQL should not produce warnings (except maybe R005/S007): {:?}", non_known);
+}
+
+// ════════════════════════════════════════════════════════════════
+// Phase 2a: Caution rules (C001-C016)
+// ════════════════════════════════════════════════════════════════
+
+// ── C001: Unknown hint ──
+
+#[test]
+fn c001_unknown_hint() {
+    let stmts = parse("SELECT /*+ bogus_hint(t1) */ * FROM t1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C001"), "expected C001 for unknown hint");
+}
+
+#[test]
+fn c001_known_hint_not_triggered() {
+    let stmts = parse("SELECT /*+ hashjoin(t1) */ * FROM t1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C001"), "known hint should not trigger C001");
+}
+
+// ── C005: Contradictory hints ──
+
+#[test]
+fn c005_contradictory_scan_hints() {
+    let stmts = parse("SELECT /*+ tablescan(t1) indexscan(t1) */ * FROM t1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C005"), "expected C005 for contradictory scan hints");
+}
+
+#[test]
+fn c005_contradictory_negation() {
+    let stmts = parse("SELECT /*+ expand_sublink no_expand_sublink */ * FROM t1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C005"), "expected C005 for hint + no_ negation");
+}
+
+// ── C006: Hint table not in FROM ──
+
+#[test]
+fn c006_hint_table_not_in_from() {
+    let stmts = parse("SELECT /*+ hashjoin(ghost_table) */ * FROM t1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C006"), "expected C006 for hint referencing non-FROM table");
+}
+
+#[test]
+fn c006_hint_table_in_from_not_triggered() {
+    let stmts = parse("SELECT /*+ hashjoin(t1) */ * FROM t1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C006"), "hint table in FROM should not trigger C006");
+}
+
+// ── C007: UPDATE without WHERE ──
+
+#[test]
+fn c007_update_no_where() {
+    let stmts = parse("UPDATE t SET a = 1");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C007"), "expected C007 for UPDATE without WHERE");
+}
+
+#[test]
+fn c007_update_with_where_not_triggered() {
+    let stmts = parse("UPDATE t SET a = 1 WHERE id = 1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C007"));
+}
+
+// ── C008: DELETE without WHERE ──
+
+#[test]
+fn c008_delete_no_where() {
+    let stmts = parse("DELETE FROM t");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C008"), "expected C008 for DELETE without WHERE");
+}
+
+#[test]
+fn c008_delete_with_where_not_triggered() {
+    let stmts = parse("DELETE FROM t WHERE id = 1");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C008"));
+}
+
+// ── C009: INSERT without column list ──
+
+#[test]
+fn c009_insert_no_columns() {
+    let stmts = parse("INSERT INTO t VALUES (1, 2)");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C009"), "expected C009 for INSERT without columns");
+}
+
+#[test]
+fn c009_insert_with_columns_not_triggered() {
+    let stmts = parse("INSERT INTO t (a, b) VALUES (1, 2)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C009"));
+}
+
+// ── C010: Unlogged table ──
+
+#[test]
+fn c010_unlogged_table() {
+    let stmts = parse("CREATE UNLOGGED TABLE t (id INT)");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C010"), "expected C010 for UNLOGGED TABLE");
+}
+
+#[test]
+fn c010_regular_table_not_triggered() {
+    let stmts = parse("CREATE TABLE t (id INT)");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C010"));
+}
+
+// ── C011: GOTO statement ──
+
+#[test]
+fn c011_goto_in_pl() {
+    let stmts = parse("DO $$ BEGIN GOTO label1; <<label1>> NULL; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C011"), "expected C011 for GOTO");
+}
+
+// ── C012: EXECUTE with concatenation ──
+
+#[test]
+fn c012_execute_concat() {
+    let stmts = parse("DO $$ BEGIN EXECUTE IMMEDIATE 'SELECT * FROM ' || v_tablename; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C012"), "expected C012 for EXECUTE with concatenation");
+}
+
+#[test]
+fn c012_execute_no_concat_not_triggered() {
+    let stmts = parse("DO $$ BEGIN EXECUTE IMMEDIATE 'SELECT 1'; END $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C012"), "EXECUTE without concatenation should not trigger C012");
+}
+
+// ── C013: Exception swallow ──
+
+#[test]
+fn c013_exception_swallow() {
+    let stmts = parse("DO $$ BEGIN NULL; EXCEPTION WHEN OTHERS THEN NULL; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C013"), "expected C013 for WHEN OTHERS THEN without RAISE");
+}
+
+#[test]
+fn c013_exception_with_raise_not_triggered() {
+    let stmts = parse("DO $$ BEGIN NULL; EXCEPTION WHEN OTHERS THEN RAISE NOTICE '%', SQLERRM; END $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C013"), "WHEN OTHERS with RAISE should not trigger C013");
+}
+
+// ── C014: PL COMMIT/ROLLBACK ──
+
+#[test]
+fn c014_pl_commit() {
+    let stmts = parse("DO $$ BEGIN COMMIT; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C014"), "expected C014 for COMMIT in PL block");
+}
+
+#[test]
+fn c014_pl_rollback() {
+    let stmts = parse("DO $$ BEGIN ROLLBACK; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C014"), "expected C014 for ROLLBACK in PL block");
+}
+
+// ── C015: SELECT FOR UPDATE blocking ──
+
+#[test]
+fn c015_for_update_blocking() {
+    let stmts = parse("SELECT * FROM t FOR UPDATE");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C015"), "expected C015 for SELECT FOR UPDATE");
+}
+
+#[test]
+fn c015_for_update_nowait_not_triggered() {
+    let stmts = parse("SELECT * FROM t FOR UPDATE NOWAIT");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C015"), "FOR UPDATE NOWAIT should not trigger C015");
+}
+
+// ── C016: Autonomous transaction ──
+
+#[test]
+fn c016_autonomous_transaction() {
+    let stmts = parse("DO $$ DECLARE PRAGMA AUTONOMOUS_TRANSACTION; BEGIN NULL; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C016"), "expected C016 for AUTONOMOUS_TRANSACTION");
+}
+
+// ════════════════════════════════════════════════════════════════
+// Phase 2b: Suggestion rules (S001-S008)
+// ════════════════════════════════════════════════════════════════
+
+// ── S001: DELETE full table → use TRUNCATE ──
+
+#[test]
+fn s001_delete_full_table() {
+    let stmts = parse("DELETE FROM t");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "S001"), "expected S001 for DELETE without WHERE");
+}
+
+// ── S002: LIMIT + OFFSET → use cursor ──
+
+#[test]
+fn s002_limit_offset() {
+    let stmts = parse("SELECT * FROM t LIMIT 10 OFFSET 20");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "S002"), "expected S002 for OFFSET");
+}
+
+#[test]
+fn s002_limit_no_offset_not_triggered() {
+    let stmts = parse("SELECT * FROM t LIMIT 10");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "S002"), "LIMIT without OFFSET should not trigger S002");
+}
+
+// ── S006: LIMIT without ORDER BY ──
+
+#[test]
+fn s006_limit_no_order() {
+    let stmts = parse("SELECT * FROM t LIMIT 10");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "S006"), "expected S006 for LIMIT without ORDER BY");
+}
+
+#[test]
+fn s006_limit_with_order_not_triggered() {
+    let stmts = parse("SELECT * FROM t ORDER BY id LIMIT 10");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "S006"), "LIMIT with ORDER BY should not trigger S006");
+}
+
+// ── S007: Explicit type for literals ──
+
+#[test]
+fn s007_string_literal_in_where() {
+    let stmts = parse("SELECT * FROM t WHERE name = 'abc'");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "S007"), "expected S007 for untyped string literal in WHERE");
+}
+
+// ── S008: Complex SQL ──
+
+#[test]
+fn s008_complex_sql() {
+    let long_sql = format!("SELECT {} FROM t", "a, ".repeat(500));
+    let stmts = parse(&long_sql);
+    let config = LintConfig { sql_length_limit: 200, ..LintConfig::default() };
+    let linter = SqlLinter::with_default_rules(config);
+    let w = linter.lint(&stmts, None, Confidence::Full);
+    assert!(has_rule(&w, "S008"), "expected S008 for long SQL");
+}
+
+// ── LintConfig from_toml_str ──
+
+#[cfg(feature = "lint-config")]
+#[test]
+fn from_toml_str_partial() {
+    let toml = r#"
+min_level = "caution"
+suppress = ["R001"]
+"#;
+    let config = LintConfig::from_toml_str(toml).unwrap();
+    assert_eq!(config.min_level, WarningLevel::Caution);
+    assert_eq!(config.min_confidence, Confidence::Partial); // default
+    assert_eq!(config.suppress, vec!["R001".to_string()]);
+    assert_eq!(config.in_list_threshold, 500); // default
+}
+
+#[cfg(feature = "lint-config")]
+#[test]
+fn from_toml_str_full() {
+    let toml = r#"
+min_level = "performance"
+min_confidence = "full"
+suppress = ["R001", "P003", "S007"]
+in_list_threshold = 100
+subquery_depth_limit = 5
+sql_length_limit = 1000
+non_equi_join_limit = 4
+group_by_column_limit = 20
+"#;
+    let config = LintConfig::from_toml_str(toml).unwrap();
+    assert_eq!(config.min_level, WarningLevel::Performance);
+    assert_eq!(config.min_confidence, Confidence::Full);
+    assert_eq!(config.suppress, vec!["R001", "P003", "S007"]);
+    assert_eq!(config.in_list_threshold, 100);
+    assert_eq!(config.subquery_depth_limit, 5);
+    assert_eq!(config.sql_length_limit, 1000);
+    assert_eq!(config.non_equi_join_limit, 4);
+    assert_eq!(config.group_by_column_limit, 20);
+}
+
+#[cfg(feature = "lint-config")]
+#[test]
+fn from_toml_str_invalid_toml() {
+    let err = LintConfig::from_toml_str("this is not toml {{{").unwrap_err();
+    assert!(!err.is_empty(), "expected error for invalid TOML");
+}
+
+#[cfg(feature = "lint-config")]
+#[test]
+fn from_toml_str_unknown_field() {
+    // Unknown fields should be silently ignored by serde
+    let toml = r#"
+min_level = "caution"
+unknown_field = "whatever"
+"#;
+    let config = LintConfig::from_toml_str(toml).unwrap();
+    assert_eq!(config.min_level, WarningLevel::Caution);
+    // other fields should still have defaults
+    assert_eq!(config.min_confidence, Confidence::Partial);
+}
+
+#[cfg(feature = "lint-config")]
+#[test]
+fn from_toml_str_empty() {
+    // Empty TOML should produce default config
+    let config = LintConfig::from_toml_str("").unwrap();
+    assert_eq!(config.min_level, WarningLevel::Suggestion);
+    assert_eq!(config.min_confidence, Confidence::Partial);
+}

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -685,6 +685,44 @@ fn c016_autonomous_transaction() {
     assert!(has_rule(&w, "C016"), "expected C016 for AUTONOMOUS_TRANSACTION");
 }
 
+// ── C017: RAISE in EXCEPTION clears variables ──
+
+#[test]
+fn c017_raise_in_exception_bare_raise() {
+    let stmts = parse("DO $$ BEGIN NULL; EXCEPTION WHEN OTHERS THEN c2 := 5; RAISE; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C017"), "expected C017 for bare RAISE in EXCEPTION");
+}
+
+#[test]
+fn c017_raise_exception_in_exception() {
+    let stmts = parse("DO $$ BEGIN NULL; EXCEPTION WHEN OTHERS THEN RAISE EXCEPTION 'err'; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C017"), "expected C017 for RAISE EXCEPTION in EXCEPTION");
+}
+
+#[test]
+fn c017_raise_info_not_triggered() {
+    let stmts = parse("DO $$ BEGIN NULL; EXCEPTION WHEN OTHERS THEN RAISE INFO 'msg'; END $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C017"), "RAISE INFO should not trigger C017");
+}
+
+#[test]
+fn c017_no_exception_block_not_triggered() {
+    let stmts = parse("DO $$ BEGIN RAISE EXCEPTION 'err'; END $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C017"), "RAISE outside EXCEPTION should not trigger C017");
+}
+
+#[test]
+fn c017_nested_block_outer_exception() {
+    let stmts =
+        parse("DO $$ BEGIN BEGIN NULL; EXCEPTION WHEN OTHERS THEN RAISE; END; EXCEPTION WHEN OTHERS THEN NULL; END $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C017"), "expected C017 for nested block EXCEPTION with RAISE");
+}
+
 // ════════════════════════════════════════════════════════════════
 // Phase 2b: Suggestion rules (S001-S008)
 // ════════════════════════════════════════════════════════════════

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -723,6 +723,51 @@ fn c017_nested_block_outer_exception() {
     assert!(has_rule(&w, "C017"), "expected C017 for nested block EXCEPTION with RAISE");
 }
 
+// ── C018: Excessive INSERT VALUES rows ──
+
+#[test]
+fn c018_excessive_insert_values_trigger() {
+    let vals = (0..101).map(|i| format!("({i}, 'x')")).collect::<Vec<_>>().join(", ");
+    let sql = format!("INSERT INTO t (a, b) VALUES {vals}");
+    let stmts = parse(&sql);
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "C018"), "expected C018 for 101-row INSERT VALUES");
+}
+
+#[test]
+fn c018_insert_values_within_limit() {
+    let vals = (0..100).map(|i| format!("({i}, 'x')")).collect::<Vec<_>>().join(", ");
+    let sql = format!("INSERT INTO t (a, b) VALUES {vals}");
+    let stmts = parse(&sql);
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C018"), "100 rows should be within default limit");
+}
+
+#[test]
+fn c018_single_row_not_triggered() {
+    let stmts = parse("INSERT INTO t (a, b) VALUES (1, 'x')");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C018"), "single-row INSERT should not trigger C018");
+}
+
+#[test]
+fn c018_insert_select_not_triggered() {
+    let stmts = parse("INSERT INTO t (a, b) SELECT c, d FROM src");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "C018"), "INSERT SELECT should not trigger C018");
+}
+
+#[test]
+fn c018_custom_threshold() {
+    let vals = (0..51).map(|i| format!("({i}, 'x')")).collect::<Vec<_>>().join(", ");
+    let sql = format!("INSERT INTO t (a, b) VALUES {vals}");
+    let stmts = parse(&sql);
+    let config = LintConfig { max_insert_values_rows: 50, ..LintConfig::default() };
+    let linter = SqlLinter::with_default_rules(config);
+    let w = linter.lint(&stmts, None, Confidence::Full);
+    assert!(has_rule(&w, "C018"), "51 rows with threshold 50 should trigger C018");
+}
+
 // ════════════════════════════════════════════════════════════════
 // Phase 2b: Suggestion rules (S001-S008)
 // ════════════════════════════════════════════════════════════════
@@ -817,6 +862,7 @@ subquery_depth_limit = 5
 sql_length_limit = 1000
 non_equi_join_limit = 4
 group_by_column_limit = 20
+max_insert_values_rows = 200
 "#;
     let config = LintConfig::from_toml_str(toml).unwrap();
     assert_eq!(config.min_level, WarningLevel::Performance);
@@ -827,6 +873,7 @@ group_by_column_limit = 20
     assert_eq!(config.sql_length_limit, 1000);
     assert_eq!(config.non_equi_join_limit, 4);
     assert_eq!(config.group_by_column_limit, 20);
+    assert_eq!(config.max_insert_values_rows, 200);
 }
 
 #[cfg(feature = "lint-config")]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -9,6 +9,7 @@ use rmcp::tool;
 use rmcp::tool_router;
 use serde::Deserialize;
 
+use crate::linter::{build_lint_summary, Confidence, LintConfig, SqlLinter};
 use crate::token_formatter::{CommaStyle, FormatConfig, KeywordCase, TokenFormatter};
 
 // ── Parameter types ──────────────────────────────────────────────────────────
@@ -20,6 +21,9 @@ pub struct ParseParams {
     /// Whether to preserve comments in output
     #[serde(default)]
     pub preserve_comments: bool,
+    /// Enable SQL anti-pattern linting
+    #[serde(default)]
+    pub lint: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -60,6 +64,9 @@ pub struct FormatParams {
 pub struct ValidateParams {
     /// SQL text to validate
     pub sql: String,
+    /// Enable SQL anti-pattern linting
+    #[serde(default)]
+    pub lint: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -104,7 +111,7 @@ pub struct OgsqlServer;
 #[tool_router(server_handler)]
 impl OgsqlServer {
     #[tool(description = "Parse SQL into structured AST JSON with error reports and query fingerprints")]
-    fn parse(&self, Parameters(ParseParams { sql, preserve_comments }): Parameters<ParseParams>) -> String {
+    fn parse(&self, Parameters(ParseParams { sql, preserve_comments, lint }): Parameters<ParseParams>) -> String {
         let options = crate::ParseOptions { preserve_comments, mybatis_params: false };
         let output = crate::Parser::parse_sql_with_options(&sql, options);
 
@@ -132,6 +139,13 @@ impl OgsqlServer {
         }
         if !output.comments.is_empty() {
             out.as_object_mut().unwrap().insert("comments".to_string(), serde_json::json!(output.comments));
+        }
+        if lint {
+            let config = LintConfig::default();
+            let linter = SqlLinter::with_default_rules(config);
+            let lint_warnings = linter.lint(&output.statements, None, Confidence::Full);
+            out.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+            out.as_object_mut().unwrap().insert("lint_summary".to_string(), build_lint_summary(&lint_warnings));
         }
         serde_json::to_string_pretty(&out).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
     }
@@ -203,7 +217,7 @@ impl OgsqlServer {
     }
 
     #[tool(description = "Validate SQL syntax and report errors and warnings")]
-    fn validate(&self, Parameters(ValidateParams { sql }): Parameters<ValidateParams>) -> String {
+    fn validate(&self, Parameters(ValidateParams { sql, lint }): Parameters<ValidateParams>) -> String {
         let output = crate::Parser::parse_sql_with_options(
             &sql,
             crate::ParseOptions { preserve_comments: false, mybatis_params: false },
@@ -247,6 +261,13 @@ impl OgsqlServer {
                 .as_object_mut()
                 .unwrap()
                 .insert("merge_semantic_errors".to_string(), serde_json::json!(merge_errors));
+        }
+        if lint {
+            let config = LintConfig::default();
+            let linter = SqlLinter::with_default_rules(config);
+            let lint_warnings = linter.lint(&output.statements, None, Confidence::Full);
+            result.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
+            result.as_object_mut().unwrap().insert("lint_summary".to_string(), build_lint_summary(&lint_warnings));
         }
         serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e))
     }


### PR DESCRIPTION
## Summary

Adds a complete SQL anti-pattern detection (lint) system to ogsql-parser with 50 rules across 4 severity tiers, integrated into CLI, MCP, and HTTP API endpoints.

## Commits

| Commit | Description |
|--------|-------------|
| 2a25805 | Core framework + all 50 rules +  config + 88 tests |
| 30981af | CLI integration: `--lint`, `--lint-config`, `--min-level` for validate/parse/parse-xml/parse-java |
| 2f0c9d0 | MCP parse/validate tools: optional `lint: bool` parameter |
| 3cf0d9f | Design plan document |

## Rule Breakdown

| Level | Count | Examples |
|-------|-------|---------|
| 🔴 **Prohibition** | 9 | R001 SELECT *, R005 implicit type conversion, R006 missing WHERE |
| 🟡 **Performance** | 22 | P001 UNION without ALL, P003 large IN list, P021 INSERT in PL loop |
| ⚠️ **Caution** | 13 | C005 contradictory hints, C007 UPDATE without WHERE, C016 autonomous transaction |
| 💡 **Suggestion** | 6 | S001 DELETE → TRUNCATE, S005 %TYPE over hardcoded types |

## Integration Points

- `validate --lint` / `parse --lint` — CLI
- `parse-xml --lint` / `parse-java --lint` — with `Confidence::Partial`
- MCP `validate` / `parse` tools — optional `lint` parameter
- HTTP `/api/validate` — optional `lint` field
- `--lint-config` / `.ogsql-lint.toml` — config file support

## Verification

- ✅ 1814 tests passing
- ✅ `cargo clippy --all-features -- -D warnings`
- ✅ `cargo fmt --all -- --check`