### PR TITLE
fix: tokenizer ||-- comment handling + ibatis flatten separator/comma fixes

### DIFF
--- a/src/ibatis/flatten.rs
+++ b/src/ibatis/flatten.rs
@@ -52,7 +52,22 @@ pub fn flatten_sql(node: &SqlNode) -> String {
             apply_trim(&content, Some("WHERE"), None, Some("AND |OR "), None)
         }
         SqlNode::Set { children } => {
-            let content = flatten_children(children);
+            let parts: Vec<String> =
+                children.iter().map(|c| flatten_sql(c).trim().to_string()).filter(|s| !s.is_empty()).collect();
+            if parts.is_empty() {
+                return String::new();
+            }
+            let mut content = String::new();
+            for (i, part) in parts.iter().enumerate() {
+                if i > 0 {
+                    let prev_needs_sep = !parts[i - 1].ends_with(',');
+                    let cur_needs_sep = !part.starts_with(',');
+                    if prev_needs_sep && cur_needs_sep {
+                        content.push(',');
+                    }
+                }
+                content.push_str(part);
+            }
             apply_trim(&content, Some("SET"), None, None, Some(","))
         }
         SqlNode::Trim { prefix, suffix, prefix_overrides, suffix_overrides, children } => {
@@ -83,7 +98,8 @@ pub fn flatten_sql(node: &SqlNode) -> String {
 }
 
 fn flatten_children(children: &[SqlNode]) -> String {
-    let raw: String = children.iter().map(flatten_sql).collect();
+    let parts: Vec<String> = children.iter().map(flatten_sql).collect();
+    let raw = parts.join(" ");
     deduplicate_conjunctions(&raw)
 }
 

--- a/src/token/tokenizer.rs
+++ b/src/token/tokenizer.rs
@@ -710,6 +710,11 @@ impl<'a> Tokenizer<'a> {
                 let start = self.pos - c.len_utf8();
                 while let Some(&nc) = self.chars.peek() {
                     if is_op_char(nc) {
+                        // Don't consume -- (line comment start) as part of an operator.
+                        // Break here so skip_whitespace_and_comments can recognize it.
+                        if nc == '-' && self.peek_byte_at(1) == Some(b'-') {
+                            break;
+                        }
                         self.chars.next();
                         self.pos += nc.len_utf8();
                     } else {


### PR DESCRIPTION
## Summary

Three fixes for MyBatis/iBatis XML parsing false-positive errors.

### 1. Tokenizer: `||--` line comment consumed as operator (`tokenizer.rs`)
- **Problem**: Greedy operator scanning consumed `||--` as a single `Token::Op("||--")` because `is_op_char(-)` is `true`. This prevented `--` from being recognized as a line comment.
- **Fix**: Break the scan loop when the next two bytes are `--`, letting `skip_whitespace_and_comments` handle them as a line comment.

### 2. Flatten: `<if>` tag concatenation missing separator (`flatten.rs`)
- **Problem**: `flatten_children` concatenated children directly. Adjacent `<if>` outputs could merge without whitespace (e.g. `__param__and`).
- **Fix**: Change from direct `collect()` to `join(" ")` to ensure at least one space between children.

### 3. Flatten: `<set>` with `<if>` missing commas (`flatten.rs`)
- **Problem**: `<set>` flatten joined all `<if>` assignment blocks without inserting commas between them.
- **Fix**: Iterate children, trim whitespace, and smart-insert commas between non-empty parts (skipping when either neighbor already has a comma).

## Test plan
- [x] 1400 lib tests pass
- [x] 51 tokenizer tests pass
- [x] clippy clean