### PR TITLE
feat: SQL anti-pattern lint system (54 rules, CLI/MCP/HTTP, config file)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -772,5 +772,5 @@ This is an active development project. Phases 1–6 are complete, and Phase 7 (O
 ---
 
 **Status / 状态**: Phase 1–6 Complete | 1646 unit tests | 1409/1409 regression tests passing  
-**Version / 版本**: 0.6.10  
+**Version / 版本**: 0.6.11  
 **Last Updated / 最后更新**: 2026-06-04

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -3073,6 +3073,7 @@ fn output_csv_validate_rows(
     stmts: &[ogsql_parser::StatementInfo],
     errors: &[ogsql_parser::ParserError],
     var_errors: &[ogsql_parser::UndefinedVariableError],
+    lint_warnings: &[ogsql_parser::linter::SqlWarning],
     file_name: &str,
     rel_dir: &str,
 ) {
@@ -3091,6 +3092,14 @@ fn output_csv_validate_rows(
         let stmt_var_errors: Vec<&ogsql_parser::UndefinedVariableError> = var_errors
             .iter()
             .filter(|ve| ve.location.as_ref().is_none_or(|sp| sp.start.line >= stmt_start && sp.start.line <= stmt_end))
+            .collect();
+
+        let stmt_lint_warnings: Vec<&ogsql_parser::linter::SqlWarning> = lint_warnings
+            .iter()
+            .filter(|w| {
+                let wline = w.location.line;
+                wline == 0 || (wline >= stmt_start && wline <= stmt_end)
+            })
             .collect();
 
         let rows = collect_validate_routine_rows(si);
@@ -3138,6 +3147,31 @@ fn output_csv_validate_rows(
                 })
                 .collect();
 
+            let row_lint: Vec<&&ogsql_parser::linter::SqlWarning> = stmt_lint_warnings
+                .iter()
+                .filter(|w| {
+                    let wline = w.location.line;
+                    let in_row = wline == 0 || (wline >= row.start_line && wline <= row.end_line);
+                    if !in_row {
+                        return false;
+                    }
+                    if is_parent_with_children {
+                        wline == 0 || !error_in_child(wline)
+                    } else {
+                        true
+                    }
+                })
+                .collect();
+
+            let mut warn_parts: Vec<String> = Vec::new();
+            if !row_parse_warn.is_empty() {
+                warn_parts.push(row_parse_warn);
+            }
+            let merged_lint = merge_lint_warnings(&row_lint);
+            if !merged_lint.is_empty() {
+                warn_parts.push(merged_lint);
+            }
+
             let mut err_parts: Vec<String> = Vec::new();
             if !row_parse_err.is_empty() {
                 err_parts.push(row_parse_err);
@@ -3151,13 +3185,15 @@ fn output_csv_validate_rows(
                 err_parts.push(format!("{} '{}' in {}{}", kind_label, ve.variable_name, ve.context, line_info));
             }
 
+            let parse_warn_count = row_parse_errors.iter().filter(|e| is_warning(e)).count();
             let error_count = {
                 let real_parse_err_count = row_parse_errors.iter().filter(|e| !is_warning(e)).count();
                 real_parse_err_count + row_var_errs.len()
             };
-            let warning_count = row_parse_errors.iter().filter(|e| is_warning(e)).count();
+            let warning_count = parse_warn_count + row_lint.len();
 
             let all_err = err_parts.join("; ");
+            let all_warn = warn_parts.join("; ");
             let is_valid = error_count == 0;
             println!(
                 "{},{},{},{},{},{},{},{},{},{},{},{},{}",
@@ -3173,10 +3209,39 @@ fn output_csv_validate_rows(
                 error_count,
                 warning_count,
                 csv_escape(&all_err),
-                csv_escape(&row_parse_warn),
+                csv_escape(&all_warn),
             );
         }
     }
+}
+
+fn merge_lint_warnings(warnings: &[&&ogsql_parser::linter::SqlWarning]) -> String {
+    use std::collections::BTreeMap;
+
+    let mut groups: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    for w in warnings {
+        groups.entry(&w.rule_id).or_default().push(w.location.line);
+    }
+
+    groups
+        .iter()
+        .map(|(rule_id, lines)| {
+            if lines.len() > 1 {
+                let mut unique_lines: Vec<usize> = lines.iter().copied().filter(|l| *l > 0).collect();
+                unique_lines.sort();
+                unique_lines.dedup();
+                if unique_lines.is_empty() {
+                    format!("{} (\u{00d7}{})", rule_id, lines.len())
+                } else {
+                    let line_strs: Vec<String> = unique_lines.iter().map(|l| l.to_string()).collect();
+                    format!("{} (\u{00d7}{}, lines {})", rule_id, lines.len(), line_strs.join(", "))
+                }
+            } else {
+                rule_id.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 /// Merge same-type error/warning messages, deduplicating identical text
@@ -3198,11 +3263,14 @@ fn merge_error_messages(errors: &[&ogsql_parser::ParserError], warn: bool) -> St
         .iter()
         .map(|(msg, lines)| {
             if lines.len() > 1 {
-                let line_nums: Vec<String> = lines.iter().filter(|l| **l > 0).map(|l| l.to_string()).collect();
-                if line_nums.is_empty() {
+                let mut unique_lines: Vec<usize> = lines.iter().copied().filter(|l| *l > 0).collect();
+                unique_lines.sort();
+                unique_lines.dedup();
+                if unique_lines.is_empty() {
                     format!("{} (\u{00d7}{})", msg, lines.len())
                 } else {
-                    format!("{} (\u{00d7}{}, lines {})", msg, lines.len(), line_nums.join(", "))
+                    let line_strs: Vec<String> = unique_lines.iter().map(|l| l.to_string()).collect();
+                    format!("{} (\u{00d7}{}, lines {})", msg, lines.len(), line_strs.join(", "))
                 }
             } else {
                 msg.clone()
@@ -3642,7 +3710,7 @@ fn cmd_validate_single(cli: &Cli, file_path: Option<&str>, csv: bool, strict: bo
             });
         }
         output_csv_validate_header();
-        output_csv_validate_rows(&stmts, &all_errors, &var_errors, file_name, ".");
+        output_csv_validate_rows(&stmts, &all_errors, &var_errors, &lint_warnings, file_name, ".");
         let real_errors: Vec<_> = errors.iter().filter(|e| !is_warning(e)).collect();
         let has_errors = !real_errors.is_empty() || !var_errors.is_empty();
         if has_errors {
@@ -3750,7 +3818,13 @@ fn cmd_validate_files(cli: &Cli, csv: bool, strict: bool) {
                     location: ogsql_parser::SourceLocation::default(),
                 });
             }
-            output_csv_validate_rows(&stmts, &all_errors, &var_errors, file_path, ".");
+            let lint_warnings = if cli.lint {
+                let config = build_lint_config(cli);
+                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+            } else {
+                vec![]
+            };
+            output_csv_validate_rows(&stmts, &all_errors, &var_errors, &lint_warnings, file_path, ".");
             let real_errors: Vec<_> = errors.iter().filter(|e| !is_warning(e)).collect();
             if !real_errors.is_empty() || !var_errors.is_empty() {
                 any_errors = true;
@@ -3979,7 +4053,13 @@ fn cmd_validate_dir(cli: &Cli, dir_paths: &[String], exts: &[String], csv: bool,
                     location: ogsql_parser::SourceLocation::default(),
                 });
             }
-            output_csv_validate_rows(&stmts, &all_errors, &var_errors, file_name, rel_dir);
+            let lint_warnings = if cli.lint {
+                let config = build_lint_config(cli);
+                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+            } else {
+                vec![]
+            };
+            output_csv_validate_rows(&stmts, &all_errors, &var_errors, &lint_warnings, file_name, rel_dir);
         } else if cli.json {
             if !real_errors.is_empty() {
                 all_results.push((

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -3191,7 +3191,7 @@ fn merge_error_messages(errors: &[&ogsql_parser::ParserError], warn: bool) -> St
             continue;
         }
         let line = error_line(e);
-        groups.entry(e.to_string()).or_default().push(line);
+        groups.entry(display_key(e)).or_default().push(line);
     }
 
     groups
@@ -3200,9 +3200,9 @@ fn merge_error_messages(errors: &[&ogsql_parser::ParserError], warn: bool) -> St
             if lines.len() > 1 {
                 let line_nums: Vec<String> = lines.iter().filter(|l| **l > 0).map(|l| l.to_string()).collect();
                 if line_nums.is_empty() {
-                    format!("{} (×{})", msg, lines.len())
+                    format!("{} (\u{00d7}{})", msg, lines.len())
                 } else {
-                    format!("{} (×{}, lines {})", msg, lines.len(), line_nums.join(", "))
+                    format!("{} (\u{00d7}{}, lines {})", msg, lines.len(), line_nums.join(", "))
                 }
             } else {
                 msg.clone()
@@ -3210,6 +3210,27 @@ fn merge_error_messages(errors: &[&ogsql_parser::ParserError], warn: bool) -> St
         })
         .collect::<Vec<_>>()
         .join("; ")
+}
+
+/// Extract the display message from a ParserError without location info,
+/// so that same-type errors at different positions are grouped together.
+fn display_key(e: &ogsql_parser::ParserError) -> String {
+    match e {
+        ogsql_parser::ParserError::Warning { message, .. } => message.clone(),
+        ogsql_parser::ParserError::ReservedKeywordAsIdentifier { keyword, .. } => {
+            format!("reserved keyword \"{}\" cannot be used as identifier", keyword)
+        }
+        ogsql_parser::ParserError::UnexpectedToken { expected, got, .. } => {
+            format!("expected {}, got {}", expected, got)
+        }
+        ogsql_parser::ParserError::UnexpectedEof { expected, .. } => {
+            format!("unexpected end of input: expected {}", expected)
+        }
+        ogsql_parser::ParserError::UnsupportedSyntax { syntax, hint, .. } => {
+            format!("{} ({})", syntax, hint)
+        }
+        _ => e.to_string(),
+    }
 }
 
 fn filter_errors_for_row(


### PR DESCRIPTION
## Summary

SQL anti-pattern detection system with 54 lint rules, CLI/MCP/HTTP integration, and config file support.

### Core Framework
- `src/linter/mod.rs`: SqlLinter engine, LintConfig (with TOML config file support), StatementInfo dispatch, build_lint_summary API

### Rules (54 total)
- **Prohibition (R001–R009)**: SELECT *, NATURAL JOIN, implicit type conversion, non-SARGable, ORDER BY constant, UNION without ALL, FLOAT/REAL primary key, correlated subquery, cursor in loop
- **Performance (P001–P022)**: IN list >500, OR in WHERE, subquery >3 levels, DISTINCT, ORDER BY in subquery, function in WHERE, non-equi join >2, GROUP BY >10 cols, UNION ALL over UNION, SELECT in EXISTS, JOIN without condition, SELECT star GaussDB-specific, function instead of CASE, INSERT in PL loop, INSERT SELECT no columns, multi-table update, INSERT ALL multi-table, EXPLAIN in production
- **Caution (C001–C018)**: Unknown/contradictory/table-not-in-from hints, UPDATE/DELETE without WHERE, INSERT no column list, unlogged table, DML on system catalog, implicit COMMIT, SELECT FOR UPDATEmisuse, non-deterministic NOT IN, ORDER BY column not in SELECT, LIKE leading wildcard, COMMIT/ROLLBACK in PL, autonomous transaction, RAISE in EXCEPTION clears variables, excessive INSERT VALUES (>100 rows)
- **Suggestion (S001–S008)**: DELETE full table → TRUNCATE, COUNT(*) check → EXISTS, DISTINCT UNION → UNION DISTINCT, CREATE TABLE without tablespace, subquery → JOIN, COALESCE chain → CASE, HAVING without GROUP BY, SQL text too long

### CLI Integration
- `validate --lint` / `validate --lint-config .ogsql-lint.toml` / `validate --csv --lint`
- `parse --lint` / `parse-xml --lint` / `parse-java --lint`
- CSV output: lint warnings merged into warnings column with rule-level dedup

### Config File
- `.ogsql-lint.toml` support with XDG path search
- Configurable thresholds: in_list_threshold, subquery_depth_limit, max_insert_values_rows, etc.

### Bug Fixes (this PR also includes)
- Parser warning dedup in CSV output (display_key strips position from grouping key)
- Lint warnings now included in `validate --csv --lint` output
- Line number dedup in merge functions

### Version
Bumped to 0.6.11.

### Commits (9)
```
2a25805 feat: add SQL linter core framework with 50 anti-pattern rules
30981af feat(ogsql): integrate --lint into CLI
2f0c9d0 feat(mcp): add lint support to parse and validate tools
3cf0d9f docs: add SQL lint plan document
4cee34f feat(linter): add C017 raise-in-exception-clears-variables
64896da feat(linter): add C018 excessive-insert-values rule
9755bf8 chore: bump version to 0.6.11
f6986bb fix(cli): dedup same-type parser warnings in validate --csv output
efcc6e4 fix(cli): include lint warnings in validate --csv output
```