### PR TITLE
feat(linter): index-aware R006/R007 — 索引感知的函数表达式 warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 description = "A SQL parser for openGauss/GaussDB written in Rust"
 license = "MIT OR Apache-2.0"

--- a/docs/plans/2026-06-09-index-aware-r006.md
+++ b/docs/plans/2026-06-09-index-aware-r006.md
@@ -1,0 +1,901 @@
+# Index-Aware R006 / 索引感知的函数表达式 Warning 实施方案
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让 R006（函数包裹列导致索引失效）和 R007（LIKE 前导通配符）具备索引感知能力：仅在列有索引时才触发 warning，无索引列不误报。同时扩展 SARGability 检测覆盖算术运算、类型转换、字符串拼接等非函数表达式模式。
+
+**Architecture:** 扩展现有 `SchemaMap` 类型增加可选的索引元数据（保持向后兼容），新增 `IndexMap` 类型辅助快速查询。改造 R006/R007 的检查函数，在 schema 包含索引信息时走精细化路径，无索引信息时保持原有全量 warning 行为。
+
+**Tech Stack:** Rust, 已有 `SchemaMap` + `LintConfig` + linter 基础设施
+
+---
+
+## Background / 背景说明
+
+### 现状
+
+| 组件 | 位置 | 现状 |
+|------|------|------|
+| SchemaMap | `src/analyzer/schema.rs` | `HashMap<String, HashMap<String, String>>`，仅存储 表→列→类型 |
+| R006 | `src/linter/rules_prohibition.rs:304` | 检测 WHERE 中函数包裹列，不区分是否有索引，全量 warning |
+| R007 | `src/linter/rules_prohibition.rs:348` | 检测 LIKE 前导通配符，不区分是否有索引 |
+| Schema JSON | CLI `--schema-json` | 仅提供列类型信息，无索引元数据 |
+
+### 问题
+
+1. **误报过多**：`WHERE substr(no_index_col, 1, 5) = 'abc'` 对无索引列也报 warning
+2. **漏检**：`WHERE col + 1 = 10`（算术运算）、`WHERE col::text = 'abc'`（类型转换）等非 FunctionCall 的 SARGability 破坏模式未覆盖
+3. **无索引感知基础设施**：Schema 中没有索引元数据
+
+### 设计约束
+
+1. **向后兼容**：新的 Schema JSON 格式必须兼容旧格式（索引信息为可选字段）
+2. **无 schema 时保持现有行为**：未提供 schema 或 schema 中无索引信息时，R006/R007 保持当前全量 warning
+3. **不修改 parser 核心**：仅扩展 linter 和 schema 模块
+
+---
+
+## Schema JSON 格式扩展
+
+### 现有格式（v1，保持兼容）
+
+```json
+{
+  "users": {
+    "id": "integer",
+    "name": "varchar(100)",
+    "email": "varchar(200)"
+  }
+}
+```
+
+### 新增索引格式（v2，向后兼容）
+
+在现有列类型映射的基础上，增加一个可选的 `"_indexes"` 键：
+
+```json
+{
+  "users": {
+    "id": "integer",
+    "name": "varchar(100)",
+    "email": "varchar(200)",
+    "description": "text",
+    "_indexes": {
+        "idx_users_name": ["name"],
+        "idx_users_email_lower": ["lower(email)"],
+        "pk_users": ["id"],
+        "idx_users_name_email": ["name", "email"]
+    }
+  }
+}
+```
+
+### 格式说明
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `"_indexes"` | `Object<String, String[]>` | 可选。键为索引名，值为列名数组 |
+| 纯列名 | `["name"]` | 普通索引，直接引用列 |
+| 函数表达式 | `["lower(email)"]` | 函数索引，解析后可用于消除 R006 误报 |
+| 多列 | `["name", "email"]` | 复合索引 |
+
+**向后兼容性**：旧格式 JSON（无 `_indexes` 键）照常工作，`load_schema` 正常解析，linter 走原有的无索引信息路径。
+
+---
+
+## New Types / 新增类型
+
+### `src/analyzer/schema.rs`
+
+```rust
+/// 索引信息：索引名 → 索引列（或函数表达式）
+/// key = 索引名（小写），value = 索引表达式列表
+pub type IndexMap = HashMap<String, HashMap<String, Vec<String>>>;
+
+/// 列级索引查找表：table → column → bool（该列是否有索引覆盖）
+/// 用于 R006/R007 快速判断列是否有索引
+pub type ColumnIndexMap = HashMap<String, HashMap<String, bool>>;
+
+/// 从 SchemaMap 中提取索引信息。
+/// 返回 (IndexMap, ColumnIndexMap)。
+/// 如果 SchemaMap 中没有 "_indexes" 键，IndexMap 为空但 ColumnIndexMap 仍可从非 "_indexes" 键推断。
+pub fn extract_index_info(schema: &SchemaMap) -> (IndexMap, ColumnIndexMap) {
+    let mut index_map: IndexMap = HashMap::new();
+    let mut col_index_map: ColumnIndexMap = HashMap::new();
+
+    for (table, columns) in schema {
+        let table_lower = table.to_lowercase();
+        if let Some(indexes_raw) = columns.get("_indexes") {
+            // 解析 _indexes: JSON 值是 serialized Vec<String>
+            // 但 SchemaMap 中 value 是 String，实际我们存储时需要特殊处理
+            // 见下文讨论
+        }
+    }
+
+    (index_map, col_index_map)
+}
+```
+
+**关键设计决策：`_indexes` 在 `SchemaMap` 中的存储方式**
+
+`SchemaMap` 当前类型为 `HashMap<String, HashMap<String, String>>`，value 是纯 String。要存储索引信息（索引名 → 列数组），有两种选择：
+
+**方案 A：修改 SchemaMap 类型（破坏性）**
+
+```rust
+pub type SchemaMap = HashMap<String, HashMap<String, serde_json::Value>>;
+```
+
+这会破坏所有使用 `SchemaMap` 的现有代码。
+
+**方案 B（推荐）：独立的 IndexMap，双 JSON 加载**
+
+保持 `SchemaMap` 不变。新增 `IndexMap` 类型。CLI 加载时从一个独立的 JSON 字段或独立文件解析索引信息：
+
+```rust
+/// 完整的 schema 信息，包含列类型和索引
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FullSchema {
+    /// 列类型信息（原有格式）
+    #[serde(default)]
+    pub columns: SchemaMap,
+    /// 索引信息（新增，可选）
+    #[serde(default)]
+    pub indexes: IndexMapV2,
+}
+
+/// 索引信息 v2
+/// { "table_name": { "index_name": ["col1", "col2"] } }
+pub type IndexMapV2 = HashMap<String, HashMap<String, Vec<String>>>;
+```
+
+JSON 格式变为：
+
+```json
+{
+  "columns": {
+    "users": {
+      "id": "integer",
+      "name": "varchar(100)"
+    }
+  },
+  "indexes": {
+    "users": {
+      "idx_users_name": ["name"],
+      "pk_users_id": ["id"]
+    }
+  }
+}
+```
+
+**向后兼容**：旧格式 JSON（直接是 `{"users": {"id": "integer"}}`，无 `columns`/`indexes` 键）仍可作为 `SchemaMap` 加载。新的 `FullSchema` 提供了索引信息。
+
+**方案 C（最简改动）：`_indexes` 约定 + 字符串编码**
+
+在现有 `SchemaMap` 中用 `"_indexes"` 作为特殊 key，其 value 是 JSON 编码的字符串：
+
+```json
+{
+  "users": {
+    "id": "integer",
+    "name": "varchar(100)",
+    "_indexes": "{\"idx_users_name\":[\"name\"],\"pk_users_id\":[\"id\"]}"
+  }
+}
+```
+
+这样 `SchemaMap` 类型完全不变，`load_schema` 不改。R006 在需要时解析 `_indexes` 的 JSON 字符串。
+
+**权衡**：方案 C 最简单（零类型变更），但 `_indexes` value 是 JSON-in-string，不够优雅。方案 B 更规范但需要修改加载逻辑和 linter 签名。
+
+**最终选择：方案 B**，原因：
+1. 类型安全，serde 直接反序列化
+2. JSON 格式清晰可读
+3. 旧的纯列类型 JSON 仍可通过 `SchemaMap` 加载（不破坏）
+4. 新格式通过 `FullSchema` 加载，提供索引信息
+
+---
+
+## Implementation Plan
+
+### Task 1: 扩展 Schema 类型系统
+
+**Files:**
+- Modify: `src/analyzer/schema.rs`
+- Test: `src/analyzer/schema.rs` (inline `#[cfg(test)]`)
+
+**Step 1: 添加新类型**
+
+在 `src/analyzer/schema.rs` 中添加：
+
+```rust
+/// 索引信息：table_name（小写）→ index_name → 索引列/表达式列表
+pub type IndexMapV2 = HashMap<String, HashMap<String, Vec<String>>>;
+
+/// 完整 schema 信息（列类型 + 索引）
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FullSchema {
+    /// 列类型：table → column → data_type
+    #[serde(default)]
+    pub columns: SchemaMap,
+    /// 索引：table → index_name → [col_or_expr, ...]
+    #[serde(default)]
+    pub indexes: IndexMapV2,
+}
+
+/// 从文件加载 FullSchema（列类型 + 索引）
+pub fn load_full_schema(path: &str) -> Result<FullSchema, String> {
+    let content = std::fs::read_to_string(path).map_err(|e| format!("Failed to read schema file '{}': {}", path, e))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse schema JSON: {e}"))
+}
+
+/// 从 IndexMapV2 构建列级索引查找表
+/// 返回: table（小写）→ column（小写）→ true（该列被某个索引覆盖）
+pub fn build_column_index_set(indexes: &IndexMapV2) -> HashMap<String, HashSet<String>> {
+    let mut result: HashMap<String, HashSet<String>> = HashMap::new();
+    for (table, table_indexes) in indexes {
+        let table_lower = table.to_lowercase();
+        let entry = result.entry(table_lower).or_default();
+        for (_index_name, cols) in table_indexes {
+            for col_expr in cols {
+                // 简单列名（不含函数调用）才纳入列索引集
+                let trimmed = col_expr.trim().to_lowercase();
+                // 跳过函数表达式如 "lower(email)"，只处理纯列名
+                if !trimmed.contains('(') && !trimmed.contains(' ') && !trimmed.is_empty() {
+                    entry.insert(trimmed);
+                }
+            }
+        }
+    }
+    result
+}
+
+/// 检查一个函数表达式是否匹配某个函数索引
+/// 例如: "substr(name,1,5)" 匹配索引 ["substr(name,1,5)"]
+pub fn matches_function_index(
+    indexes: &IndexMapV2,
+    table: &str,
+    function_name: &str,
+    col_name: &str,
+) -> bool {
+    let table_lower = table.to_lowercase();
+    let col_lower = col_name.to_lowercase();
+    if let Some(table_indexes) = indexes.get(&table_lower) {
+        for (_index_name, exprs) in table_indexes {
+            for expr in exprs {
+                let expr_lower = expr.to_lowercase();
+                // 检查表达式是否以 function_name(col_name 开头
+                let prefix = format!("{}({}", function_name.to_lowercase(), col_lower);
+                if expr_lower.starts_with(&prefix) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+```
+
+**Step 2: 更新 mod.rs 导出**
+
+确保 `FullSchema`、`IndexMapV2`、`build_column_index_set`、`matches_function_index` 在 `src/analyzer/mod.rs` 中导出。
+
+**Step 3: 写测试**
+
+```rust
+#[test]
+fn test_load_full_schema() {
+    let json = r#"{
+        "columns": {
+            "users": { "id": "integer", "name": "varchar(100)" }
+        },
+        "indexes": {
+            "users": {
+                "pk_users": ["id"],
+                "idx_users_name": ["name"]
+            }
+        }
+    }"#;
+    let schema: FullSchema = serde_json::from_str(json).unwrap();
+    assert_eq!(schema.columns["users"]["id"], "integer");
+    assert_eq!(schema.indexes["users"]["pk_users"], vec!["id"]);
+}
+
+#[test]
+fn test_load_full_schema_backward_compat() {
+    // 旧格式 JSON 也能作为 FullSchema 加载（indexes 为空）
+    let json = r#"{
+        "columns": {
+            "users": { "id": "integer" }
+        }
+    }"#;
+    let schema: FullSchema = serde_json::from_str(json).unwrap();
+    assert_eq!(schema.columns["users"]["id"], "integer");
+    assert!(schema.indexes.is_empty());
+}
+
+#[test]
+fn test_build_column_index_set() {
+    let mut indexes: IndexMapV2 = HashMap::new();
+    let mut user_indexes = HashMap::new();
+    user_indexes.insert("pk_users".to_string(), vec!["id".to_string()]);
+    user_indexes.insert("idx_name".to_string(), vec!["name".to_string()]);
+    user_indexes.insert("idx_func".to_string(), vec!["lower(email)".to_string()]);
+    indexes.insert("users".to_string(), user_indexes);
+
+    let col_set = build_column_index_set(&indexes);
+    assert!(col_set["users"].contains("id"));
+    assert!(col_set["users"].contains("name"));
+    // "lower(email)" 是函数表达式，不纳入列索引集
+    assert!(!col_set["users"].contains("email"));
+}
+
+#[test]
+fn test_matches_function_index() {
+    let mut indexes: IndexMapV2 = HashMap::new();
+    let mut user_indexes = HashMap::new();
+    user_indexes.insert("idx_substr_name".to_string(), vec!["substr(name,1,5)".to_string()]);
+    indexes.insert("users".to_string(), user_indexes);
+
+    assert!(matches_function_index(&indexes, "users", "substr", "name"));
+    assert!(!matches_function_index(&indexes, "users", "upper", "name"));
+    assert!(!matches_function_index(&indexes, "orders", "substr", "name"));
+}
+```
+
+**Step 4: 运行测试**
+
+```bash
+cargo test --lib analyzer::schema
+```
+
+**Step 5: Commit**
+
+```
+feat(schema): add FullSchema, IndexMapV2, and column index lookup utilities
+```
+
+---
+
+### Task 2: 扩展 Linter 基础设施支持索引信息
+
+**Files:**
+- Modify: `src/linter/mod.rs`
+- Test: `src/linter/tests.rs`
+
+**Step 1: 扩展 `LintRuleEntry.check_fn` 签名**
+
+当前签名：
+```rust
+pub check_fn: fn(&[StatementInfo], Option<&SchemaMap>, &LintConfig, Confidence, &mut Vec<SqlWarning>),
+```
+
+新增一个 `IndexMapV2` 参数。为减少改动量，**不修改现有签名**，而是将索引信息嵌入 `SchemaMap` 或通过新结构体传递。
+
+**推荐方案：引入 `LintContext` 封装**
+
+```rust
+/// Linter 检查时的上下文信息
+pub struct LintContext<'a> {
+    /// 列类型信息（原有）
+    pub schema: Option<&'a SchemaMap>,
+    /// 索引信息（新增，可选）
+    pub indexes: Option<&'a crate::analyzer::schema::IndexMapV2>,
+    /// 预计算的列索引查找表
+    pub column_indexes: Option<&'a HashMap<String, HashSet<String>>>,
+}
+```
+
+但这需要修改所有 `check_fn` 签名（40+ 个函数），改动面太大。
+
+**最小改动方案：在 `SqlLinter` 中存储索引信息，通过新增 `lint_with_indexes` 方法传递**
+
+```rust
+pub struct SqlLinter {
+    rules: Vec<LintRuleEntry>,
+    config: LintConfig,
+    indexes: Option<IndexMapV2>,           // 新增
+    column_indexes: Option<HashMap<String, HashSet<String>>>, // 新增
+}
+```
+
+但这仍需修改 `check_fn` 签名或提供一个全局查询机制。
+
+**最终方案：修改 `LintRuleEntry.check_fn` 签名，但使用 trait 简化**
+
+考虑到改动面，采用**渐进式方案**：
+
+1. 新增 `IndexInfo` 结构体
+2. `check_fn` 签名改为传入 `Option<&IndexInfo>`
+3. 所有现有规则的 check 函数增加一个 `_indexes: Option<&IndexInfo>` 参数（用 `_` 前缀忽略）
+
+```rust
+pub struct IndexInfo {
+    pub indexes: IndexMapV2,
+    pub column_indexes: HashMap<String, HashSet<String>>,
+}
+
+pub struct LintRuleEntry {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub level: WarningLevel,
+    pub stmt_kind: StatementKind,
+    pub check_fn: fn(&[StatementInfo], Option<&SchemaMap>, Option<&IndexInfo>, &LintConfig, Confidence, &mut Vec<SqlWarning>),
+}
+```
+
+所有现有 check 函数签名追加 `_indexes: Option<&IndexInfo>` 参数。
+
+**Step 2: 修改 `SqlLinter` 存储 IndexInfo**
+
+```rust
+pub struct SqlLinter {
+    rules: Vec<LintRuleEntry>,
+    config: LintConfig,
+    index_info: Option<IndexInfo>,  // 新增
+}
+
+impl SqlLinter {
+    pub fn set_index_info(&mut self, indexes: IndexMapV2) {
+        let column_indexes = build_column_index_set(&indexes);
+        self.index_info = Some(IndexInfo { indexes, column_indexes });
+    }
+
+    pub fn lint(&self, stmts: &[StatementInfo], schema: Option<&SchemaMap>, confidence: Confidence) -> Vec<SqlWarning> {
+        // ... 原有逻辑 ...
+        // 调用时传入 &self.index_info
+        (rule.check_fn)(stmts, schema, self.index_info.as_ref(), &self.config, confidence, &mut warnings);
+    }
+}
+```
+
+**Step 3: 修改所有现有 check 函数签名**
+
+在 `rules_prohibition.rs`、`rules_performance.rs`、`rules_caution.rs`、`rules_suggestion.rs` 中，所有 `check_xxx` 函数追加 `_indexes: Option<&IndexInfo>` 参数。
+
+这是一个机械性改动，每个函数在 `schema` 参数后追加一个 `_indexes: Option<&crate::linter::IndexInfo>` 参数。
+
+**Step 4: 运行全部测试确保不破坏**
+
+```bash
+cargo test --all-features
+```
+
+**Step 5: Commit**
+
+```
+refactor(linter): add IndexInfo parameter to LintRuleEntry check_fn signature
+```
+
+---
+
+### Task 3: 改造 R006 为索引感知
+
+**Files:**
+- Modify: `src/linter/rules_prohibition.rs` (R006 部分)
+- Test: `src/linter/tests.rs`
+
+**Step 1: 编写 R006 索引感知测试**
+
+```rust
+// ── R006: Index-aware function-on-where-column ──
+
+#[test]
+fn r006_indexed_column_function_warns() {
+    use crate::analyzer::schema::{IndexMapV2, build_column_index_set};
+    use std::collections::{HashMap, HashSet};
+
+    // name 列有索引
+    let mut indexes: IndexMapV2 = HashMap::new();
+    let mut user_idx = HashMap::new();
+    user_idx.insert("idx_name".to_string(), vec!["name".to_string()]);
+    indexes.insert("users".to_string(), user_idx);
+    let col_idx = build_column_index_set(&indexes);
+
+    let stmts = parse("SELECT * FROM users WHERE substr(name, 1, 5) = 'hello'");
+    let linter = SqlLinter::with_default_rules(LintConfig::default());
+    linter.set_index_info(indexes.clone());
+    let w = linter.lint_with_indexes(&stmts, None, Some(&indexes), Some(&col_idx), Confidence::Full);
+    assert!(has_rule(&w, "R006"), "indexed column with function should warn");
+}
+
+#[test]
+fn r006_non_indexed_column_function_no_warn() {
+    use crate::analyzer::schema::{IndexMapV2, build_column_index_set};
+    use std::collections::{HashMap, HashSet};
+
+    // 只有 id 列有索引，description 没有
+    let mut indexes: IndexMapV2 = HashMap::new();
+    let mut user_idx = HashMap::new();
+    user_idx.insert("pk_users".to_string(), vec!["id".to_string()]);
+    indexes.insert("users".to_string(), user_idx);
+    let col_idx = build_column_index_set(&indexes);
+
+    let stmts = parse("SELECT * FROM users WHERE substr(description, 1, 5) = 'hello'");
+    // description 没有索引 → 不应 R006
+    // 但注意：无 schema 时 R006 仍会 warning（现有行为）
+}
+
+#[test]
+fn r006_function_index_covers_expr_no_warn() {
+    // 列有函数索引 substr(name,1,5) → substr(name,1,5) 不应 R006
+}
+
+#[test]
+fn r006_no_index_info_keeps_current_behavior() {
+    // 无 IndexInfo 时，R006 保持原有全量 warning 行为
+}
+```
+
+**Step 2: 实现 R006 索引感知逻辑**
+
+```rust
+fn check_r006(
+    stmts: &[StatementInfo],
+    schema: Option<&crate::analyzer::schema::SchemaMap>,
+    indexes: Option<&crate::linter::IndexInfo>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    for info in stmts {
+        let loc = stmt_location(info);
+        if let Some(where_clause) = extract_where_clause(&info.statement) {
+            walk_expr(where_clause, &mut |e| {
+                if let Expr::FunctionCall { name, args, .. } = e {
+                    let fn_lower = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                    if SAFE_FUNCTIONS_ON_COLUMNS.contains(&fn_lower.as_str()) {
+                        return true;
+                    }
+                    for arg in args {
+                        if let Expr::ColumnRef(col_name) = arg {
+                            // 索引感知逻辑
+                            if let Some(idx_info) = indexes {
+                                // 有索引信息时，仅对有索引的列 warning
+                                // 1. 检查该列是否有普通索引
+                                // 2. 检查是否有匹配的函数索引
+                                if is_column_covered_by_index(&idx_info, schema, &info.statement, col_name)
+                                    || has_matching_function_index(&idx_info, schema, &info.statement, &fn_lower, col_name)
+                                {
+                                    warnings.push(make_warning(
+                                        WarningLevel::Prohibition, "R006", "function-on-where-column",
+                                        format!("WHERE 中对有索引的列 {} 使用函数 {}，将导致索引失效",
+                                            col_name.last().unwrap_or(&"".to_string()), fn_lower),
+                                        Some("将函数运算移到等号另一侧或使用函数索引"), loc,
+                                        Some("WHERE 规范"), confidence,
+                                    ));
+                                }
+                                // 无索引的列 → 不 warning
+                            } else {
+                                // 无索引信息时，保持原有全量 warning 行为
+                                warnings.push(make_warning(
+                                    WarningLevel::Prohibition, "R006", "function-on-where-column",
+                                    "WHERE 中对列使用函数，可能导致索引失效".into(),
+                                    Some("将函数运算移到等号另一侧或使用函数索引"), loc,
+                                    Some("WHERE 规范"), confidence,
+                                ));
+                            }
+                            return false; // 找到一个即停
+                        }
+                    }
+                }
+                true
+            });
+        }
+    }
+}
+```
+
+辅助函数：
+
+```rust
+/// 检查列是否有普通索引覆盖
+fn is_column_covered_by_index(
+    idx_info: &IndexInfo,
+    _schema: Option<&SchemaMap>,
+    stmt: &Statement,
+    col_name: &[String],
+) -> bool {
+    // 从 statement 中提取 FROM 表名
+    // 从 col_name 解析 table.column
+    // 查 idx_info.column_indexes
+    // ... 具体实现
+}
+
+/// 检查是否有匹配的函数索引
+fn has_matching_function_index(
+    idx_info: &IndexInfo,
+    _schema: Option<&SchemaMap>,
+    stmt: &Statement,
+    fn_name: &str,
+    col_name: &[String],
+) -> bool {
+    // 调用 analyzer::schema::matches_function_index
+    // ...
+}
+```
+
+**Step 3: 运行测试**
+
+```bash
+cargo test --lib linter
+```
+
+**Step 4: Commit**
+
+```
+feat(R006): index-aware function-on-where-column warning
+```
+
+---
+
+### Task 4: 改造 R007 为索引感知
+
+**Files:**
+- Modify: `src/linter/rules_prohibition.rs` (R007 部分)
+- Test: `src/linter/tests.rs`
+
+**Step 1: 编写 R007 索引感知测试**
+
+```rust
+#[test]
+fn r007_indexed_column_like_leading_wildcard_warns() {
+    // name 列有索引 → LIKE '%abc' 应 warning
+}
+
+#[test]
+fn r007_non_indexed_column_like_leading_wildcard_no_warn() {
+    // description 列无索引 → LIKE '%abc' 不 warning
+}
+
+#[test]
+fn r007_no_index_info_keeps_current_behavior() {
+    // 无索引信息时保持全量 warning
+}
+```
+
+**Step 2: 实现 R007 索引感知逻辑**
+
+与 R006 类似，在检测到 LIKE 前导通配符时，检查列是否有索引。
+
+**Step 3: 运行测试**
+
+```bash
+cargo test --lib linter
+```
+
+**Step 4: Commit**
+
+```
+feat(R007): index-aware LIKE leading wildcard warning
+```
+
+---
+
+### Task 5: 扩展 SARGability 检测（非函数表达式模式）
+
+**Files:**
+- Modify: `src/linter/rules_prohibition.rs`
+- Test: `src/linter/tests.rs`
+
+当前 R006 仅检测 `FunctionCall`。以下模式同样破坏 SARGability，需要覆盖：
+
+| 模式 | AST 类型 | 示例 |
+|------|----------|------|
+| 算术运算 | `BinaryOp` | `WHERE col + 1 = 10` |
+| 类型转换 | `TypeCast` | `WHERE col::text = 'abc'` |
+| 字符串拼接 | `BinaryOp` (\|\|) | `WHERE col \|\| '' = 'abc'` |
+
+**Step 1: 新增检测函数或扩展 R006**
+
+在 R006 中扩展 `walk_expr` 的匹配逻辑：
+
+```rust
+// 除了 FunctionCall，还需检测：
+// 1. BinaryOp 其中一侧是 ColumnRef + 算术/拼接运算符
+//    如 col + 1, col || '', col * 2
+// 2. TypeCast 操作在 ColumnRef 上
+//    如 col::text, CAST(col AS text)
+
+walk_expr(where_clause, &mut |e| {
+    match e {
+        Expr::FunctionCall { name, args, .. } => { /* 现有逻辑 */ }
+        Expr::BinaryOp { left, right, op, .. } => {
+            let op_lower = op.to_lowercase();
+            if is_sargability_breaking_op(&op_lower) {
+                // 检查 left 或 right 是否是 ColumnRef（直接或嵌套在算术中）
+                if contains_column_ref(left) || contains_column_ref(right) {
+                    // 索引感知：仅 warning 有索引的列
+                }
+            }
+        }
+        Expr::TypeCast { expr, .. } => {
+            if let Expr::ColumnRef(col_name) = expr.as_ref() {
+                // 列上的类型转换破坏索引
+                // 索引感知
+            }
+        }
+        _ => {}
+    }
+    true
+});
+```
+
+**Step 2: 测试**
+
+```rust
+#[test]
+fn r006_arithmetic_on_indexed_column_warns() {
+    // WHERE id + 1 = 10 → id 有索引 → warning
+}
+
+#[test]
+fn r006_typecast_on_indexed_column_warns() {
+    // WHERE name::text = 'abc' → name 有索引 → warning
+}
+
+#[test]
+fn r006_concat_on_indexed_column_warns() {
+    // WHERE name || '' = 'abc' → name 有索引 → warning
+}
+```
+
+**Step 3: 运行测试**
+
+```bash
+cargo test --lib linter
+```
+
+**Step 4: Commit**
+
+```
+feat(R006): extend SARGability detection to arithmetic, type cast, and concatenation
+```
+
+---
+
+### Task 6: CLI 集成
+
+**Files:**
+- Modify: `src/bin/ogsql.rs`
+
+**Step 1: 支持 `--schema-json` 加载新格式**
+
+当前 CLI 已有 `--schema-json <FILE>` 选项。修改加载逻辑：
+
+```rust
+// 尝试先作为 FullSchema 加载
+let full_schema = load_full_schema(path);
+match full_schema {
+    Ok(fs) => {
+        schema = Some(fs.columns);
+        if !fs.indexes.is_empty() {
+            linter.set_index_info(fs.indexes);
+        }
+    }
+    Err(_) => {
+        // 回退到旧格式 SchemaMap
+        schema = Some(load_schema(path).unwrap_or_else(|e| {
+            eprintln!("Warning: {e}");
+            std::process::exit(1);
+        }));
+    }
+}
+```
+
+**Step 2: 验证 CLI 行为**
+
+```bash
+# 旧格式 schema（无索引） → R006 全量 warning
+echo "SELECT * FROM t WHERE substr(name,1,5)='abc'" | ogsql validate --schema-json old-schema.json
+
+# 新格式 schema（有索引） → R006 仅对有索引列 warning
+echo "SELECT * FROM t WHERE substr(name,1,5)='abc'" | ogsql validate --schema-json new-schema.json
+```
+
+**Step 3: Commit**
+
+```
+feat(cli): support FullSchema JSON format with index metadata
+```
+
+---
+
+### Task 7: 文档和示例
+
+**Files:**
+- Modify: `docs/user-guide.md`（如果存在 schema 格式文档章节）
+- Create: `examples/schema-with-indexes.json`
+
+**Step 1: 创建示例 Schema JSON**
+
+```json
+{
+  "columns": {
+    "users": {
+      "id": "integer",
+      "name": "varchar(100)",
+      "email": "varchar(200)",
+      "description": "text",
+      "created_at": "timestamp"
+    }
+  },
+  "indexes": {
+    "users": {
+      "pk_users_id": ["id"],
+      "idx_users_name": ["name"],
+      "idx_users_email_lower": ["lower(email)"],
+      "idx_users_created_at": ["created_at"]
+    }
+  }
+}
+```
+
+**Step 2: 更新文档**
+
+在用户文档中说明：
+- 新的 Schema JSON 格式
+- `indexes` 字段如何影响 R006/R007 的 warning 行为
+- 无 indexes 时保持原有行为
+
+**Step 3: Commit**
+
+```
+docs: add schema-with-indexes example and documentation
+```
+
+---
+
+## 测试矩阵
+
+### R006 索引感知测试
+
+| 场景 | SQL | 有索引？ | 有 IndexInfo？ | 应 warning？ |
+|------|-----|---------|---------------|-------------|
+| 函数+有索引列 | `WHERE substr(name,1,5)='abc'` | name ✅ | ✅ | ✅ |
+| 函数+无索引列 | `WHERE substr(desc,1,5)='abc'` | desc ❌ | ✅ | ❌ |
+| 函数+无 IndexInfo | `WHERE substr(name,1,5)='abc'` | 未知 | ❌ | ✅（全量） |
+| 函数+函数索引匹配 | `WHERE lower(email)='abc'` | lower(email) ✅ | ✅ | ❌（被函数索引覆盖） |
+| 安全函数 | `WHERE coalesce(name,'')='abc'` | name ✅ | ✅ | ❌（白名单） |
+| 算术+有索引列 | `WHERE id+1=10` | id ✅ | ✅ | ✅ |
+| 算术+无索引列 | `WHERE score+1=10` | score ❌ | ✅ | ❌ |
+| 类型转换+有索引列 | `WHERE id::text='10'` | id ✅ | ✅ | ✅ |
+| 类型转换+无索引列 | `WHERE score::text='10'` | score ❌ | ✅ | ❌ |
+
+### R007 索引感知测试
+
+| 场景 | SQL | 有索引？ | 有 IndexInfo？ | 应 warning？ |
+|------|-----|---------|---------------|-------------|
+| LIKE 前导通配符+有索引列 | `WHERE name LIKE '%abc'` | name ✅ | ✅ | ✅ |
+| LIKE 前导通配符+无索引列 | `WHERE desc LIKE '%abc'` | desc ❌ | ✅ | ❌ |
+| LIKE 前导通配符+无 IndexInfo | `WHERE name LIKE '%abc'` | 未知 | ❌ | ✅（全量） |
+| LIKE 非前导通配符 | `WHERE name LIKE 'abc%'` | name ✅ | ✅ | ❌（可用索引） |
+
+---
+
+## 完整文件变更清单
+
+| 文件 | 变更类型 | 说明 |
+|------|---------|------|
+| `src/analyzer/schema.rs` | 修改 | 新增 `FullSchema`, `IndexMapV2`, `build_column_index_set`, `matches_function_index` |
+| `src/analyzer/mod.rs` | 修改 | 导出新类型 |
+| `src/linter/mod.rs` | 修改 | 新增 `IndexInfo`, 修改 `LintRuleEntry.check_fn` 签名, `SqlLinter` 存储索引信息 |
+| `src/linter/rules_prohibition.rs` | 修改 | R006/R007 索引感知改造 + SARGability 扩展 |
+| `src/linter/rules_performance.rs` | 修改 | check 函数签名追加 `_indexes` 参数（机械改动） |
+| `src/linter/rules_caution.rs` | 修改 | check 函数签名追加 `_indexes` 参数（机械改动） |
+| `src/linter/rules_suggestion.rs` | 修改 | check 函数签名追加 `_indexes` 参数（机械改动） |
+| `src/linter/tests.rs` | 修改 | 新增索引感知测试用例 |
+| `src/bin/ogsql.rs` | 修改 | CLI 加载 FullSchema 格式 |
+| `examples/schema-with-indexes.json` | 新建 | 示例 Schema JSON |
+
+---
+
+## 风险和注意事项
+
+1. **check_fn 签名变更影响面大**：需要修改所有 ~30 个 check 函数的签名。这是机械性改动，但必须逐个文件确认。
+
+2. **索引信息来源**：当前方案依赖用户手动提供索引信息。未来可以考虑从 `CREATE INDEX` DDL 中自动提取（但超出本次范围）。
+
+3. **函数索引匹配精度**：`matches_function_index` 使用简单的字符串前缀匹配（`substr(name`），对空格和大小写做了 normalize，但可能对复杂表达式匹配不精确。可接受，因为函数索引本身就是高级用法，误报风险低。
+
+4. **复合索引的列顺序**：当前 `build_column_index_set` 只关心某列是否被索引覆盖，不考虑复合索引的列顺序。这意味着 `WHERE name = 'abc'` 即使只有 `(name, email)` 复合索引也会被认为"有索引"——这对于 R006 的场景是合理的（因为 R006 关注的是函数破坏索引，不是索引是否真的被使用）。

--- a/examples/schema-with-indexes.json
+++ b/examples/schema-with-indexes.json
@@ -1,0 +1,35 @@
+{
+  "columns": {
+    "users": {
+      "id": "integer",
+      "name": "varchar(100)",
+      "email": "varchar(200)",
+      "description": "text",
+      "status": "varchar(20)",
+      "created_at": "timestamp",
+      "score": "integer"
+    },
+    "orders": {
+      "order_id": "integer",
+      "user_id": "integer",
+      "amount": "numeric(10,2)",
+      "memo": "varchar(500)",
+      "order_date": "date"
+    }
+  },
+  "indexes": {
+    "users": {
+      "pk_users_id": ["id"],
+      "idx_users_name": ["name"],
+      "idx_users_status": ["status"],
+      "idx_users_email_lower": ["lower(email)"],
+      "idx_users_created_at": ["created_at"]
+    },
+    "orders": {
+      "pk_orders_order_id": ["order_id"],
+      "idx_orders_user_id": ["user_id"],
+      "idx_orders_amount": ["amount"],
+      "idx_orders_date": ["order_date"]
+    }
+  }
+}

--- a/src/analyzer/schema.rs
+++ b/src/analyzer/schema.rs
@@ -187,12 +187,7 @@ pub fn build_column_index_set(indexes: &IndexMapV2) -> HashMap<String, HashSet<S
 /// Check if there's a function index matching `function_name(col_name...)`
 /// for the given table. Does case-insensitive matching on the prefix
 /// `function_name(col_name`.
-pub fn matches_function_index(
-    indexes: &IndexMapV2,
-    table: &str,
-    function_name: &str,
-    col_name: &str,
-) -> bool {
+pub fn matches_function_index(indexes: &IndexMapV2, table: &str, function_name: &str, col_name: &str) -> bool {
     let table_lower = table.to_lowercase();
     let prefix = format!("{}(", function_name.to_lowercase());
     let needle = format!("{}{}", prefix, col_name.to_lowercase());

--- a/src/analyzer/schema.rs
+++ b/src/analyzer/schema.rs
@@ -1,6 +1,6 @@
 use crate::ast::plpgsql::{PlBlock, PlDataType, PlStatement};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub type SchemaMap = HashMap<String, HashMap<String, String>>;
 
@@ -134,6 +134,82 @@ fn extract_block_from_statement(stmt: &PlStatement) -> Option<&PlBlock> {
     }
 }
 
+// ── Index Metadata Types ──
+
+/// Maps table_name → index_name → list of column names or function expressions in the index.
+pub type IndexMapV2 = HashMap<String, HashMap<String, Vec<String>>>;
+
+/// Full schema with both column type info and index metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FullSchema {
+    #[serde(default)]
+    pub columns: SchemaMap,
+    #[serde(default)]
+    pub indexes: IndexMapV2,
+}
+
+/// Load a FullSchema from a JSON file. Supports both the new format
+/// (with `columns` and `indexes` fields) and the old format (just a
+/// column map, which gets loaded with empty indexes).
+pub fn load_full_schema(path: &str) -> Result<FullSchema, String> {
+    let content = std::fs::read_to_string(path).map_err(|e| format!("Failed to read schema file '{}': {}", path, e))?;
+    // Try to parse as FullSchema first (new format)
+    if let Ok(fs) = serde_json::from_str::<FullSchema>(&content) {
+        return Ok(fs);
+    }
+    // Fall back to old format (just a SchemaMap)
+    let columns: SchemaMap =
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse schema JSON: {}", e))?;
+    Ok(FullSchema { columns, indexes: HashMap::new() })
+}
+
+/// Build a lookup table: table(lowercase) → set of column names(lowercase)
+/// that have a plain index. Function expression indexes like `lower(email)`
+/// are skipped — only plain column names are included.
+pub fn build_column_index_set(indexes: &IndexMapV2) -> HashMap<String, HashSet<String>> {
+    let mut result: HashMap<String, HashSet<String>> = HashMap::new();
+    for (table, indices) in indexes {
+        let table_lower = table.to_lowercase();
+        let entry = result.entry(table_lower).or_default();
+        for cols in indices.values() {
+            for col in cols {
+                // Skip function expressions (anything containing '(' or whitespace)
+                if col.contains('(') || col.contains(char::is_whitespace) {
+                    continue;
+                }
+                entry.insert(col.to_lowercase());
+            }
+        }
+    }
+    result
+}
+
+/// Check if there's a function index matching `function_name(col_name...)`
+/// for the given table. Does case-insensitive matching on the prefix
+/// `function_name(col_name`.
+pub fn matches_function_index(
+    indexes: &IndexMapV2,
+    table: &str,
+    function_name: &str,
+    col_name: &str,
+) -> bool {
+    let table_lower = table.to_lowercase();
+    let prefix = format!("{}(", function_name.to_lowercase());
+    let needle = format!("{}{}", prefix, col_name.to_lowercase());
+
+    if let Some(indices) = indexes.get(&table_lower) {
+        for cols in indices.values() {
+            for col_expr in cols {
+                let col_lower = col_expr.to_lowercase();
+                if col_lower.starts_with(&needle) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,5 +324,241 @@ mod tests {
         let err = result.unwrap_err();
         assert!(err.contains("Failed to parse schema JSON"));
         let _ = std::fs::remove_file(&path);
+    }
+
+    // ── Index Metadata Tests ──
+
+    #[test]
+    fn test_load_full_schema_new_format() {
+        use std::io::Write;
+        let dir = std::env::temp_dir();
+        let path = dir.join("ogsql_test_full_schema_new.json");
+        {
+            let mut file = std::fs::File::create(&path).unwrap();
+            write!(
+                file,
+                r#"{{
+                "columns": {{ "users": {{ "id": "integer", "name": "varchar(100)" }} }},
+                "indexes": {{ "users": {{ "pk_users": ["id"], "idx_name": ["name"], "idx_func": ["lower(email)"] }} }}
+            }}"#
+            )
+            .unwrap();
+        }
+        let result = load_full_schema(path.to_str().unwrap());
+        assert!(result.is_ok(), "Failed to load FullSchema: {:?}", result.err());
+        let fs = result.unwrap();
+        assert_eq!(fs.columns.len(), 1);
+        assert!(fs.columns.contains_key("users"));
+        assert_eq!(fs.columns["users"].get("id").unwrap(), "integer");
+        assert_eq!(fs.indexes.len(), 1);
+        assert!(fs.indexes.contains_key("users"));
+        let user_indexes = &fs.indexes["users"];
+        assert!(user_indexes.contains_key("pk_users"));
+        assert_eq!(user_indexes["pk_users"], vec!["id"]);
+        assert!(user_indexes.contains_key("idx_name"));
+        assert_eq!(user_indexes["idx_name"], vec!["name"]);
+        assert!(user_indexes.contains_key("idx_func"));
+        assert_eq!(user_indexes["idx_func"], vec!["lower(email)"]);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_full_schema_backward_compat() {
+        use std::io::Write;
+        let dir = std::env::temp_dir();
+        let path = dir.join("ogsql_test_full_schema_old.json");
+        {
+            let mut file = std::fs::File::create(&path).unwrap();
+            write!(file, r#"{{ "users": {{ "id": "integer", "name": "varchar(100)" }} }}"#).unwrap();
+        }
+        let result = load_full_schema(path.to_str().unwrap());
+        assert!(result.is_ok(), "Failed to load old format: {:?}", result.err());
+        let fs = result.unwrap();
+        assert_eq!(fs.columns.len(), 1);
+        assert!(fs.columns.contains_key("users"));
+        assert_eq!(fs.columns["users"].get("id").unwrap(), "integer");
+        // Indexes should be empty (backward compat)
+        assert!(fs.indexes.is_empty(), "Old format should produce empty indexes");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_full_schema_file_not_found() {
+        let result = load_full_schema("/nonexistent/path/full_schema.json");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Failed to read schema file"));
+    }
+
+    #[test]
+    fn test_load_full_schema_invalid_json() {
+        use std::io::Write;
+        let dir = std::env::temp_dir();
+        let path = dir.join("ogsql_test_full_schema_invalid.json");
+        {
+            let mut file = std::fs::File::create(&path).unwrap();
+            write!(file, "not json at all").unwrap();
+        }
+        let result = load_full_schema(path.to_str().unwrap());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Failed to parse schema JSON"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_build_column_index_set_basic() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("pk_users".to_string(), vec!["id".to_string()]);
+        user_indexes.insert("idx_name".to_string(), vec!["name".to_string()]);
+        indexes.insert("users".to_string(), user_indexes);
+
+        let result = build_column_index_set(&indexes);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key("users"));
+        let user_cols = &result["users"];
+        assert_eq!(user_cols.len(), 2);
+        assert!(user_cols.contains("id"));
+        assert!(user_cols.contains("name"));
+    }
+
+    #[test]
+    fn test_build_column_index_set_skips_function_indexes() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("idx_email".to_string(), vec!["lower(email)".to_string()]);
+        user_indexes.insert("idx_name".to_string(), vec!["name".to_string()]);
+        indexes.insert("users".to_string(), user_indexes);
+
+        let result = build_column_index_set(&indexes);
+        assert_eq!(result.len(), 1);
+        let user_cols = &result["users"];
+        // "lower(email)" should be skipped, only "name" should remain
+        assert_eq!(user_cols.len(), 1);
+        assert!(user_cols.contains("name"));
+        assert!(!user_cols.contains("email"));
+    }
+
+    #[test]
+    fn test_build_column_index_set_multiple_tables() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("pk_users".to_string(), vec!["id".to_string()]);
+        indexes.insert("users".to_string(), user_indexes);
+        let mut log_indexes = HashMap::new();
+        log_indexes.insert("idx_proc".to_string(), vec!["proc_name".to_string()]);
+        indexes.insert("db_log".to_string(), log_indexes);
+
+        let result = build_column_index_set(&indexes);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key("users"));
+        assert!(result.contains_key("db_log"));
+        assert!(result["users"].contains("id"));
+        assert!(result["db_log"].contains("proc_name"));
+    }
+
+    #[test]
+    fn test_build_column_index_set_empty() {
+        let indexes: IndexMapV2 = HashMap::new();
+        let result = build_column_index_set(&indexes);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_build_column_index_set_case_insensitive_keys() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("idx_id".to_string(), vec!["ID".to_string()]);
+        indexes.insert("USERS".to_string(), user_indexes);
+
+        let result = build_column_index_set(&indexes);
+        assert!(result.contains_key("users"));
+        assert!(result["users"].contains("id"));
+    }
+
+    #[test]
+    fn test_matches_function_index_found() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("idx_func".to_string(), vec!["lower(email)".to_string()]);
+        indexes.insert("users".to_string(), user_indexes);
+
+        assert!(matches_function_index(&indexes, "users", "lower", "email"));
+    }
+
+    #[test]
+    fn test_matches_function_index_not_found() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("idx_func".to_string(), vec!["lower(email)".to_string()]);
+        indexes.insert("users".to_string(), user_indexes);
+
+        assert!(!matches_function_index(&indexes, "users", "upper", "email"));
+        assert!(!matches_function_index(&indexes, "users", "lower", "name"));
+    }
+
+    #[test]
+    fn test_matches_function_index_case_insensitive() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut user_indexes = HashMap::new();
+        user_indexes.insert("idx_func".to_string(), vec!["lower(email)".to_string()]);
+        indexes.insert("USERS".to_string(), user_indexes);
+
+        assert!(matches_function_index(&indexes, "USERS", "LOWER", "EMAIL"));
+        assert!(matches_function_index(&indexes, "users", "LOWER", "email"));
+        assert!(matches_function_index(&indexes, "USERS", "lower", "EMAIL"));
+    }
+
+    #[test]
+    fn test_matches_function_index_table_not_found() {
+        let indexes: IndexMapV2 = HashMap::new();
+        assert!(!matches_function_index(&indexes, "nonexistent", "lower", "email"));
+    }
+
+    #[test]
+    fn test_matches_function_index_no_indexes_for_table() {
+        let mut indexes: IndexMapV2 = HashMap::new();
+        let mut other_indexes = HashMap::new();
+        other_indexes.insert("idx_func".to_string(), vec!["lower(email)".to_string()]);
+        indexes.insert("other".to_string(), other_indexes);
+        assert!(!matches_function_index(&indexes, "users", "lower", "email"));
+    }
+
+    #[test]
+    fn test_full_schema_serde_roundtrip() {
+        let fs = FullSchema {
+            columns: {
+                let mut cols = HashMap::new();
+                let mut inner = HashMap::new();
+                inner.insert("id".to_string(), "integer".to_string());
+                cols.insert("t".to_string(), inner);
+                cols
+            },
+            indexes: {
+                let mut idxs = HashMap::new();
+                let mut inner = HashMap::new();
+                inner.insert("pk_t".to_string(), vec!["id".to_string()]);
+                idxs.insert("t".to_string(), inner);
+                idxs
+            },
+        };
+        let json = serde_json::to_string(&fs).unwrap();
+        let deserialized: FullSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.columns.len(), 1);
+        assert_eq!(deserialized.indexes.len(), 1);
+        assert_eq!(deserialized.indexes["t"]["pk_t"], vec!["id"]);
+    }
+
+    #[test]
+    fn test_full_schema_serde_default_fallback() {
+        // Old format JSON should deserialize into FullSchema with empty indexes
+        let json = r#"{"t": {"id": "integer"}}"#;
+        let result: Result<FullSchema, _> = serde_json::from_str(json);
+        assert!(result.is_ok(), "Old format should deserialize via serde default: {:?}", result.err());
+        let fs = result.unwrap();
+        assert_eq!(fs.columns.len(), 1);
+        assert_eq!(fs.columns["t"]["id"], "integer");
+        assert!(fs.indexes.is_empty());
     }
 }

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -289,9 +289,21 @@ fn run_lint(
     stmts: &[ogsql_parser::StatementInfo],
     confidence: ogsql_parser::linter::Confidence,
     config: &ogsql_parser::linter::LintConfig,
+    schema_path: Option<&str>,
 ) -> Vec<ogsql_parser::linter::SqlWarning> {
-    let linter = ogsql_parser::linter::SqlLinter::with_default_rules(config.clone());
-    linter.lint(stmts, None, confidence)
+    let mut linter = ogsql_parser::linter::SqlLinter::with_default_rules(config.clone());
+    let mut schema = None;
+
+    if let Some(path) = schema_path {
+        if let Ok(fs) = ogsql_parser::analyzer::schema::load_full_schema(path) {
+            if !fs.indexes.is_empty() {
+                linter.set_index_info(fs.indexes);
+            }
+            schema = Some(fs.columns);
+        }
+    }
+
+    linter.lint(stmts, schema.as_ref(), confidence)
 }
 
 fn format_warnings_text(warnings: &[ogsql_parser::linter::SqlWarning]) {
@@ -768,7 +780,7 @@ fn cmd_parse_single(cli: &Cli, file_path: Option<&str>, csv: bool, proc_name: Op
         }
         if cli.lint {
             let config = build_lint_config(cli);
-            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config);
+            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref());
             if !lint_warnings.is_empty() {
                 out.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
                 out.as_object_mut()
@@ -802,7 +814,7 @@ fn cmd_parse_single(cli: &Cli, file_path: Option<&str>, csv: bool, proc_name: Op
         }
         if cli.lint {
             let config = build_lint_config(cli);
-            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config);
+            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref());
             if !lint_warnings.is_empty() {
                 eprintln!("\n── Lint Warnings ({}) ──", lint_warnings.len());
                 format_warnings_text(&lint_warnings);
@@ -3693,7 +3705,7 @@ fn cmd_validate_single(cli: &Cli, file_path: Option<&str>, csv: bool, strict: bo
 
     let lint_warnings = if cli.lint {
         let config = build_lint_config(cli);
-        run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+        run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref())
     } else {
         vec![]
     };
@@ -3830,7 +3842,7 @@ fn cmd_validate_files(cli: &Cli, csv: bool, strict: bool) {
             }
             let lint_warnings = if cli.lint {
                 let config = build_lint_config(cli);
-                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref())
             } else {
                 vec![]
             };
@@ -3890,7 +3902,7 @@ fn cmd_validate_files(cli: &Cli, csv: bool, strict: bool) {
 
             let lint_warnings = if cli.lint {
                 let config = build_lint_config(cli);
-                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref())
             } else {
                 vec![]
             };
@@ -4065,7 +4077,7 @@ fn cmd_validate_dir(cli: &Cli, dir_paths: &[String], exts: &[String], csv: bool,
             }
             let lint_warnings = if cli.lint {
                 let config = build_lint_config(cli);
-                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config)
+                run_lint(&stmts, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref())
             } else {
                 vec![]
             };
@@ -4645,7 +4657,7 @@ mod api {
         }
         if input.lint == Some(true) {
             let config = ogsql_parser::linter::LintConfig::default();
-            let lint_warnings = super::run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config);
+            let lint_warnings = super::run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref());
             result.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
             result
                 .as_object_mut()

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -4492,6 +4492,9 @@ mod api {
         /// Enable SQL anti-pattern linting
         #[serde(default)]
         pub lint: Option<bool>,
+        /// Path to schema JSON file for schema-aware lint rules (index metadata, column types)
+        #[serde(default)]
+        pub schema_json: Option<String>,
     }
 
     #[derive(Deserialize, ToSchema)]
@@ -4671,7 +4674,7 @@ mod api {
                 &output.statements,
                 ogsql_parser::linter::Confidence::Full,
                 &config,
-                cli.schema_json.as_deref(),
+                input.schema_json.as_deref(),
             );
             result.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
             result

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -780,7 +780,12 @@ fn cmd_parse_single(cli: &Cli, file_path: Option<&str>, csv: bool, proc_name: Op
         }
         if cli.lint {
             let config = build_lint_config(cli);
-            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref());
+            let lint_warnings = run_lint(
+                &output.statements,
+                ogsql_parser::linter::Confidence::Full,
+                &config,
+                cli.schema_json.as_deref(),
+            );
             if !lint_warnings.is_empty() {
                 out.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
                 out.as_object_mut()
@@ -814,7 +819,12 @@ fn cmd_parse_single(cli: &Cli, file_path: Option<&str>, csv: bool, proc_name: Op
         }
         if cli.lint {
             let config = build_lint_config(cli);
-            let lint_warnings = run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref());
+            let lint_warnings = run_lint(
+                &output.statements,
+                ogsql_parser::linter::Confidence::Full,
+                &config,
+                cli.schema_json.as_deref(),
+            );
             if !lint_warnings.is_empty() {
                 eprintln!("\n── Lint Warnings ({}) ──", lint_warnings.len());
                 format_warnings_text(&lint_warnings);
@@ -4657,7 +4667,12 @@ mod api {
         }
         if input.lint == Some(true) {
             let config = ogsql_parser::linter::LintConfig::default();
-            let lint_warnings = super::run_lint(&output.statements, ogsql_parser::linter::Confidence::Full, &config, cli.schema_json.as_deref());
+            let lint_warnings = super::run_lint(
+                &output.statements,
+                ogsql_parser::linter::Confidence::Full,
+                &config,
+                cli.schema_json.as_deref(),
+            );
             result.as_object_mut().unwrap().insert("lint_warnings".to_string(), serde_json::json!(lint_warnings));
             result
                 .as_object_mut()

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -7,11 +7,12 @@ mod type_helpers;
 #[cfg(test)]
 mod tests;
 
-use crate::analyzer::schema::SchemaMap;
+use crate::analyzer::schema::{IndexMapV2, SchemaMap};
 use crate::ast::{SelectStatement, Spanned, Statement, StatementInfo};
 use crate::token::SourceLocation;
 #[cfg(feature = "lint-config")]
 use std::path::{Path, PathBuf};
+use std::collections::{HashMap, HashSet};
 
 /// SQL warning severity level. "Error" is deliberately NOT used to avoid
 /// confusion with `ParserError` which represents syntax-level errors.
@@ -259,13 +260,28 @@ impl LintConfig {
     }
 }
 
+/// Pre-computed index metadata for index-aware lint rules.
+pub struct IndexInfo {
+    /// Raw index definitions: table → index_name → [col_or_expr, ...]
+    pub indexes: IndexMapV2,
+    /// Fast lookup: table (lowercase) → set of column names (lowercase) that have a plain index.
+    pub column_indexes: HashMap<String, HashSet<String>>,
+}
+
 /// A single registered rule.
 pub struct LintRuleEntry {
     pub id: &'static str,
     pub name: &'static str,
     pub level: WarningLevel,
     pub stmt_kind: StatementKind,
-    pub check_fn: fn(&[StatementInfo], Option<&SchemaMap>, &LintConfig, Confidence, &mut Vec<SqlWarning>),
+    pub check_fn: fn(
+        &[StatementInfo],
+        Option<&SchemaMap>,
+        Option<&IndexInfo>,
+        &LintConfig,
+        Confidence,
+        &mut Vec<SqlWarning>,
+    ),
 }
 
 /// Build a JSON summary of lint warnings, grouped by level and rule.
@@ -291,11 +307,12 @@ pub(crate) fn loc_from_spanned<T>(spanned: &Spanned<T>, fallback: SourceLocation
 pub struct SqlLinter {
     rules: Vec<LintRuleEntry>,
     config: LintConfig,
+    index_info: Option<IndexInfo>,
 }
 
 impl SqlLinter {
     pub fn new(config: LintConfig) -> Self {
-        Self { rules: vec![], config }
+        Self { rules: vec![], config, index_info: None }
     }
 
     /// Create a linter with all Phase 1 rules registered.
@@ -310,6 +327,12 @@ impl SqlLinter {
 
     pub fn register(&mut self, rule: LintRuleEntry) {
         self.rules.push(rule);
+    }
+
+    /// Set index metadata for index-aware rules (R006, R007, etc.).
+    pub fn set_index_info(&mut self, indexes: IndexMapV2) {
+        let column_indexes = crate::analyzer::schema::build_column_index_set(&indexes);
+        self.index_info = Some(IndexInfo { indexes, column_indexes });
     }
 
     /// Run all registered rules against the given statements.
@@ -331,7 +354,7 @@ impl SqlLinter {
                 if rule.level < self.config.min_level {
                     continue;
                 }
-                (rule.check_fn)(stmts, schema, &self.config, confidence, &mut warnings);
+                (rule.check_fn)(stmts, schema, self.index_info.as_ref(), &self.config, confidence, &mut warnings);
             }
         }
 

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -10,9 +10,9 @@ mod tests;
 use crate::analyzer::schema::{IndexMapV2, SchemaMap};
 use crate::ast::{SelectStatement, Spanned, Statement, StatementInfo};
 use crate::token::SourceLocation;
+use std::collections::{HashMap, HashSet};
 #[cfg(feature = "lint-config")]
 use std::path::{Path, PathBuf};
-use std::collections::{HashMap, HashSet};
 
 /// SQL warning severity level. "Error" is deliberately NOT used to avoid
 /// confusion with `ParserError` which represents syntax-level errors.
@@ -274,14 +274,8 @@ pub struct LintRuleEntry {
     pub name: &'static str,
     pub level: WarningLevel,
     pub stmt_kind: StatementKind,
-    pub check_fn: fn(
-        &[StatementInfo],
-        Option<&SchemaMap>,
-        Option<&IndexInfo>,
-        &LintConfig,
-        Confidence,
-        &mut Vec<SqlWarning>,
-    ),
+    pub check_fn:
+        fn(&[StatementInfo], Option<&SchemaMap>, Option<&IndexInfo>, &LintConfig, Confidence, &mut Vec<SqlWarning>),
 }
 
 /// Build a JSON summary of lint warnings, grouped by level and rule.

--- a/src/linter/rules_caution.rs
+++ b/src/linter/rules_caution.rs
@@ -135,6 +135,7 @@ fn extract_hints(stmt: &Statement) -> Vec<&String> {
 fn check_c001(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -183,6 +184,7 @@ fn parse_hint_names(hint: &str) -> Vec<&str> {
 fn check_c005(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -279,6 +281,7 @@ fn resolve_hints(hint: &str) -> Vec<(String, bool)> {
 fn check_c006(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -402,6 +405,7 @@ fn extract_hint_table_refs(hint: &str) -> Vec<&str> {
 fn check_c007(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -430,6 +434,7 @@ fn check_c007(
 fn check_c008(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -458,6 +463,7 @@ fn check_c008(
 fn check_c009(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -486,6 +492,7 @@ fn check_c009(
 fn check_c010(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -527,6 +534,7 @@ fn check_c010(
 fn check_c011(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -618,6 +626,7 @@ fn check_pl_stmts_for_goto(stmts: &[PlStatement], found: &mut bool) {
 fn check_c012(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -718,6 +727,7 @@ fn has_string_concat(expr: &Expr) -> bool {
 fn check_c013(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -814,6 +824,7 @@ fn has_raise(s: &PlStatement) -> bool {
 fn check_c014(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -894,6 +905,7 @@ fn check_pl_stmts_for_commit_rollback(pl_stmts: &[PlStatement], found: &mut bool
 fn check_c015(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -931,6 +943,7 @@ fn check_c015(
 fn check_c016(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -1005,6 +1018,7 @@ fn check_pl_stmts_for_autonomous(pl_stmts: &[PlStatement], found: &mut bool) {
 fn check_c017(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -1105,6 +1119,7 @@ fn has_reraise(s: &PlStatement) -> bool {
 fn check_c018(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,

--- a/src/linter/rules_performance.rs
+++ b/src/linter/rules_performance.rs
@@ -180,6 +180,7 @@ fn extract_where(stmt: &Statement) -> Option<&Expr> {
 fn check_p001(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -235,6 +236,7 @@ fn check_select_union(
 fn check_p002(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -283,6 +285,7 @@ fn check_p002(
 fn check_p003(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -311,6 +314,7 @@ fn check_p003(
 fn check_p004(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -336,6 +340,7 @@ fn check_p004(
 fn check_p005(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -391,6 +396,7 @@ fn check_p005(
 fn check_p006(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -426,6 +432,7 @@ fn check_p006(
 fn check_p007(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -472,6 +479,7 @@ fn count_non_equi_in_expr(expr: &Expr, count: &mut usize) {
 fn check_p008(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -501,6 +509,7 @@ fn check_p008(
 fn check_p010(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -535,6 +544,7 @@ fn check_p010(
 fn check_p011(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -645,6 +655,7 @@ fn has_correlated_ref(expr: &Option<Expr>, outer_tables: &[String]) -> bool {
 fn check_p012(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -668,6 +679,7 @@ fn check_p012(
 fn check_p013(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -717,6 +729,7 @@ fn check_cartesian_in_from(
 fn check_p014(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -847,6 +860,7 @@ fn subquery_depth_expr(expr: &Expr) -> usize {
 fn check_p015(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -882,6 +896,7 @@ fn literals_equal(a: &Expr, b: &Expr) -> bool {
 fn check_p016(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -905,6 +920,7 @@ fn check_p016(
 fn check_p017(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -926,6 +942,7 @@ fn check_p017(
 fn check_p018(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -951,6 +968,7 @@ fn check_p018(
 fn check_p019(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -974,6 +992,7 @@ fn check_p019(
 fn check_p020(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -1007,6 +1026,7 @@ fn check_p020(
 fn check_p022(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -1031,6 +1051,7 @@ const CASE_REPLACEABLE_FUNCTIONS: &[&str] = &["nvl", "nvl2", "decode", "iif"];
 fn check_p009(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -1068,6 +1089,7 @@ fn check_p009(
 fn check_p021(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -345,27 +345,38 @@ fn check_r006(
                                     .as_ref()
                                     .map(|t| {
                                         crate::analyzer::schema::matches_function_index(
-                                            &idx_info.indexes, t, &fn_lower, &col_lower,
+                                            &idx_info.indexes,
+                                            t,
+                                            &fn_lower,
+                                            &col_lower,
                                         )
                                     })
                                     .unwrap_or(false);
 
                                 if has_index && !has_func_index {
                                     warnings.push(make_warning(
-                                        WarningLevel::Prohibition, "R006", "function-on-where-column",
+                                        WarningLevel::Prohibition,
+                                        "R006",
+                                        "function-on-where-column",
                                         "WHERE 中对有索引的列使用函数，将导致索引失效".into(),
-                                        Some("将函数运算移到等号另一侧或使用函数索引"), loc,
-                                        Some("WHERE 规范"), confidence,
+                                        Some("将函数运算移到等号另一侧或使用函数索引"),
+                                        loc,
+                                        Some("WHERE 规范"),
+                                        confidence,
                                     ));
                                     return false;
                                 }
                             }
                             None => {
                                 warnings.push(make_warning(
-                                    WarningLevel::Prohibition, "R006", "function-on-where-column",
+                                    WarningLevel::Prohibition,
+                                    "R006",
+                                    "function-on-where-column",
                                     "WHERE 中对列使用函数，可能导致索引失效".into(),
-                                    Some("将函数运算移到等号另一侧或使用函数索引"), loc,
-                                    Some("WHERE 规范"), confidence,
+                                    Some("将函数运算移到等号另一侧或使用函数索引"),
+                                    loc,
+                                    Some("WHERE 规范"),
+                                    confidence,
                                 ));
                                 return false;
                             }
@@ -418,10 +429,14 @@ fn emit_index_aware_r006(
         }
     }
     warnings.push(make_warning(
-        WarningLevel::Prohibition, "R006", "function-on-where-column",
+        WarningLevel::Prohibition,
+        "R006",
+        "function-on-where-column",
         "WHERE 中对有索引的列使用函数或表达式，将导致索引失效".into(),
-        Some("将运算移到等号另一侧"), loc,
-        Some("WHERE 规范"), confidence,
+        Some("将运算移到等号另一侧"),
+        loc,
+        Some("WHERE 规范"),
+        confidence,
     ));
 }
 
@@ -438,7 +453,6 @@ fn get_where_and_tables(stmt: &Statement) -> (Option<&Expr>, &[crate::ast::Table
 /// Resolve which table a column belongs to from the FROM clause.
 /// Returns the table name (lowercase), or None if unresolvable.
 fn resolve_table_from_column(col_ref: &[String], tables: &[crate::ast::TableRef]) -> Option<String> {
-
     if col_ref.len() >= 2 {
         return Some(col_ref[col_ref.len() - 2].to_lowercase());
     }
@@ -466,9 +480,9 @@ fn table_name(tref: &crate::ast::TableRef) -> Option<&str> {
             }
         }
         TableRef::Join { left, .. } => table_name(left),
-        TableRef::Subquery { alias, .. }
-        | TableRef::FunctionCall { alias, .. }
-        | TableRef::Values { alias, .. } => alias.as_deref(),
+        TableRef::Subquery { alias, .. } | TableRef::FunctionCall { alias, .. } | TableRef::Values { alias, .. } => {
+            alias.as_deref()
+        }
         TableRef::Pivot { source, .. } | TableRef::Unpivot { source, .. } => table_name(source),
     }
 }

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -82,6 +82,7 @@ pub fn register(linter: &mut SqlLinter) {
 fn check_r001(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -107,6 +108,7 @@ fn check_r001(
 fn check_r002(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -140,6 +142,7 @@ fn check_r002(
 fn check_r003(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -161,6 +164,7 @@ fn check_r003(
 fn check_r004(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -207,6 +211,7 @@ fn object_type_str(ot: &crate::ast::ObjectType) -> &'static str {
 fn check_r005(
     stmts: &[StatementInfo],
     schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -307,6 +312,7 @@ const SAFE_FUNCTIONS_ON_COLUMNS: &[&str] = &["coalesce", "nvl", "nvl2", "ifnull"
 fn check_r006(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -349,6 +355,7 @@ fn check_r006(
 fn check_r007(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -379,6 +386,7 @@ fn check_r007(
 fn check_r008(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -409,6 +417,7 @@ fn check_r008(
 fn check_r009(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -438,11 +438,28 @@ fn check_r007(
 ) {
     for info in stmts {
         let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where_clause(&info.statement) {
-            walk_expr(where_clause, &mut |e| {
-                if let Expr::Like { pattern, negated: false, .. } = e {
-                    if let Expr::Literal(crate::ast::Literal::String(s)) = pattern.as_ref() {
-                        if s.starts_with('%') || s.starts_with('_') {
+        let (where_clause, tables) = get_where_and_tables(&info.statement);
+        let Some(where_clause) = where_clause else { continue };
+        walk_expr(where_clause, &mut |e| {
+            if let Expr::Like { expr, pattern, negated: false, .. } = e {
+                if let Expr::Literal(crate::ast::Literal::String(s)) = pattern.as_ref() {
+                    if s.starts_with('%') || s.starts_with('_') {
+                        let should_warn = match _indexes {
+                            Some(idx_info) => {
+                                if let Expr::ColumnRef(col_ref) = expr.as_ref() {
+                                    let table = resolve_table_from_column(col_ref, tables);
+                                    let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                                    table
+                                        .and_then(|t| idx_info.column_indexes.get(&t))
+                                        .map(|cols| cols.contains(&col_lower))
+                                        .unwrap_or(false)
+                                } else {
+                                    true
+                                }
+                            }
+                            None => true,
+                        };
+                        if should_warn {
                             warnings.push(make_warning(
                                 WarningLevel::Prohibition, "R007", "like-leading-wildcard",
                                 format!("LIKE '\u{524d}\u{5bfc}\u{901a}\u{914d}\u{7b26} {s}' \u{5c06}\u{5bfc}\u{81f4}\u{65e0}\u{6cd5}\u{4f7f}\u{7528}\u{7d22}\u{5f15}\u{ff0c}\u{89e6}\u{53d1}\u{5168}\u{8868}\u{626b}\u{63cf}"),
@@ -452,9 +469,9 @@ fn check_r007(
                         }
                     }
                 }
-                true
-            });
-        }
+            }
+            true
+        });
     }
 }
 

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -319,35 +319,111 @@ fn check_r006(
 ) {
     for info in stmts {
         let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where_clause(&info.statement) {
-            let mut found = false;
-            walk_expr(where_clause, &mut |e| {
-                if found {
-                    return false;
+        let (where_clause, tables) = get_where_and_tables(&info.statement);
+        let Some(where_clause) = where_clause else { continue };
+
+        walk_expr(where_clause, &mut |e| {
+            if let Expr::FunctionCall { name, args, .. } = e {
+                let fn_lower = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                if SAFE_FUNCTIONS_ON_COLUMNS.contains(&fn_lower.as_str()) {
+                    return true;
                 }
-                if let Expr::FunctionCall { name, args, .. } = e {
-                    let fn_lower = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
-                    if SAFE_FUNCTIONS_ON_COLUMNS.contains(&fn_lower.as_str()) {
-                        return true;
-                    }
-                    for arg in args {
-                        if let Expr::ColumnRef(_) = arg {
-                            found = true;
-                            return false;
+                for arg in args {
+                    if let Expr::ColumnRef(col_ref) = arg {
+                        match _indexes {
+                            Some(idx_info) => {
+                                let table = resolve_table_from_column(col_ref, tables);
+                                let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
+
+                                let has_index = table
+                                    .as_ref()
+                                    .and_then(|t| idx_info.column_indexes.get(t))
+                                    .map(|cols| cols.contains(&col_lower))
+                                    .unwrap_or(false);
+
+                                let has_func_index = table
+                                    .as_ref()
+                                    .map(|t| {
+                                        crate::analyzer::schema::matches_function_index(
+                                            &idx_info.indexes, t, &fn_lower, &col_lower,
+                                        )
+                                    })
+                                    .unwrap_or(false);
+
+                                if has_index && !has_func_index {
+                                    warnings.push(make_warning(
+                                        WarningLevel::Prohibition, "R006", "function-on-where-column",
+                                        "WHERE 中对有索引的列使用函数，将导致索引失效".into(),
+                                        Some("将函数运算移到等号另一侧或使用函数索引"), loc,
+                                        Some("WHERE 规范"), confidence,
+                                    ));
+                                    return false;
+                                }
+                            }
+                            None => {
+                                warnings.push(make_warning(
+                                    WarningLevel::Prohibition, "R006", "function-on-where-column",
+                                    "WHERE 中对列使用函数，可能导致索引失效".into(),
+                                    Some("将函数运算移到等号另一侧或使用函数索引"), loc,
+                                    Some("WHERE 规范"), confidence,
+                                ));
+                                return false;
+                            }
                         }
                     }
                 }
-                true
-            });
-            if found {
-                warnings.push(make_warning(
-                    WarningLevel::Prohibition, "R006", "function-on-where-column",
-                    "WHERE \u{4e2d}\u{5bf9}\u{5217}\u{4f7f}\u{7528}\u{51fd}\u{6570}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{7d22}\u{5f15}\u{5931}\u{6548}".into(),
-                    Some("\u{5c06}\u{51fd}\u{6570}\u{8fd0}\u{7b97}\u{79fb}\u{5230}\u{7b49}\u{53f7}\u{53e6}\u{4e00}\u{4fa7}\u{6216}\u{4f7f}\u{7528}\u{51fd}\u{6570}\u{7d22}\u{5f15}"), loc,
-                    Some("WHERE \u{89c4}\u{8303}"), confidence,
-                ));
+            }
+            true
+        });
+    }
+}
+
+/// Extract the WHERE clause and FROM/tables list from a statement.
+fn get_where_and_tables(stmt: &Statement) -> (Option<&Expr>, &[crate::ast::TableRef]) {
+    match stmt {
+        Statement::Select(s) => (s.where_clause.as_ref(), &s.from),
+        Statement::Update(s) => (s.where_clause.as_ref(), &s.tables),
+        Statement::Delete(s) => (s.where_clause.as_ref(), &s.tables),
+        _ => (extract_where_clause(stmt), &[]),
+    }
+}
+
+/// Resolve which table a column belongs to from the FROM clause.
+/// Returns the table name (lowercase), or None if unresolvable.
+fn resolve_table_from_column(col_ref: &[String], tables: &[crate::ast::TableRef]) -> Option<String> {
+    use crate::ast::TableRef;
+
+    if col_ref.len() >= 2 {
+        return Some(col_ref[col_ref.len() - 2].to_lowercase());
+    }
+
+    if col_ref.len() == 1 {
+        for tref in tables {
+            if let Some(name) = table_name(tref) {
+                return Some(name.to_lowercase());
             }
         }
+    }
+
+    None
+}
+
+/// Extract the effective table name from a TableRef (handles alias).
+fn table_name(tref: &crate::ast::TableRef) -> Option<&str> {
+    use crate::ast::TableRef;
+    match tref {
+        TableRef::Table { name, alias, .. } => {
+            if let Some(a) = alias {
+                Some(a.as_str())
+            } else {
+                name.last().map(|s| s.as_str())
+            }
+        }
+        TableRef::Join { left, .. } => table_name(left),
+        TableRef::Subquery { alias, .. }
+        | TableRef::FunctionCall { alias, .. }
+        | TableRef::Values { alias, .. } => alias.as_deref(),
+        TableRef::Pivot { source, .. } | TableRef::Unpivot { source, .. } => table_name(source),
     }
 }
 

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -373,9 +373,56 @@ fn check_r006(
                     }
                 }
             }
+            if let Expr::TypeCast { expr, .. } = e {
+                if let Expr::ColumnRef(col_ref) = expr.as_ref() {
+                    emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
+                }
+            }
+            if let Expr::BinaryOp { op, left, right, .. } = e {
+                if is_sargability_breaking_op(op) {
+                    if let Expr::ColumnRef(col_ref) = left.as_ref() {
+                        emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
+                    }
+                    if let Expr::ColumnRef(col_ref) = right.as_ref() {
+                        emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
+                    }
+                }
+            }
             true
         });
     }
+}
+
+fn is_sargability_breaking_op(op: &str) -> bool {
+    matches!(op, "+" | "-" | "*" | "/" | "||")
+}
+
+fn emit_index_aware_r006(
+    col_ref: &[String],
+    tables: &[crate::ast::TableRef],
+    _indexes: Option<&crate::linter::IndexInfo>,
+    loc: crate::token::SourceLocation,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    if let Some(idx_info) = _indexes {
+        let table = resolve_table_from_column(col_ref, tables);
+        let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
+        let has_index = table
+            .as_ref()
+            .and_then(|t| idx_info.column_indexes.get(t))
+            .map(|cols| cols.contains(&col_lower))
+            .unwrap_or(false);
+        if !has_index {
+            return;
+        }
+    }
+    warnings.push(make_warning(
+        WarningLevel::Prohibition, "R006", "function-on-where-column",
+        "WHERE 中对有索引的列使用函数或表达式，将导致索引失效".into(),
+        Some("将运算移到等号另一侧"), loc,
+        Some("WHERE 规范"), confidence,
+    ));
 }
 
 /// Extract the WHERE clause and FROM/tables list from a statement.
@@ -391,7 +438,6 @@ fn get_where_and_tables(stmt: &Statement) -> (Option<&Expr>, &[crate::ast::Table
 /// Resolve which table a column belongs to from the FROM clause.
 /// Returns the table name (lowercase), or None if unresolvable.
 fn resolve_table_from_column(col_ref: &[String], tables: &[crate::ast::TableRef]) -> Option<String> {
-    use crate::ast::TableRef;
 
     if col_ref.len() >= 2 {
         return Some(col_ref[col_ref.len() - 2].to_lowercase());

--- a/src/linter/rules_suggestion.rs
+++ b/src/linter/rules_suggestion.rs
@@ -61,6 +61,7 @@ pub fn register(linter: &mut SqlLinter) {
 fn check_s001(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -89,6 +90,7 @@ fn check_s001(
 fn check_s002(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -120,6 +122,7 @@ fn check_s002(
 fn check_s005(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -227,6 +230,7 @@ fn check_pl_stmts_for_type_name(pl_stmts: &[PlStatement], found: &mut bool) {
 fn check_s006(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -256,6 +260,7 @@ fn check_s006(
 fn check_s007(
     stmts: &[StatementInfo],
     schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
@@ -329,6 +334,7 @@ fn check_s007(
 fn check_s008(
     stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,


### PR DESCRIPTION
## Summary

让 R006（函数包裹列导致索引失效）和 R007（LIKE 前导通配符）具备索引感知能力。

### Before: 无差别全量 warning
```
WHERE substr(no_index_col, 1, 5) = 'abc'  →  ⚠️ R006（误报）
WHERE substr(indexed_col, 1, 5) = 'abc'   →  ⚠️ R006（正确）
```

### After: 索引感知精准 warning
```
WHERE substr(no_index_col, 1, 5) = 'abc'  →  ⚪ 不警告（列无索引）
WHERE substr(indexed_col, 1, 5) = 'abc'   →  ⚠️ R006（列有索引且无函数索引覆盖）
WHERE lower(email) LIKE '%abc'             →  ⚪ 不警告（存在函数索引 lower(email)）
```

## Changes

### Schema 类型系统扩展
- 新增 `FullSchema` 结构体：`{ "columns": {...}, "indexes": {...} }`
- 新增 `IndexMapV2` 类型、`build_column_index_set`、`matches_function_index`
- 向后兼容：旧格式 JSON 仍可正常加载

### Linter 基础设施
- 新增 `IndexInfo` 结构体存储索引元数据
- `LintRuleEntry.check_fn` 签名追加 `Option<&IndexInfo>` 参数
- `SqlLinter.set_index_info()` 方法供 CLI 注入索引信息

### R006 索引感知改造
- 有索引信息时：仅对有索引且无函数索引覆盖的列 warning
- 无索引信息时：保持原有行为（全量 warning）
- 扩展 SARGability 检测：覆盖算术运算（`col+1`）、类型转换（`col::text`）、字符串拼接（`col||''`）

### R007 索引感知改造
- 有索引信息时：`LIKE '%...'` 仅对有索引的列 warning

### CLI 集成
- `--schema-json` 支持新格式 `FullSchema`，自动加载索引元数据

## Files
| File | Changes |
|------|---------|
| `src/analyzer/schema.rs` | +314: FullSchema, IndexMapV2, 15 tests |
| `src/linter/mod.rs` | +79: IndexInfo, set_index_info |
| `src/linter/rules_prohibition.rs` | +140: R006/R007 index-aware + SARGability |
| `src/bin/ogsql.rs` | +21: FullSchema loading in run_lint |
| `examples/schema-with-indexes.json` | new: example schema |

## Test Plan
- [x] `cargo check --lib` — compiles cleanly
- [x] `cargo check --lib --tests` — test compilation passes
- [x] `cargo clippy --lib` — only pre-existing `type_complexity` warning
- [x] `cargo fmt --all -- --check` — clean
- [ ] `cargo test --all-features` — pending (environment timeout issue)