### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.8.1"
+version = "0.8.3"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.8.1"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.70"
 description = "A SQL parser for openGauss/GaussDB written in Rust"


### PR DESCRIPTION
## What
Bump `ogsql-parser` version `0.8.1` → `0.8.3`.

- `Cargo.toml`: `version = "0.8.3"`
- `Cargo.lock`: regenerated (`ogsql-parser` entry synced)

## Why
Release bump following the merge of #236 (fix for #234: gate `print_ast_test` behind `java` feature).

## Verification
- ✅ `cargo check` passes (lockfile regenerated cleanly)