### PR TITLE
fix(formatter): preserve quote_style for table/column aliases (fixes #228)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.7.2"
+version = "0.8.1"
 dependencies = [
  "axum",
  "clap",

--- a/src/analyzer/return_cursor.rs
+++ b/src/analyzer/return_cursor.rs
@@ -128,11 +128,15 @@ fn extract_result_columns(stmt: &Statement) -> Vec<ResultColumn> {
     for target in &select.targets {
         match target {
             SelectTarget::Expr(expr, alias) => {
-                let name = alias.clone().or_else(|| infer_column_name(expr)).unwrap_or_else(|| "?".to_string());
+                let name = alias
+                    .as_ref()
+                    .map(|i| i.value.clone())
+                    .or_else(|| infer_column_name(expr))
+                    .unwrap_or_else(|| "?".to_string());
                 columns.push(ResultColumn { name, inferred_type: None, expression: format_expr_brief(expr) });
             }
             SelectTarget::Star(table) => {
-                let name = table.as_ref().map(|t| format!("{}.*", t)).unwrap_or_else(|| "*".to_string());
+                let name = table.as_ref().map(|t| t.value.clone() + ".*").unwrap_or_else(|| "*".to_string());
                 columns.push(ResultColumn { name, inferred_type: None, expression: "*".to_string() });
             }
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1050,15 +1050,15 @@ pub struct Cte {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum SelectTarget {
-    Expr(Expr, Option<String>),
-    Star(Option<String>),
+    Expr(Expr, Option<Ident>),
+    Star(Option<Ident>),
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TableRef {
     Table {
         name: ObjectName,
-        alias: Option<String>,
+        alias: Option<Ident>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         column_aliases: Vec<String>,
         partition: Option<TablePartitionRef>,
@@ -1068,20 +1068,20 @@ pub enum TableRef {
     FunctionCall {
         name: ObjectName,
         args: Vec<Expr>,
-        alias: Option<String>,
+        alias: Option<Ident>,
         column_defs: Vec<ColumnDef>,
         #[serde(skip_serializing_if = "Option::is_none")]
         builtin: Option<BuiltinFuncMeta>,
     },
     Subquery {
         query: Box<SelectStatement>,
-        alias: Option<String>,
+        alias: Option<Ident>,
         #[serde(default)]
         lateral: bool,
     },
     Values {
         values: Box<ValuesStatement>,
-        alias: Option<String>,
+        alias: Option<Ident>,
         column_names: Vec<String>,
         #[serde(default)]
         lateral: bool,
@@ -1129,7 +1129,7 @@ pub struct PivotClause {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PivotValue {
     pub value: Expr,
-    pub alias: Option<String>,
+    pub alias: Option<Ident>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1436,13 +1436,13 @@ pub struct XmlAttributes {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct XmlAttribute {
     pub value: Expr,
-    pub name: Option<String>,
+    pub name: Option<Ident>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct XmlContent {
     pub expr: Expr,
-    pub alias: Option<String>,
+    pub alias: Option<Ident>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1500,7 +1500,7 @@ pub struct InsertStatement {
     pub hints: Vec<String>,
     pub with: Option<WithClause>,
     pub table: ObjectName,
-    pub alias: Option<String>,
+    pub alias: Option<Ident>,
     pub partition: Option<DmlPartitionClause>,
     pub columns: Vec<String>,
     pub source: InsertSource,

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -706,12 +706,12 @@ impl SqlFormatter {
             SelectTarget::Expr(expr, alias) => {
                 let mut result = self.format_expr(expr);
                 if let Some(a) = alias {
-                    result = format!("{} AS {}", result, self.quote_identifier(a));
+                    result = format!("{} AS {}", result, self.format_ident(a));
                 }
                 result
             }
             SelectTarget::Star(alias) => match alias {
-                Some(a) => format!("{}.*", self.quote_identifier(a)),
+                Some(a) => format!("{}.*", self.format_ident(a)),
                 None => "*".to_string(),
             },
         }
@@ -742,7 +742,7 @@ impl SqlFormatter {
                     result = format!("{} TIMECAPSULE {}", result, self.format_expr(tc));
                 }
                 if let Some(a) = alias {
-                    result = format!("{} AS {}", result, self.quote_identifier(a));
+                    result = format!("{} AS {}", result, self.format_ident(a));
                 }
                 if !column_aliases.is_empty() {
                     let cols: Vec<String> = column_aliases.iter().map(|c| self.quote_identifier(c)).collect();
@@ -754,7 +754,7 @@ impl SqlFormatter {
                 let args_str: Vec<String> = args.iter().map(|a| self.format_expr(a)).collect();
                 let mut result = format!("{}({})", self.format_object_name(name), args_str.join(", "));
                 if let Some(a) = alias {
-                    result = format!("{} AS {}", result, self.quote_identifier(a));
+                    result = format!("{} AS {}", result, self.format_ident(a));
                 }
                 if !column_defs.is_empty() {
                     let defs: Vec<String> = column_defs.iter().map(|d| self.format_column_def(d)).collect();
@@ -766,7 +766,7 @@ impl SqlFormatter {
                 let sub = format!("({})", self.format_select(query));
                 let result = if *lateral { format!("{} {}", self.kw("LATERAL"), sub) } else { sub };
                 match alias {
-                    Some(a) => format!("{} AS {}", result, self.quote_identifier(a)),
+                    Some(a) => format!("{} AS {}", result, self.format_ident(a)),
                     None => result,
                 }
             }
@@ -783,7 +783,7 @@ impl SqlFormatter {
                                 column_names.iter().map(|c| self.quote_identifier(c)).collect::<Vec<_>>().join(", ")
                             )
                         };
-                        format!(" AS {}{}", self.quote_identifier(a), cols)
+                        format!(" AS {}{}", self.format_ident(a), cols)
                     }
                     None => String::new(),
                 };
@@ -1265,7 +1265,7 @@ impl SqlFormatter {
                 for item in content {
                     result = result + ", " + &self.format_expr(&item.expr);
                     if let Some(alias) = &item.alias {
-                        result = result + " " + &self.kw("AS") + " " + &self.quote_identifier_relaxed(alias);
+                        result = result + " " + &self.kw("AS") + " " + &self.format_ident(alias);
                     }
                 }
                 result + ")"
@@ -1279,7 +1279,7 @@ impl SqlFormatter {
                     .map(|item| {
                         let mut s = self.format_expr(&item.expr);
                         if let Some(alias) = &item.alias {
-                            s = s + " " + &self.kw("AS") + " " + &self.quote_identifier_relaxed(alias);
+                            s = s + " " + &self.kw("AS") + " " + &self.format_ident(alias);
                         }
                         s
                     })
@@ -1383,7 +1383,7 @@ impl SqlFormatter {
             .map(|a| {
                 let mut s = self.format_expr(&a.value);
                 if let Some(name) = &a.name {
-                    s = s + " " + &self.kw("AS") + " " + &self.quote_identifier_relaxed(name);
+                    s = s + " " + &self.kw("AS") + " " + &self.format_ident(name);
                 }
                 s
             })
@@ -1573,7 +1573,7 @@ impl SqlFormatter {
         parts.push(self.format_object_name(&stmt.table));
 
         if let Some(ref alias) = stmt.alias {
-            parts.push(self.quote_identifier(alias));
+            parts.push(self.format_ident(alias));
         }
 
         if let Some(ref p) = stmt.partition {

--- a/src/linter/type_helpers.rs
+++ b/src/linter/type_helpers.rs
@@ -34,7 +34,7 @@ fn collect_table_types(
         TableRef::Table { name, alias, .. } => {
             let table_key = find_schema_table(schema, name);
             if let Some(columns) = table_key.and_then(|k| schema.get(k)) {
-                let lookup_name = alias.as_deref().unwrap_or_else(|| name.last().unwrap_or(&name[0]));
+                let lookup_name = alias.as_deref().unwrap_or_else(|| name.last().map(|i| i.as_str()).unwrap_or(""));
                 let lookup_lower = lookup_name.to_lowercase();
                 for (col, dtype) in columns {
                     map.insert((lookup_lower.clone(), col.to_lowercase()), dtype.clone());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -887,19 +887,19 @@ impl Parser {
     }
 
     /// Try to consume an optional alias: [AS] identifier
-    fn parse_optional_alias(&mut self) -> Result<Option<String>, ParserError> {
+    fn parse_optional_alias(&mut self) -> Result<Option<crate::ast::Ident>, ParserError> {
         if self.match_keyword(Keyword::AS) {
             self.advance();
-            Ok(Some(self.parse_identifier()?))
+            Ok(Some(self.parse_ident()?))
         } else {
             match self.peek() {
-                Token::Ident(_) | Token::QuotedIdent(_) => Ok(Some(self.parse_identifier()?)),
+                Token::Ident(_) | Token::QuotedIdent(_) => Ok(Some(self.parse_ident()?)),
                 Token::Keyword(kw) => {
                     if kw.category() != crate::token::keyword::KeywordCategory::Reserved
                         && !self.is_clause_keyword(kw)
                         && self.looks_like_alias()
                     {
-                        Ok(Some(self.parse_identifier()?))
+                        Ok(Some(self.parse_ident()?))
                     } else {
                         Ok(None)
                     }
@@ -913,15 +913,15 @@ impl Parser {
     /// Unlike parse_optional_alias, also accepts non-reserved keywords as implicit aliases.
     /// Uses 1-token lookahead to avoid consuming keywords that start subsequent clauses
     /// (e.g., LOOP in PL/pgSQL, CONNECT in hierarchical queries, ON DUPLICATE KEY UPDATE in INSERT).
-    fn parse_optional_column_alias(&mut self) -> Result<Option<String>, ParserError> {
+    fn parse_optional_column_alias(&mut self) -> Result<Option<crate::ast::Ident>, ParserError> {
         if self.match_keyword(Keyword::AS) {
             self.advance();
-            Ok(Some(self.parse_identifier()?))
+            Ok(Some(self.parse_ident()?))
         } else {
             match self.peek() {
                 Token::Ident(_) | Token::QuotedIdent(_) => {
                     if self.looks_like_alias() || self.is_bulk_collect_ahead() {
-                        Ok(Some(self.parse_identifier()?))
+                        Ok(Some(self.parse_ident()?))
                     } else {
                         Ok(None)
                     }
@@ -930,7 +930,7 @@ impl Parser {
                     if kw.category() != crate::token::keyword::KeywordCategory::Reserved
                         && (self.looks_like_alias() || self.is_bulk_collect_ahead())
                     {
-                        Ok(Some(self.parse_identifier()?))
+                        Ok(Some(self.parse_ident()?))
                     } else {
                         Ok(None)
                     }

--- a/src/parser/select.rs
+++ b/src/parser/select.rs
@@ -382,13 +382,13 @@ impl Parser {
         let expr = self.parse_expr()?;
         let alias = if self.match_keyword(Keyword::AS) {
             self.advance();
-            Some(self.parse_identifier()?)
+            Some(self.parse_ident()?)
         } else {
             self.parse_optional_column_alias()?
         };
         // Heuristic: catch tokenizer-level merge of "INTO var" into "INTOvar" (missing space)
-        if let Some(ref alias_str) = alias {
-            let upper = alias_str.to_uppercase();
+        if let Some(ref alias_ident) = alias {
+            let upper = alias_ident.to_uppercase();
             if upper.starts_with("INTO")
                 && upper.len() > 4
                 && upper[4..].chars().next().is_some_and(|c| c.is_ascii_alphabetic())
@@ -397,8 +397,8 @@ impl Parser {
                 self.add_error(ParserError::Warning {
                     message: format!(
                         "alias \"{}\" looks like a typo for \"INTO {}\" — possible missing space",
-                        alias_str,
-                        &alias_str[4..]
+                        alias_ident.as_str(),
+                        &upper[4..]
                     ),
                     location: loc,
                 });
@@ -738,15 +738,15 @@ impl Parser {
             self.expect_token(&Token::RParen)?;
             let alias = if self.match_keyword(Keyword::AS) {
                 self.advance();
-                Some(self.parse_identifier()?)
+                Some(self.parse_ident()?)
             } else {
                 match self.peek() {
-                    Token::Ident(_) | Token::QuotedIdent(_) => Some(self.parse_identifier()?),
+                    Token::Ident(_) | Token::QuotedIdent(_) => Some(self.parse_ident()?),
                     Token::Keyword(kw) => {
                         if kw.category() != crate::token::keyword::KeywordCategory::Reserved
                             && !self.is_clause_keyword(kw)
                         {
-                            Some(self.parse_identifier()?)
+                            Some(self.parse_ident()?)
                         } else {
                             None
                         }
@@ -1009,14 +1009,14 @@ impl Parser {
         Ok(Some(clause))
     }
 
-    fn parse_pivot_alias(&mut self) -> Result<Option<String>, ParserError> {
+    fn parse_pivot_alias(&mut self) -> Result<Option<crate::ast::Ident>, ParserError> {
         if self.match_keyword(Keyword::AS) {
             self.advance();
             let alias = match self.peek().clone() {
-                Token::Ident(_) | Token::QuotedIdent(_) => self.parse_identifier()?,
+                Token::Ident(_) | Token::QuotedIdent(_) => self.parse_ident()?,
                 Token::StringLiteral(s) => {
                     self.advance();
-                    s
+                    crate::ast::Ident::new(s)
                 }
                 _ => {
                     return Err(ParserError::UnexpectedToken {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -12016,7 +12016,7 @@ fn guard_unreserved_keyword_table_alias() {
         Statement::Select(s) => match &s.from[0] {
             TableRef::Table { alias, name, .. } => {
                 assert_eq!(name, &vec!["table_name".to_string()]);
-                assert_eq!(alias, &Some("client".to_string()));
+                assert_eq!(alias.as_deref(), Some("client"));
             }
             other => panic!("expected Table ref, got {:?}", other),
         },

--- a/tests/quoted_identifier_roundtrip.rs
+++ b/tests/quoted_identifier_roundtrip.rs
@@ -42,3 +42,44 @@ fn create_table_quoted_name() {
     let out = format_sql("CREATE TABLE \"MyTable\" (id INT)");
     assert!(out.contains("\"MyTable\""), "Got: {out}");
 }
+
+// --- Issue #228: alias quote_style preservation ---
+
+#[test]
+fn unquoted_uppercase_table_alias_not_quoted() {
+    // Issue #228: uppercase unquoted alias "A" must NOT gain quotes
+    let out = format_sql("SELECT * FROM PAR A, VAB v WHERE a.col = v.col");
+    assert!(!out.contains("\"A\""), "Unquoted alias should not gain quotes. Got: {out}");
+    assert!(!out.contains("\"v\""), "Unquoted lowercase alias should not gain quotes. Got: {out}");
+}
+
+#[test]
+fn quoted_table_alias_preserved() {
+    let out = format_sql("SELECT * FROM \"PAR\" \"A\"");
+    assert!(out.contains("\"PAR\""), "Quoted table name should keep quotes. Got: {out}");
+    assert!(out.contains("\"A\""), "Quoted alias should keep quotes. Got: {out}");
+}
+
+#[test]
+fn subquery_alias_quote_style_preserved() {
+    let out = format_sql("SELECT * FROM (SELECT 1) T");
+    assert!(!out.contains("\"T\""), "Unquoted subquery alias should not gain quotes. Got: {out}");
+
+    let out = format_sql("SELECT * FROM (SELECT 1) \"T\"");
+    assert!(out.contains("\"T\""), "Quoted subquery alias should keep quotes. Got: {out}");
+}
+
+#[test]
+fn column_alias_quote_style_preserved() {
+    let out = format_sql("SELECT col AS MyCol FROM t");
+    assert!(!out.contains("\"MyCol\""), "Unquoted column alias should not gain quotes. Got: {out}");
+
+    let out = format_sql("SELECT col AS \"MyCol\" FROM t");
+    assert!(out.contains("\"MyCol\""), "Quoted column alias should keep quotes. Got: {out}");
+}
+
+#[test]
+fn insert_alias_quote_style_preserved() {
+    let out = format_sql("INSERT INTO t T VALUES (1)");
+    assert!(!out.contains("\"T\""), "Unquoted INSERT alias should not gain quotes. Got: {out}");
+}


### PR DESCRIPTION
## Summary

Follow-up to #224 (fixed by PR #226 for `ObjectName`). The same quote-style bug persisted for **aliases** because they were stored as `Option<String>`, not `Option<Ident>`.

## Problem

`SqlFormatter` used `quote_identifier(&str)` (character heuristic: non-lowercase → add quotes) for aliases. This wrongly quoted unquoted uppercase aliases:

```sql
Input:  SELECT * FROM PAR A, VAB v WHERE a.col = v.col
Before: SELECT * FROM PAR AS "A", VAB AS v WHERE a.col = v.col  -- "A" wrongly quoted
After:  SELECT * FROM PAR AS A, VAB AS v WHERE a.col = v.col     -- correct
```

In openGauss (PostgreSQL folding), `"A"` (quoted) ≠ `a` (unquoted ref) → column references break.

## Fix

Migrated **9 AST fields** from `Option<String>` to `Option<Ident>`:

| Struct | Field |
|---|---|
| `TableRef::Table` | `alias` |
| `TableRef::FunctionCall` | `alias` |
| `TableRef::Subquery` | `alias` |
| `TableRef::Values` | `alias` |
| `PivotValue` | `alias` |
| `XmlContent` | `alias` |
| `XmlAttribute` | `name` |
| `InsertStatement` | `alias` |
| `SelectTarget::Expr`/`Star` | column alias |

Parser (`parse_optional_alias`, `parse_optional_column_alias`) now uses `parse_ident()` to preserve `quote_style`. Formatter uses `format_ident()` (quote-style-aware) instead of `quote_identifier()` (heuristic).

## Verification

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --all-features -- -D warnings`
- ✅ `cargo test --all-features` — 1927 tests, 0 failures
- ✅ 5 regression tests added in `tests/quoted_identifier_roundtrip.rs`
- ✅ JSON serde backward compatible (Ident accepts both plain strings and objects)