### PR TITLE
fix(parser): reject ON CONFLICT syntax unsupported by openGauss/GaussDB

### DIFF
--- a/src/parser/dml.rs
+++ b/src/parser/dml.rs
@@ -1,7 +1,7 @@
 use crate::ast::{
-    ConflictAction, ConflictTarget, DeleteStatement, DmlPartitionClause, InsertAllCondition, InsertAllStatement,
-    InsertAllTarget, InsertFirstStatement, InsertSource, InsertStatement, MergeAction, MergeStatement, MergeWhenClause,
-    OnConflict, OnDuplicateKeyUpdate, OrderByItem, TablePartitionRef, TableRef, UpdateAssignment, UpdateStatement,
+    DeleteStatement, DmlPartitionClause, InsertAllCondition, InsertAllStatement, InsertAllTarget, InsertFirstStatement,
+    InsertSource, InsertStatement, MergeAction, MergeStatement, MergeWhenClause, OnConflict, OnDuplicateKeyUpdate,
+    OrderByItem, TablePartitionRef, TableRef, UpdateAssignment, UpdateStatement,
 };
 use crate::parser::{Parser, ParserError};
 use crate::token::keyword::Keyword;
@@ -153,7 +153,7 @@ impl Parser {
                 got: format!("{:?}", self.peek()),
             });
         };
-        let mut on_conflict: Option<OnConflict> = None;
+        let on_conflict: Option<OnConflict> = None;
         let on_duplicate_key = if self.match_keyword(Keyword::ON) {
             self.advance();
             if self.match_keyword(Keyword::DUPLICATE) {
@@ -179,52 +179,11 @@ impl Parser {
                 };
                 Some(OnDuplicateKeyUpdate { assignments, where_clause })
             } else if self.match_keyword(Keyword::CONFLICT) {
-                self.advance();
-                let target = if self.match_keyword(Keyword::ON) {
-                    self.advance();
-                    self.expect_keyword(Keyword::CONSTRAINT)?;
-                    let name = self.parse_identifier()?;
-                    Some(ConflictTarget::OnConstraint(name))
-                } else if self.match_token(&Token::LParen) {
-                    self.advance();
-                    let mut cols = vec![self.parse_identifier()?];
-                    while self.match_token(&Token::Comma) {
-                        self.advance();
-                        cols.push(self.parse_identifier()?);
-                    }
-                    self.expect_token(&Token::RParen)?;
-                    Some(ConflictTarget::Columns(cols))
-                } else {
-                    None
-                };
-                self.expect_keyword(Keyword::DO)?;
-                let action = if self.match_keyword(Keyword::NOTHING) {
-                    self.advance();
-                    ConflictAction::DoNothing
-                } else {
-                    self.expect_keyword(Keyword::UPDATE)?;
-                    self.expect_keyword(Keyword::SET)?;
-                    let mut assignments = Vec::new();
-                    loop {
-                        let column = self.parse_object_name()?;
-                        self.expect_token(&Token::Eq)?;
-                        let value = self.parse_expr()?;
-                        assignments.push(UpdateAssignment { columns: vec![column], value });
-                        if !self.match_token(&Token::Comma) {
-                            break;
-                        }
-                        self.advance();
-                    }
-                    let where_clause = if self.match_keyword(Keyword::WHERE) {
-                        self.advance();
-                        Some(self.parse_expr()?)
-                    } else {
-                        None
-                    };
-                    ConflictAction::DoUpdate { assignments, where_clause }
-                };
-                on_conflict = Some(OnConflict { target, action });
-                None
+                return Err(ParserError::UnsupportedSyntax {
+                    location: self.current_location(),
+                    syntax: "ON CONFLICT".to_string(),
+                    hint: "use ON DUPLICATE KEY UPDATE instead (openGauss/GaussDB does not support PostgreSQL's ON CONFLICT syntax)".to_string(),
+                });
             } else {
                 self.pos -= 1;
                 None

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -6928,88 +6928,52 @@ END;"#;
 }
 
 #[test]
-fn test_on_conflict_do_nothing() {
+fn test_on_conflict_rejected_do_nothing() {
     let sql = "INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING";
     let tokens = Tokenizer::new(sql).tokenize().unwrap();
     let mut parser = Parser::new(tokens);
-    let stmts = parser.parse();
+    let _ = parser.parse();
     let errors = parser.errors();
-    assert!(errors.is_empty(), "Expected no errors: {:?}", errors);
-    match &stmts[0] {
-        Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.as_ref().expect("expected on_conflict");
-            assert!(oc.target.is_none());
-            assert!(matches!(oc.action, ConflictAction::DoNothing));
-        }
-        _ => panic!("expected Insert"),
-    }
+    assert!(!errors.is_empty(), "ON CONFLICT should be rejected");
+    let msg = format!("{}", errors[0]);
+    assert!(msg.contains("ON CONFLICT"), "error should mention ON CONFLICT: {}", msg);
+    assert!(msg.contains("ON DUPLICATE KEY UPDATE"), "error should suggest ON DUPLICATE KEY UPDATE: {}", msg);
 }
 
 #[test]
-fn test_on_conflict_do_update() {
+fn test_on_conflict_rejected_do_update() {
     let sql = "INSERT INTO t VALUES (1) ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name";
     let tokens = Tokenizer::new(sql).tokenize().unwrap();
     let mut parser = Parser::new(tokens);
-    let stmts = parser.parse();
-    match &stmts[0] {
-        Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.as_ref().expect("expected on_conflict");
-            match &oc.target {
-                Some(ConflictTarget::Columns(cols)) => assert_eq!(cols, &["id"]),
-                _ => panic!("expected Columns target"),
-            }
-            match &oc.action {
-                ConflictAction::DoUpdate { assignments, where_clause } => {
-                    assert_eq!(assignments.len(), 1);
-                    assert!(where_clause.is_none());
-                }
-                _ => panic!("expected DoUpdate"),
-            }
-        }
-        _ => panic!("expected Insert, got {:?}", stmts[0]),
-    }
+    let _ = parser.parse();
+    let errors = parser.errors();
+    assert!(!errors.is_empty(), "ON CONFLICT should be rejected");
+    let msg = format!("{}", errors[0]);
+    assert!(msg.contains("ON CONFLICT"), "error should mention ON CONFLICT: {}", msg);
 }
 
 #[test]
-fn test_on_conflict_on_constraint() {
+fn test_on_conflict_rejected_on_constraint() {
     let sql = "INSERT INTO t VALUES (1) ON CONFLICT ON CONSTRAINT pk DO NOTHING";
     let tokens = Tokenizer::new(sql).tokenize().unwrap();
     let mut parser = Parser::new(tokens);
-    let stmts = parser.parse();
+    let _ = parser.parse();
     let errors = parser.errors();
-    assert!(errors.is_empty(), "Expected no errors: {:?}", errors);
-    match &stmts[0] {
-        Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.as_ref().expect("expected on_conflict");
-            match &oc.target {
-                Some(ConflictTarget::OnConstraint(name)) => assert_eq!(name, "pk"),
-                _ => panic!("expected OnConstraint target"),
-            }
-            assert!(matches!(oc.action, ConflictAction::DoNothing));
-        }
-        _ => panic!("expected Insert"),
-    }
+    assert!(!errors.is_empty(), "ON CONFLICT should be rejected");
+    let msg = format!("{}", errors[0]);
+    assert!(msg.contains("ON CONFLICT"), "error should mention ON CONFLICT: {}", msg);
 }
 
 #[test]
-fn test_on_conflict_with_where() {
+fn test_on_conflict_rejected_with_where() {
     let sql = "INSERT INTO t VALUES (1, 'test') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name WHERE t.id > 0";
     let tokens = Tokenizer::new(sql).tokenize().unwrap();
     let mut parser = Parser::new(tokens);
-    let stmts = parser.parse();
-    match &stmts[0] {
-        Statement::Insert(ins) => {
-            let oc = ins.node.on_conflict.as_ref().expect("expected on_conflict");
-            match &oc.action {
-                ConflictAction::DoUpdate { assignments, where_clause } => {
-                    assert_eq!(assignments.len(), 1);
-                    assert!(where_clause.is_some());
-                }
-                _ => panic!("expected DoUpdate"),
-            }
-        }
-        _ => panic!("expected Insert, got {:?}", stmts[0]),
-    }
+    let _ = parser.parse();
+    let errors = parser.errors();
+    assert!(!errors.is_empty(), "ON CONFLICT should be rejected");
+    let msg = format!("{}", errors[0]);
+    assert!(msg.contains("ON CONFLICT"), "error should mention ON CONFLICT: {}", msg);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

openGauss/GaussDB does not support PostgreSQL's `ON CONFLICT` UPSERT syntax. The parser now rejects it with a clear `UnsupportedSyntax` error, suggesting `ON DUPLICATE KEY UPDATE` as the correct alternative.

## Background

Issue #165 reported that `ON CONFLICT` was silently accepted by the parser. A previous fix (commit `93ac311`) rejected it, but later commits (`6c8e94e`, `e61f06f`) re-added it for json2sql round-trip compatibility (#168/#170).

This PR takes a different approach: **reject at the parser level while retaining AST types for serde compatibility**.

## Changes

- **`src/parser/dml.rs`**: Replace the `ON CONFLICT` parsing branch (~45 lines) with `ParserError::UnsupportedSyntax`
- **`src/parser/tests.rs`**: Convert 4 `test_on_conflict_*` tests from "expect successful parse" to "expect rejection error"

## Design Decision

| Component | Behavior | Rationale |
|-----------|----------|-----------|
| Parser (SQL → AST) | **Reject** with error | GaussDB doesn't support ON CONFLICT |
| AST types (`OnConflict`, etc.) | **Retained** | json2sql deserialization of old JSON still works |
| Formatter (AST → SQL) | **Retained** | json2sql direction can still format OnConflict nodes |

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --lib --all-features -- -D warnings` — clean
- `cargo test --lib` — **1432 passed, 0 failed**
- `cargo test --test roundtrip` — **16 passed, 0 failed**
- `ON DUPLICATE KEY UPDATE` tests — **2 passed, 0 failed**

## Error Output Example

```
INSERT INTO t VALUES (1) ON CONFLICT DO NOTHING
                          ^^^^^^^^^^^ unsupported syntax at line 1, column 26: ON CONFLICT (use ON DUPLICATE KEY UPDATE instead ...)
```

Closes #165