### PR TITLE
feat(formatter): subquery indentation, AND/OR indent, BETWEEN/comma/JOIN fixes

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -365,11 +365,17 @@ impl SqlFormatter {
     }
 
     fn multiline_format_sql(&self, flat: &str, indent: usize) -> String {
-        let pad = Self::pad(indent);
-        let cont_pad = format!("{}{}", pad, Self::pad(1));
-
-        let break_before = [
+        // Break points: (pattern, is_conditional_clause).
+        // JOIN variants are listed before bare " JOIN " so the overlap
+        // dedup below keeps the longer match and discards the inner one.
+        let break_before: [(&str, bool); 21] = [
             (" FROM ", false),
+            (" LEFT JOIN ", false),
+            (" RIGHT JOIN ", false),
+            (" INNER JOIN ", false),
+            (" FULL JOIN ", false),
+            (" CROSS JOIN ", false),
+            (" JOIN ", false),
             (" WHERE ", true),
             (" GROUP BY ", false),
             (" HAVING ", true),
@@ -386,32 +392,27 @@ impl SqlFormatter {
             (" EXCEPT ", false),
         ];
 
-        let mut positions: Vec<(usize, usize, bool)> = Vec::new();
+        let depths = Self::compute_paren_depths(flat);
+
+        let mut positions: Vec<(usize, usize, bool, i32)> = Vec::new();
         for (pattern, is_cond) in &break_before {
             let mut search_from = 0;
             while let Some(pos) = flat[search_from..].find(pattern) {
                 let match_start = search_from + pos;
                 let kw_start = match_start + 1;
                 let kw_end = kw_start + pattern.trim().len();
-                let mut paren_depth = 0i32;
-                for ch in flat[..kw_start].chars() {
-                    match ch {
-                        '(' => paren_depth += 1,
-                        ')' => paren_depth -= 1,
-                        _ => {}
-                    }
-                }
-                if paren_depth == 0 {
-                    positions.push((kw_start, kw_end, *is_cond));
-                }
+                let paren_depth = depths.get(kw_start).copied().unwrap_or(0);
+                positions.push((kw_start, kw_end, *is_cond, paren_depth));
                 search_from = match_start + pattern.len();
                 if search_from >= flat.len() {
                     break;
                 }
             }
         }
-        positions.sort_by_key(|(start, _, _)| *start);
-        positions.dedup_by_key(|(start, _, _)| *start);
+        positions.sort_by_key(|(start, _, _, _)| *start);
+        // Deduplicate: remove keywords whose range falls inside a longer
+        // keyword at the same position (e.g. "JOIN" inside "LEFT JOIN").
+        positions.dedup_by(|next, prev| next.0 >= prev.0 && next.0 < prev.1);
 
         if positions.is_empty() {
             return flat.to_string();
@@ -419,14 +420,16 @@ impl SqlFormatter {
 
         let mut result = String::new();
 
-        for (i, (start, kw_end, is_cond)) in positions.iter().enumerate() {
+        for (i, (start, kw_end, is_cond, depth)) in positions.iter().enumerate() {
             if i == 0 && *start > 0 {
                 result.push_str(flat[..*start].trim());
             }
 
             if !result.is_empty() {
                 result.push('\n');
-                result.push_str(&pad);
+                // Indent proportionally to subquery nesting depth.
+                let line_pad = Self::pad(indent + *depth as usize);
+                result.push_str(&line_pad);
             }
 
             let kw_and_content_end = if i + 1 < positions.len() { positions[i + 1].0 } else { flat.len() };
@@ -435,9 +438,10 @@ impl SqlFormatter {
             let content = flat[*kw_end..kw_and_content_end].trim();
 
             if *is_cond && !content.is_empty() {
+                let cond_cont_pad = format!("{}{}", Self::pad(indent + *depth as usize), Self::pad(1));
                 result.push_str(kw_text);
                 result.push(' ');
-                result.push_str(&Self::break_logical_ops(content, &cont_pad));
+                result.push_str(&Self::break_logical_ops(content, &cond_cont_pad));
             } else {
                 result.push_str(kw_text);
                 if !content.is_empty() {
@@ -452,6 +456,27 @@ impl SqlFormatter {
         } else {
             result
         }
+    }
+
+    /// Compute parenthesis nesting depth at every byte position of `s`.
+    ///
+    /// Returns a vector where `depths[i]` is the paren depth *after*
+    /// processing byte `i-1` (i.e. the depth at position `i`).
+    /// Works on raw bytes because `(` and `)` are single-byte ASCII.
+    fn compute_paren_depths(s: &str) -> Vec<i32> {
+        let bytes = s.as_bytes();
+        let mut depths = Vec::with_capacity(bytes.len() + 1);
+        let mut d = 0i32;
+        depths.push(d);
+        for &b in bytes {
+            match b {
+                b'(' => d += 1,
+                b')' => d -= 1,
+                _ => {}
+            }
+            depths.push(d);
+        }
+        depths
     }
 
     fn break_logical_ops(condition: &str, pad: &str) -> String {
@@ -5940,13 +5965,44 @@ mod tests {
     }
 
     #[test]
-    fn test_pretty_print_subquery_no_break_inside() {
+    fn test_pretty_print_subquery_from_clause() {
         let sql = "SELECT * FROM (SELECT id FROM t WHERE x = 1) sub";
         let stmt = parse_one(sql);
         let formatter = SqlFormatter::new().pretty_print(true);
         let result = formatter.format_statement(&stmt);
-        assert!(result.contains("\nFROM"));
-        assert_eq!(result.matches("\nFROM").count(), 1);
+        assert!(result.contains("\nFROM (SELECT"), "outer FROM: {result}");
+        assert!(result.contains("\n  FROM t"), "subquery FROM at depth 1: {result}");
+        assert!(result.contains("\n  WHERE x = 1"), "subquery WHERE: {result}");
+    }
+
+    #[test]
+    fn test_pretty_print_exists_subquery() {
+        let sql = "SELECT id FROM t WHERE a = 1 AND EXISTS (SELECT 1 FROM u WHERE u.id = t.id)";
+        let stmt = parse_one(sql);
+        let formatter = SqlFormatter::new().pretty_print(true);
+        let result = formatter.format_statement(&stmt);
+        assert!(result.contains("\n  FROM u"), "EXISTS subquery FROM: {result}");
+        assert!(result.contains("\n  WHERE u.id = t.id"), "EXISTS subquery WHERE: {result}");
+    }
+
+    #[test]
+    fn test_pretty_print_join_breaks() {
+        let sql = "SELECT a.id FROM users a LEFT JOIN orders b ON a.id = b.uid INNER JOIN items c ON b.iid = c.id";
+        let stmt = parse_one(sql);
+        let formatter = SqlFormatter::new().pretty_print(true);
+        let result = formatter.format_statement(&stmt);
+        assert!(result.contains("\nLEFT JOIN"), "LEFT JOIN on new line: {result}");
+        assert!(result.contains("\nINNER JOIN"), "INNER JOIN on new line: {result}");
+    }
+
+    #[test]
+    fn test_pretty_print_nested_subquery() {
+        let sql = "SELECT * FROM (SELECT id FROM (SELECT id FROM deep WHERE x = 1) inner_t) outer_t";
+        let stmt = parse_one(sql);
+        let formatter = SqlFormatter::new().pretty_print(true);
+        let result = formatter.format_statement(&stmt);
+        assert!(result.contains("\n  FROM (SELECT"), "middle subquery at depth 1: {result}");
+        assert!(result.contains("\n    FROM deep"), "innermost subquery at depth 2: {result}");
     }
 
     #[test]

--- a/src/token_formatter.rs
+++ b/src/token_formatter.rs
@@ -81,6 +81,8 @@ enum IndentKind {
     Merge,
     Cte,
     UpdateSet,
+    WhereCont,
+    ParenExpr,
 }
 
 // ── TokenFormatter ─────────────────────────────────────────────────────────────
@@ -95,6 +97,23 @@ pub struct TokenFormatter<'a> {
     config: FormatConfig,
     /// Parenthesis nesting depth (for subquery / nested expression detection)
     paren_depth: usize,
+    /// Tracks the paren_depth at which BETWEEN was last seen.
+    /// When AND is encountered at the same depth, it is treated as
+    /// BETWEEN's partner (not a logical AND) and kept inline.
+    between_depth: Option<i32>,
+    /// Parallel to indent_stack: records the paren_depth at which each
+    /// IndentKind::Subquery was pushed.  Used in RParen to only pop the
+    /// Subquery indent when the matching `)` is encountered, avoiding
+    /// false pops for function-call parens inside subqueries.
+    subquery_depths: Vec<usize>,
+    /// Parallel to indent_stack for IndentKind::ParenExpr: records the
+    /// paren_depth at which each expression-paren was opened, so RParen
+    /// can pop the correct indent level.
+    paren_expr_depths: Vec<usize>,
+    /// True when inside a DML statement (SELECT / INSERT / UPDATE / DELETE
+    /// / MERGE / WITH).  AND/OR continuation indent is only applied in
+    /// DML contexts to avoid false positives in DDL like CREATE OR REPLACE.
+    dml_stmt_active: bool,
 }
 
 impl<'a> TokenFormatter<'a> {
@@ -118,6 +137,10 @@ impl<'a> TokenFormatter<'a> {
             output: String::new(),
             config,
             paren_depth: 0,
+            between_depth: None,
+            subquery_depths: Vec::new(),
+            paren_expr_depths: Vec::new(),
+            dml_stmt_active: false,
         }
     }
 
@@ -278,6 +301,10 @@ impl<'a> TokenFormatter<'a> {
         self.indent_stack.iter().any(|k| matches!(k, IndentKind::Select))
     }
 
+    fn in_subquery(&self) -> bool {
+        self.indent_stack.iter().any(|k| matches!(k, IndentKind::Subquery))
+    }
+
     fn in_pl_block(&self) -> bool {
         self.indent_stack
             .iter()
@@ -298,6 +325,16 @@ impl<'a> TokenFormatter<'a> {
 
     fn in_cte_context(&self) -> bool {
         self.indent_stack.iter().any(|k| matches!(k, IndentKind::Cte))
+    }
+
+    fn in_where_cont(&self) -> bool {
+        self.indent_stack.iter().any(|k| matches!(k, IndentKind::WhereCont))
+    }
+
+    fn pop_where_cont(&mut self) {
+        while self.indent_stack.last() == Some(&IndentKind::WhereCont) {
+            self.indent_stack.pop();
+        }
     }
 
     fn is_procedure_or_function_context(&self) -> bool {
@@ -435,6 +472,7 @@ impl<'a> TokenFormatter<'a> {
             // ── Semicolon ──────────────────────────────────────────────────────
             Token::Semicolon => {
                 self.emit_current_token();
+                self.dml_stmt_active = false;
                 // Pop DML/CTE indent contexts, but keep PL/pgSQL block contexts
                 self.indent_stack
                     .retain(|k| matches!(k, IndentKind::Begin | IndentKind::If | IndentKind::Loop | IndentKind::Case));
@@ -448,6 +486,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── SELECT ─────────────────────────────────────────────────────────
             Token::Keyword(Keyword::SELECT) => {
+                self.dml_stmt_active = true;
                 self.emit_line_start();
                 self.emit_current_token();
                 self.indent_stack.push(IndentKind::Select);
@@ -468,6 +507,7 @@ impl<'a> TokenFormatter<'a> {
                     self.emit_space();
                 }
                 self.emit_current_token();
+                self.emit_space();
                 self.pos += 1;
             }
 
@@ -480,11 +520,16 @@ impl<'a> TokenFormatter<'a> {
             | Token::Keyword(Keyword::UNION)
             | Token::Keyword(Keyword::INTERSECT)
             | Token::Keyword(Keyword::EXCEPT) => {
-                if self.in_select_context() {
-                    self.pop_indent_to(IndentKind::Select);
-                }
-                if self.in_update_context() {
-                    self.pop_indent_to(IndentKind::Update);
+                if self.paren_depth == 0 {
+                    if !self.in_subquery() {
+                        self.pop_where_cont();
+                    }
+                    if self.in_select_context() {
+                        self.pop_indent_to(IndentKind::Select);
+                    }
+                    if self.in_update_context() {
+                        self.pop_indent_to(IndentKind::Update);
+                    }
                 }
                 self.emit_line_start();
                 self.emit_current_token();
@@ -500,6 +545,8 @@ impl<'a> TokenFormatter<'a> {
             | Token::Keyword(Keyword::JOIN) => {
                 if self.paren_depth == 0 {
                     self.emit_line_start();
+                } else {
+                    self.emit_space();
                 }
                 self.emit_current_token();
                 self.emit_space();
@@ -507,8 +554,34 @@ impl<'a> TokenFormatter<'a> {
             }
 
             // ── AND / OR ──────────────────────────────────────────────────────
-            Token::Keyword(Keyword::AND) | Token::Keyword(Keyword::OR) => {
-                if self.config.logical_operator_newline && self.paren_depth == 0 {
+            Token::Keyword(Keyword::AND) => {
+                // BETWEEN ... AND: keep the AND inline (it is BETWEEN's partner)
+                if let Some(bd) = self.between_depth {
+                    if bd == self.paren_depth as i32 {
+                        self.emit_default_token();
+                        self.between_depth = None;
+                        // emit_default_token already advanced self.pos
+                        return;
+                    }
+                    self.between_depth = None;
+                }
+                if self.config.logical_operator_newline {
+                    if self.dml_stmt_active && !self.in_subquery() && !self.in_where_cont() {
+                        self.indent_stack.push(IndentKind::WhereCont);
+                    }
+                    self.emit_line_start();
+                    self.emit_current_token();
+                    self.emit_space();
+                    self.pos += 1;
+                } else {
+                    self.emit_default_token();
+                }
+            }
+            Token::Keyword(Keyword::OR) => {
+                if self.config.logical_operator_newline {
+                    if self.dml_stmt_active && !self.in_subquery() && !self.in_where_cont() {
+                        self.indent_stack.push(IndentKind::WhereCont);
+                    }
                     self.emit_line_start();
                     self.emit_current_token();
                     self.emit_space();
@@ -520,11 +593,12 @@ impl<'a> TokenFormatter<'a> {
 
             // ── Comma ──────────────────────────────────────────────────────────
             Token::Comma => {
-                if self.config.select_newline
+                let in_list = (matches!(self.indent_stack.last(), Some(IndentKind::Select))
+                    && self.config.select_newline)
                     || self.in_create_table_body()
                     || self.in_insert_context()
-                    || self.in_update_context()
-                {
+                    || self.in_update_context();
+                if in_list {
                     self.handle_list_comma();
                 } else {
                     self.emit_current_token();
@@ -538,10 +612,13 @@ impl<'a> TokenFormatter<'a> {
                 self.emit_current_token();
                 self.paren_depth += 1;
                 self.pos += 1;
-                // Check if next token is SELECT (subquery)
                 if let Some(Token::Keyword(Keyword::SELECT)) = self.peek_token(0) {
+                    self.subquery_depths.push(self.paren_depth);
                     self.indent_stack.push(IndentKind::Subquery);
                     self.needs_line = true;
+                } else {
+                    self.paren_expr_depths.push(self.paren_depth);
+                    self.indent_stack.push(IndentKind::ParenExpr);
                 }
             }
 
@@ -554,13 +631,24 @@ impl<'a> TokenFormatter<'a> {
                     self.emit_current_token();
                     self.pos += 1;
                 } else {
+                    // Only pop Subquery indent when this ) matches the depth
+                    // of the ( that pushed it (avoid false pops for
+                    // function-call parens inside subqueries).
+                    if let Some(&depth) = self.subquery_depths.last() {
+                        if self.paren_depth == depth {
+                            self.subquery_depths.pop();
+                            self.indent_stack.pop();
+                            self.emit_line_start();
+                        }
+                    }
+                    if let Some(&depth) = self.paren_expr_depths.last() {
+                        if self.paren_depth == depth {
+                            self.paren_expr_depths.pop();
+                            self.indent_stack.pop();
+                        }
+                    }
                     if self.paren_depth > 0 {
                         self.paren_depth -= 1;
-                    }
-                    // If we were in subquery mode, pop indent
-                    if self.indent_stack.last() == Some(&IndentKind::Subquery) {
-                        self.indent_stack.pop();
-                        self.emit_line_start();
                     }
                     self.emit_current_token();
                     self.pos += 1;
@@ -611,9 +699,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── CASE ──────────────────────────────────────────────────────────
             Token::Keyword(Keyword::CASE) => {
-                if self.in_pl_block() {
-                    self.emit_line_start();
-                }
+                self.emit_line_start();
                 self.emit_current_token();
                 self.indent_stack.push(IndentKind::Case);
                 self.pos += 1;
@@ -656,6 +742,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── INSERT INTO ... VALUES ──────────────────────────────────────
             Token::Keyword(Keyword::INSERT) => {
+                self.dml_stmt_active = true;
                 self.emit_line_start();
                 self.emit_current_token();
                 self.emit_space();
@@ -667,6 +754,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── DELETE FROM ─────────────────────────────────────────────────
             Token::Keyword(Keyword::DELETE_P) => {
+                self.dml_stmt_active = true;
                 self.emit_line_start();
                 self.emit_current_token();
                 self.emit_space();
@@ -675,6 +763,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── UPDATE ... SET ──────────────────────────────────────────────
             Token::Keyword(Keyword::UPDATE) => {
+                self.dml_stmt_active = true;
                 self.emit_line_start();
                 self.emit_current_token();
                 self.emit_space();
@@ -686,6 +775,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── MERGE INTO ... USING ... ON ... WHEN ────────────────────────
             Token::Keyword(Keyword::MERGE) => {
+                self.dml_stmt_active = true;
                 self.emit_line_start();
                 self.emit_current_token();
                 self.emit_space();
@@ -695,6 +785,7 @@ impl<'a> TokenFormatter<'a> {
 
             // ── WITH (CTE) ─────────────────────────────────────────────────
             Token::Keyword(Keyword::WITH) => {
+                self.dml_stmt_active = true;
                 self.emit_line_start();
                 self.emit_current_token();
                 self.emit_space();
@@ -760,6 +851,12 @@ impl<'a> TokenFormatter<'a> {
                 self.emit_current_token();
                 self.emit_space();
                 self.pos += 1;
+            }
+
+            // ── BETWEEN (needed for BETWEEN ... AND tracking) ─────────────────
+            Token::Keyword(Keyword::BETWEEN) => {
+                self.between_depth = Some(self.paren_depth as i32);
+                self.emit_default_token();
             }
 
             // ── Default ───────────────────────────────────────────────────────
@@ -1020,7 +1117,7 @@ mod tests {
         let config = FormatConfig { logical_operator_newline: true, select_newline: false, ..Default::default() };
         let input = "SELECT id FROM users WHERE a = 1 AND b = 2 OR c = 3";
         let output = format_sql_with(input, config);
-        assert!(output.contains("WHERE a = 1\nAND b = 2\nOR c = 3"), "AND/OR on new lines: {:?}", output);
+        assert!(output.contains("WHERE a = 1\n  AND b = 2\n  OR c = 3"), "AND/OR on new lines: {:?}", output);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Enhances both formatters (AST `SqlFormatter` and token `TokenFormatter`) to properly indent subqueries, break AND/OR conditions, and handle BETWEEN/comma/JOIN spacing.

## Changes

### AST Formatter (`src/formatter/mod.rs`)
- **Subquery multiline indentation**: Remove `paren_depth==0` filter so keywords inside subqueries (FROM, WHERE, etc.) break onto separate lines with depth-proportional indentation
- **JOIN line breaks**: Add LEFT/RIGHT/INNER/FULL/CROSS JOIN to break keywords with overlap dedup
- **Performance**: `compute_paren_depths()` for O(1) depth lookup

### Token Formatter (`src/token_formatter.rs`)
- **AND/OR indentation**: New `IndentKind::WhereCont` indents AND/OR under WHERE (DML-only via `dml_stmt_active`)
- **Parenthesized OR indent**: New `IndentKind::ParenExpr` indents OR inside `AND (cond1 OR cond2)`
- **BETWEEN...AND**: `between_depth` tracking keeps BETWEEN's AND inline
- **Function-call comma fix**: Use `indent_stack.last()` instead of `in_select_context()` to prevent function commas from breaking
- **Subquery depth matching**: `subquery_depths`/`paren_expr_depths` vectors ensure RParen only pops at matching depth
- **OVER(ORDER BY) fix**: Guard clause-ending keyword pops with `paren_depth==0`
- **Spacing fixes**: FROM, CASE, JOIN keyword spacing corrections

## Test plan
- [x] `cargo test --all-features` — 1934 passed, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] Verified with `metamorphosis/testcases/case6-3.sql` — subqueries, AND/OR, BETWEEN, JOINs all formatted correctly

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)