### PR TITLE
feat(parser): support ORDER BY and LIMIT in UPDATE statements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1587,6 +1587,12 @@ pub struct UpdateStatement {
     pub assignments: Vec<UpdateAssignment>,
     pub from: Vec<TableRef>,
     pub where_clause: Option<Expr>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub order_by: Option<Vec<OrderByItem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub limit: Option<Expr>,
     pub returning: Vec<SelectTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -770,6 +770,20 @@ fn walk_update(visitor: &mut dyn Visitor, update: &UpdateStatement) -> VisitorRe
         }
     }
 
+    if let Some(ref order_by) = update.order_by {
+        for item in order_by {
+            if walk_expr(visitor, &item.expr) == VisitorResult::Stop {
+                return VisitorResult::Stop;
+            }
+        }
+    }
+
+    if let Some(ref limit) = update.limit {
+        if walk_expr(visitor, limit) == VisitorResult::Stop {
+            return VisitorResult::Stop;
+        }
+    }
+
     VisitorResult::Continue
 }
 

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1753,6 +1753,46 @@ impl SqlFormatter {
             parts.push(format!("{} {}", self.kw("WHERE"), self.format_expr(where_clause)));
         }
 
+        if let Some(order_by) = &stmt.order_by {
+            let items: Vec<String> = order_by
+                .iter()
+                .map(|item| {
+                    let mut s = self.format_expr(&item.expr);
+                    match item.asc {
+                        Some(true) => {
+                            s.push(' ');
+                            s.push_str(&self.kw("ASC"));
+                        }
+                        Some(false) => {
+                            s.push(' ');
+                            s.push_str(&self.kw("DESC"));
+                        }
+                        None => {}
+                    }
+                    if let Some(nf) = item.nulls_first {
+                        s.push(' ');
+                        if nf {
+                            s.push_str(&self.kw("NULLS FIRST"));
+                        } else {
+                            s.push_str(&self.kw("NULLS LAST"));
+                        }
+                    }
+                    if let Some(ref using) = item.using {
+                        s.push(' ');
+                        s.push_str(&self.kw("USING"));
+                        s.push(' ');
+                        s.push_str(&self.format_expr(using));
+                    }
+                    s
+                })
+                .collect();
+            parts.push(format!("{} {}", self.kw("ORDER BY"), items.join(", ")));
+        }
+
+        if let Some(limit) = &stmt.limit {
+            parts.push(format!("{} {}", self.kw("LIMIT"), self.format_expr(limit)));
+        }
+
         if !stmt.returning.is_empty() {
             parts.push(format!("{} {}", self.kw("RETURNING"), self.format_select_targets(&stmt.returning)));
         }

--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -370,6 +370,57 @@ impl Parser {
         } else {
             None
         };
+        let order_by = if self.match_keyword(Keyword::ORDER) {
+            self.advance();
+            self.expect_keyword(Keyword::BY)?;
+            let mut items = Vec::new();
+            loop {
+                let expr = self.parse_expr()?;
+                let asc = match self.peek_keyword() {
+                    Some(Keyword::ASC) => {
+                        self.advance();
+                        Some(true)
+                    }
+                    Some(Keyword::DESC) => {
+                        self.advance();
+                        Some(false)
+                    }
+                    _ => None,
+                };
+                let nulls_first = if self.match_keyword(Keyword::NULLS_P) {
+                    self.advance();
+                    if self.match_keyword(Keyword::FIRST_P) {
+                        self.advance();
+                        Some(true)
+                    } else {
+                        self.expect_keyword(Keyword::LAST_P)?;
+                        Some(false)
+                    }
+                } else {
+                    None
+                };
+                items.push(OrderByItem { expr, asc, nulls_first, using: None });
+                if !self.match_token(&Token::Comma) {
+                    break;
+                }
+                self.advance();
+            }
+            Some(items)
+        } else {
+            None
+        };
+        let limit = if self.match_keyword(Keyword::LIMIT) {
+            self.advance();
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+        if order_by.is_some() && limit.is_none() {
+            self.add_error(ParserError::Warning {
+                message: "UPDATE ORDER BY without LIMIT has no effect on row update order".to_string(),
+                location: self.prev_location(),
+            });
+        }
         let (returning, into_targets, bulk_collect) = if self.match_keyword(Keyword::RETURNING) {
             self.advance();
             let returning = self.parse_target_list()?;
@@ -400,6 +451,8 @@ impl Parser {
             assignments,
             from,
             where_clause,
+            order_by,
+            limit,
             returning,
             into_targets,
             bulk_collect,

--- a/src/parser/select.rs
+++ b/src/parser/select.rs
@@ -877,7 +877,15 @@ impl Parser {
                 self.advance();
                 stmt.limit = None;
             } else {
-                stmt.limit = Some(self.parse_expr()?);
+                let expr = self.parse_expr()?;
+                if self.match_token(&Token::Comma) {
+                    // GaussDB syntax: LIMIT offset, count
+                    self.advance();
+                    stmt.offset = Some(expr);
+                    stmt.limit = Some(self.parse_expr()?);
+                } else {
+                    stmt.limit = Some(expr);
+                }
             }
         }
         if self.match_keyword(Keyword::OFFSET) {
@@ -892,7 +900,15 @@ impl Parser {
             if self.match_keyword(Keyword::ALL) {
                 self.advance();
             } else {
-                stmt.limit = Some(self.parse_expr()?);
+                let expr = self.parse_expr()?;
+                if self.match_token(&Token::Comma) {
+                    // GaussDB syntax: LIMIT offset, count
+                    self.advance();
+                    stmt.offset = Some(expr);
+                    stmt.limit = Some(self.parse_expr()?);
+                } else {
+                    stmt.limit = Some(expr);
+                }
             }
         }
         stmt.fetch = self.parse_fetch_clause()?;
@@ -1136,24 +1152,30 @@ impl Parser {
             }
         }
 
-        let limit = if self.match_keyword(Keyword::LIMIT) {
+        let (limit, mut offset) = if self.match_keyword(Keyword::LIMIT) {
             self.advance();
             if self.match_keyword(Keyword::ALL) {
                 self.advance();
-                None
+                (None, None)
             } else {
-                Some(self.parse_expr()?)
+                let expr = self.parse_expr()?;
+                if self.match_token(&Token::Comma) {
+                    // GaussDB syntax: LIMIT offset, count
+                    self.advance();
+                    let count = self.parse_expr()?;
+                    (Some(count), Some(expr))
+                } else {
+                    (Some(expr), None)
+                }
             }
         } else {
-            None
+            (None, None)
         };
 
-        let offset = if self.match_keyword(Keyword::OFFSET) {
+        if offset.is_none() && self.match_keyword(Keyword::OFFSET) {
             self.advance();
-            Some(self.parse_expr()?)
-        } else {
-            None
-        };
+            offset = Some(self.parse_expr()?);
+        }
 
         Ok(ValuesStatement { rows, order_by, limit, offset })
     }


### PR DESCRIPTION
## Changes

### 1. UPDATE ORDER BY and LIMIT (`f663b03`, `7572d6b`)
- Support `ORDER BY` and `LIMIT` clauses in UPDATE statements (openGauss/GaussDB extension)
- Support multi-table UPDATE syntax
- Add formatter and visitor support for new clauses
- Add lint warning when ORDER BY is used without LIMIT

### 2. SELECT LIMIT `offset,count` comma syntax (`a2b0ae0`)
- Support GaussDB `LIMIT offset, count` comma syntax in SELECT and VALUES statements
- Per openGauss backend grammar rule `limit_offcnt_clause` (gram.y:23891)
- Examples: `SELECT * FROM t LIMIT 0,1` → offset=0, limit=1
- Existing syntax unaffected: `LIMIT count`, `LIMIT count OFFSET offset`, `OFFSET offset LIMIT count`, `LIMIT ALL`

## Verification
- `cargo test --all-features`: 1772 passed, 0 failed
- `cargo clippy --all-features -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean