### PR TITLE
fix(cli): show lint warning message in validate --lint --csv output

### DIFF
--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -3219,26 +3219,35 @@ fn output_csv_validate_rows(
 fn merge_lint_warnings(warnings: &[&&ogsql_parser::linter::SqlWarning]) -> String {
     use std::collections::BTreeMap;
 
-    let mut groups: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    struct Group {
+        message: String,
+        lines: Vec<usize>,
+    }
+    let mut groups: BTreeMap<&str, Group> = BTreeMap::new();
     for w in warnings {
-        groups.entry(&w.rule_id).or_default().push(w.location.line);
+        groups
+            .entry(&w.rule_id)
+            .or_insert_with(|| Group { message: w.message.clone(), lines: Vec::new() })
+            .lines
+            .push(w.location.line);
     }
 
     groups
         .iter()
-        .map(|(rule_id, lines)| {
-            if lines.len() > 1 {
-                let mut unique_lines: Vec<usize> = lines.iter().copied().filter(|l| *l > 0).collect();
+        .map(|(rule_id, group)| {
+            let label = format!("{}: {}", rule_id, group.message);
+            if group.lines.len() > 1 {
+                let mut unique_lines: Vec<usize> = group.lines.iter().copied().filter(|l| *l > 0).collect();
                 unique_lines.sort();
                 unique_lines.dedup();
                 if unique_lines.is_empty() {
-                    format!("{} (\u{00d7}{})", rule_id, lines.len())
+                    format!("{} (\u{00d7}{})", label, group.lines.len())
                 } else {
                     let line_strs: Vec<String> = unique_lines.iter().map(|l| l.to_string()).collect();
-                    format!("{} (\u{00d7}{}, lines {})", rule_id, lines.len(), line_strs.join(", "))
+                    format!("{} (\u{00d7}{}, lines {})", label, group.lines.len(), line_strs.join(", "))
                 }
             } else {
-                rule_id.to_string()
+                label
             }
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
## 问题

`validate --lint --csv` 的 warnings 列对于带编号的 lint warning（如 P003、R001），仅显示编号和次数/行号，不显示具体 warning 信息。

**之前：**
- 单条: `P003`
- 多条: `P003 (×3, lines 5, 10, 15)`

## 修复

在 `merge_lint_warnings` 中将 `rule_id` 与 `message` 组合输出。

**之后：**
- 单条: `P003: IN list 超过 500 个元素`
- 多条: `P003: IN list 超过 500 个元素 (×3, lines 5, 10, 15)`