### PR TITLE
fix(parser): support ALTER LARGE SEQUENCE, ALTER SEQUENCE OWNER TO, and Float in WITH options

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2386,6 +2386,7 @@ pub enum AlterSchemaAction {
 pub struct AlterSequenceStatement {
     pub name: ObjectName,
     pub options: Vec<SequenceOption>,
+    pub is_large: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -2399,6 +2400,7 @@ pub enum SequenceOption {
     Cycle(bool),
     NoCycle,
     OwnedBy { owner: ObjectName },
+    OwnerTo { owner: ObjectName },
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -4872,9 +4872,13 @@ impl SqlFormatter {
                 SequenceOption::OwnedBy { owner } => {
                     format!("{} {}", self.kw("OWNED BY"), self.format_object_name(owner))
                 }
+                SequenceOption::OwnerTo { owner } => {
+                    format!("{} {}", self.kw("OWNER TO"), self.format_object_name(owner))
+                }
             })
             .collect();
-        format!("{} {} {}", self.kw("ALTER SEQUENCE"), self.format_object_name(&stmt.name), opts.join(" "))
+        let prefix = if stmt.is_large { self.kw("ALTER LARGE SEQUENCE") } else { self.kw("ALTER SEQUENCE") };
+        format!("{} {} {}", prefix, self.format_object_name(&stmt.name), opts.join(" "))
     }
 
     fn format_alter_function(&self, stmt: &AlterFunctionStatement) -> String {

--- a/src/parser/ddl/table.rs
+++ b/src/parser/ddl/table.rs
@@ -371,6 +371,10 @@ impl Parser {
                             self.advance();
                             kw.as_str().to_string()
                         }
+                        Token::Float(f) => {
+                            self.advance();
+                            f
+                        }
                         _ => {
                             return Err(ParserError::UnexpectedToken {
                                 location: self.current_location(),
@@ -468,6 +472,10 @@ impl Parser {
                         Token::Keyword(kw) => {
                             self.advance();
                             kw.as_str().to_string()
+                        }
+                        Token::Float(f) => {
+                            self.advance();
+                            f
                         }
                         _ => {
                             return Err(ParserError::UnexpectedToken {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4412,17 +4412,36 @@ impl Parser {
                 },
                 Some(Keyword::LARGE_P) => {
                     self.advance();
-                    match self.parse_alter_large_object() {
-                        Ok(stmt) => {
-                            self.try_consume_semicolon();
-                            crate::ast::Statement::AlterLargeObject(crate::ast::Spanned::new(
-                                stmt,
-                                Some(crate::ast::SourceSpan { start, end: self.prev_location() }),
-                            ))
+                    if self.match_keyword(Keyword::SEQUENCE) {
+                        self.advance();
+                        self.parse_if_exists();
+                        match self.parse_alter_sequence_inner() {
+                            Ok(mut stmt) => {
+                                stmt.is_large = true;
+                                self.try_consume_semicolon();
+                                crate::ast::Statement::AlterSequence(crate::ast::Spanned::new(
+                                    stmt,
+                                    Some(crate::ast::SourceSpan { start, end: self.prev_location() }),
+                                ))
+                            }
+                            Err(e) => {
+                                self.add_error(e);
+                                self.skip_to_semicolon()
+                            }
                         }
-                        Err(e) => {
-                            self.add_error(e);
-                            self.skip_to_semicolon()
+                    } else {
+                        match self.parse_alter_large_object() {
+                            Ok(stmt) => {
+                                self.try_consume_semicolon();
+                                crate::ast::Statement::AlterLargeObject(crate::ast::Spanned::new(
+                                    stmt,
+                                    Some(crate::ast::SourceSpan { start, end: self.prev_location() }),
+                                ))
+                            }
+                            Err(e) => {
+                                self.add_error(e);
+                                self.skip_to_semicolon()
+                            }
                         }
                     }
                 }

--- a/src/parser/utility/statements.rs
+++ b/src/parser/utility/statements.rs
@@ -867,6 +867,10 @@ impl Parser {
 
     pub(crate) fn parse_alter_sequence(&mut self) -> Result<AlterSequenceStatement, ParserError> {
         self.expect_keyword(Keyword::SEQUENCE)?;
+        self.parse_alter_sequence_inner()
+    }
+
+    pub(crate) fn parse_alter_sequence_inner(&mut self) -> Result<AlterSequenceStatement, ParserError> {
         let name = self.parse_object_name()?;
         let mut options = Vec::new();
 
@@ -930,6 +934,12 @@ impl Parser {
                     let owner = self.parse_object_name()?;
                     options.push(SequenceOption::OwnedBy { owner });
                 }
+                Some(Keyword::OWNER) => {
+                    self.advance();
+                    self.expect_keyword(Keyword::TO)?;
+                    let owner = self.parse_object_name()?;
+                    options.push(SequenceOption::OwnerTo { owner });
+                }
                 Some(Keyword::NO) => {
                     self.advance();
                     match self.peek_keyword() {
@@ -952,7 +962,7 @@ impl Parser {
             }
         }
 
-        Ok(AlterSequenceStatement { name, options })
+        Ok(AlterSequenceStatement { name, options, is_large: false })
     }
 
     pub(crate) fn parse_integer_literal(&mut self) -> Result<i64, ParserError> {


### PR DESCRIPTION
## Summary

Fix three parser bugs found in production SQL files:

1. **Float values in WITH options** — `CREATE TABLE ... WITH (autovacuum_vacuum_scale_factor=0.1)` failed because the option value parser only accepted `StringLiteral`, `Ident`, `Integer`, and `Keyword` tokens. Added `Token::Float` handling at both WITH parsing locations in `table.rs`.

2. **`ALTER SEQUENCE ... OWNER TO`** — `SequenceOption` enum lacked an `OwnerTo` variant. Added the variant to the AST, parser, and formatter.

3. **`ALTER LARGE SEQUENCE`** — The `LARGE_P` branch in `dispatch_alter()` only routed to `parse_alter_large_object()`. Added lookahead for `SEQUENCE` keyword after `LARGE_P`, routing to the alter sequence parser with `is_large = true`. Supports `IF EXISTS` variant. Added `is_large` field to `AlterSequenceStatement` for round-trip fidelity.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `cargo test --all-features` — 16/16 pass
- [x] `ALTER LARGE SEQUENCE bigfund.log_seq OWNER TO bigfund;` → VALID
- [x] `ALTER SEQUENCE bigfund.note_pkg_seq OWNER TO bigfund;` → VALID
- [x] `CREATE TABLE t (x int) WITH (autovacuum_vacuum_scale_factor=0.1);` → VALID
- [x] `ALTER LARGE SEQUENCE IF EXISTS seq OWNER TO owner;` → VALID