### PR TITLE
fix(test): gate print_ast_test behind java feature (fixes #234)

### DIFF
--- a/tests/print_ast_test.rs
+++ b/tests/print_ast_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "java")]
+
 use tree_sitter::Parser;
 
 fn print_subtree(src: &str, node: tree_sitter::Node, depth: usize) {


### PR DESCRIPTION
## Problem

`tests/print_ast_test.rs` uses `tree_sitter` and `tree_sitter_java`, both optional dependencies gated behind the `java` feature in `Cargo.toml`:

```toml
tree-sitter = { version = "0.24", optional = true }
tree-sitter-java = { version = "0.23", optional = true }
java = ["dep:tree-sitter", "dep:tree-sitter-java", "dep:walkdir"]
```

The file had no feature gate, so any build without the `java` feature failed with:

```
error[E0433]: cannot find module or crate `tree_sitter` in this scope
 --> tests/print_ast_test.rs:1:5
```

This breaks:
- `cargo test` (default features) — the command documented in the README
- External consumers using ogsql-parser as a path dependency without enabling `java`

Note: CI runs `cargo test --all-features`, which compiles the file (because `java` is enabled), so the bug went unnoticed.

## Fix

Add `#![cfg(feature = "java")]` at the top of the file, matching the existing gate pattern used by `tests/validate_java.rs` (`#[cfg(feature = "java")]`) and `tests/validate_xml.rs` (`#[cfg(feature = "ibatis")]`).

## Verification

- ✅ `cargo test --no-run` (default features) — previously E0433, now all test targets compile
- ✅ `cargo test --features java --test print_ast_test` — `print_ast` runs and passes (no regression)

Closes #234.