### PR TITLE
fix(linter): R005 schema-gated detection + R009 severity alignment (#240, #241)

### DIFF
--- a/docs/ecosystem-rule-mapping.md
+++ b/docs/ecosystem-rule-mapping.md
@@ -1,0 +1,52 @@
+# 生态工具规则映射 (Ecosystem Rule Mapping)
+
+本文档作为 ogsql-parser、metamorphosis、ogexplain-analyzer 三工具间的中性参考。根据 M-ARCH-01 架构原则（"禁止反向依赖"），ogsql-parser 作为基础层，仅输出纯规则违规（rule_id、level、suggestion），不嵌入任何上层工具的引用。上层工具（metamorphosis、ogexplain-analyzer）消费 ogsql-parser 输出，并可根据自身能力添加标注。
+
+## 架构关系
+
+```
+ogsql-parser (base — lint rules R*/P*/C*/S*)
+      ▲
+      │ consumed by
+      ├── metamorphosis (rewrite engine — auto-fix)
+      ├── ogexplain-analyzer (runtime plan diagnosis)
+      └── verieql (bounded equivalence verification)
+```
+
+## 规则映射表
+
+| ogsql Rule ID | ogsql Rule Name | ogsql Severity | metamorphosis Rewrite Capability | ogexplain-analyzer Runtime Check |
+|--------------|----------------|----------------|----------------------------------|--------------------------------|
+| R001 | select-star | Prohibition | Safe-level: auto-expand SELECT * to explicit column list | — |
+| R005 | implicit-type-conversion | Prohibition (schema-aware) | — | TYPE-001: confirms implicit conversion at runtime |
+| R007 | like-leading-wildcard | Prohibition | — | TYPE-004: confirms full scan from leading wildcard |
+| R009 | scalar-subquery-in-select | Performance | Manual-level: suggests JOIN rewrite | — |
+| P001 | union-without-all | Performance | Auto-rewrite: UNION → UNION ALL | — |
+| P002 | not-in-subquery | Performance | subquery-to-join: rewrites NOT IN to LEFT JOIN ... IS NULL | — |
+| P009 | function-instead-of-case | Performance | nvl-to-case: rewrites NVL/NVL2/DECODE to CASE | — |
+| P011 | correlated-subquery | Performance | subquery-to-join: rewrites correlated subquery to JOIN | — |
+
+## 集成模式
+
+ogsql-parser 通过 CLI、HTTP API 或 MCP 接口输出纯规则违规信息：
+
+```json
+{
+  "rule_id": "R001",
+  "level": "prohibition",
+  "message": "SELECT * violates coding standards",
+  "suggestion": "Expand to explicit column list"
+}
+```
+
+上层工具读取此输出后，可基于自身能力添加标注：
+
+- **metamorphosis**：识别可自动重写的规则，提供 rewrite 建议（如 P001、P002、P009、P011）
+- **ogexplain-analyzer**：识别可在执行计划中确认的规则，提供 runtime 验证（如 R005、R007）
+- **verieql**：识别可通过有界等价验证的规则
+
+每个工具在其内部维护独立的映射表；本文档为人工维护的跨工具参考，确保各工具间的映射一致性。
+
+## 维护说明
+
+本文档由 ogsql-parser 维护，作为三工具间的中性参考。当任一工具的规则 ID 或能力变更时，应同步更新此表。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -861,12 +861,10 @@ max_insert_values_rows = 65535 # INSERT VALUES 行数×列数阈值
 | R002 | `large-column-sort` | SELECT | GROUP BY / ORDER BY 超过阈值列的表达式，可能导致性能问题 |
 | R003 | `lock-table` | All | `LOCK TABLE` 可能导致死锁风险 |
 | R004 | `drop-cascade` | All | `DROP ... CASCADE` 可能误删依赖对象 |
-| R005 | `implicit-type-conversion` | SELECT | WHERE 中可能存在隐式类型转换，导致索引失效 |
+| R005 | `implicit-type-conversion` | SELECT | WHERE 中可能存在隐式类型转换，导致索引失效（需 schema 辅助，无 schema 时跳过） |
 | R006 | `function-on-where-column` | DML | WHERE 中对有索引的列使用函数或表达式 |
 | R007 | `like-leading-wildcard` | DML | `LIKE '%...'` 前导通配符导致无法使用索引，触发全表扫描 |
 | R008 | `same-table-column-compare` | DML | 同表列比较：可能未正确使用索引 |
-| R009 | `scalar-subquery-in-select` | SELECT | SELECT 列中包含标量子查询，每行都会执行一次子查询 |
-
 #### 性能 (Performance) — 可识别的性能陷阱
 
 | ID | 名称 | 适用语句 | 说明 |
@@ -882,6 +880,7 @@ max_insert_values_rows = 65535 # INSERT VALUES 行数×列数阈值
 | P009 | `function-instead-of-case` | DML | `NVL`/`NVL2`/`DECODE`/`IIF` 函数可用 CASE 替代，可能更高效 |
 | P010 | `multi-column-update-subquery` | UPDATE | 多列 UPDATE 使用子查询效率较低 |
 | P011 | `correlated-subquery` | DML | 关联子查询可能导致每行执行一次子查询 |
+| R009 | `scalar-subquery-in-select` | SELECT | SELECT 列中包含标量子查询，每行都会执行一次子查询 |
 | P012 | `unnecessary-distinct` | SELECT | DISTINCT 存在，需结合唯一键判断是否必要 |
 | P013 | `cartesian-product` | SELECT | CROSS JOIN 或缺少 JOIN 条件，可能产生笛卡尔积 |
 | P014 | `deeply-nested-subquery` | DML | 子查询嵌套深度超过阈值，性能可能较差 |

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -68,7 +68,7 @@ pub fn register(linter: &mut SqlLinter) {
         LintRuleEntry {
             id: "R009",
             name: "scalar-subquery-in-select",
-            level: WarningLevel::Prohibition,
+            level: WarningLevel::Performance,
             stmt_kind: StatementKind::Select,
             check_fn: check_r009,
         },
@@ -216,6 +216,15 @@ fn check_r005(
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
+    // Without schema, R005 cannot distinguish genuine cross-family implicit
+    // type conversion from safe same-family comparisons (e.g. varchar_col =
+    // 'str'). Skip entirely to avoid false positives on legitimate col =
+    // literal patterns. Mirrors S007's "no schema → skip, no evidence"
+    // approach. See issue #240.
+    let Some(schema) = schema else {
+        return;
+    };
+
     for info in stmts {
         let loc = stmt_location(info);
         let (where_clause, tables) = match &info.statement {
@@ -230,7 +239,7 @@ fn check_r005(
         };
         let Some(where_clause) = where_clause else { continue };
 
-        let col_types = schema.map(|s| build_column_type_map(s, tables));
+        let col_types = build_column_type_map(schema, tables);
 
         let mut found = false;
         walk_expr(where_clause, &mut |e| {
@@ -246,15 +255,13 @@ fn check_r005(
                     return true;
                 }
 
-                if let Some(ref ct) = col_types {
-                    let (lit_expr, col_expr) =
-                        if l_lit { (left.as_ref(), right.as_ref()) } else { (right.as_ref(), left.as_ref()) };
-                    if let (Expr::Literal(lit), Some(col_type)) = (lit_expr, resolve_column_type(col_expr, ct)) {
-                        let lit_family = literal_type_family(lit);
-                        let col_family = classify_type_family(&col_type);
-                        if lit_family == col_family {
-                            return true;
-                        }
+                let (lit_expr, col_expr) =
+                    if l_lit { (left.as_ref(), right.as_ref()) } else { (right.as_ref(), left.as_ref()) };
+                if let (Expr::Literal(lit), Some(col_type)) = (lit_expr, resolve_column_type(col_expr, &col_types)) {
+                    let lit_family = literal_type_family(lit);
+                    let col_family = classify_type_family(&col_type);
+                    if lit_family == col_family {
+                        return true;
                     }
                 }
                 found = true;
@@ -593,7 +600,7 @@ fn check_r009(
                     });
                     if found {
                         warnings.push(make_warning(
-                            WarningLevel::Prohibition, "R009", "scalar-subquery-in-select",
+                            WarningLevel::Performance, "R009", "scalar-subquery-in-select",
                             "SELECT \u{5217}\u{4e2d}\u{5305}\u{542b}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}\u{ff0c}\u{6bcf}\u{884c}\u{90fd}\u{4f1a}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
                             Some("\u{6539}\u{7528} JOIN \u{66ff}\u{4ee3}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}"), loc,
                             Some("SQL \u{7f16}\u{5199}"), confidence,

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -94,10 +94,13 @@ fn r004_drop_no_cascade_not_triggered() {
 // ── R005: Implicit type conversion ──
 
 #[test]
-fn r005_literal_column_comparison() {
+fn r005_literal_column_comparison_no_schema_skipped() {
     let stmts = parse("SELECT * FROM t WHERE name = 'abc'");
     let w = lint(&stmts);
-    assert!(has_rule(&w, "R005"), "expected R005 for literal-column comparison");
+    assert!(
+        !has_rule(&w, "R005"),
+        "without schema, R005 should skip — no evidence of cross-family conversion (issue #240)"
+    );
 }
 
 #[test]
@@ -565,10 +568,8 @@ fn multiple_rules_same_statement() {
 fn no_warnings_clean_sql() {
     let stmts = parse("SELECT id, name FROM users WHERE status = 'active' ORDER BY id");
     let w = lint(&stmts);
-    // R005 may trigger for literal-column comparison, filter it out.
-    // S007 no longer triggers without schema evidence.
-    let non_known: Vec<_> = w.iter().filter(|w| w.rule_id != "R005").collect();
-    assert!(non_known.is_empty(), "clean SQL should not produce warnings (except maybe R005/S007): {:?}", non_known);
+    // Without schema, neither R005 nor S007 fire (both require schema evidence).
+    assert!(w.is_empty(), "clean SQL should not produce warnings: {:?}", w);
 }
 
 // ════════════════════════════════════════════════════════════════
@@ -1091,10 +1092,13 @@ fn r005_int_column_int_literal_no_warn_with_schema() {
 }
 
 #[test]
-fn r005_no_schema_fallback_still_warns() {
+fn r005_no_schema_skips_entirely() {
     let stmts = parse("SELECT * FROM t WHERE name = 'abc'");
     let w = lint(&stmts);
-    assert!(has_rule(&w, "R005"), "without schema, R005 should still warn on literal-column comparison");
+    assert!(
+        !has_rule(&w, "R005"),
+        "without schema, R005 must not warn — avoiding false positives on legitimate col = literal (issue #240)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Resolves #240 and #241 with two distinct concerns plus a documentation addition.

### #240: R005 over-warns without schema (bug)

R005 (implicit-type-conversion) warned on **any** `col = literal` comparison when no schema was provided, producing false positives on safe patterns like `varchar_col = 'str'`.

**Fix**: Early-return when schema is `None`, aligning with S007's established "no schema → skip, no evidence" pattern (`rules_suggestion.rs:300`). The schema-aware path (precise cross-family type comparison) remains unchanged.

### #241: Cross-tool references + R009 severity (enhancement)

**Cross-tool references** — The original proposal to embed `metamorphosis`/`ogexplain-analyzer` references in suggestion strings was **rejected** because ogsql-parser is the base layer (per **M-ARCH-01**: 禁止反向依赖). Instead:
- Created `docs/ecosystem-rule-mapping.md` as a neutral reference doc
- Upper-layer tools maintain their own internal mappings

**R009 severity** — Downgraded from Prohibition to Performance. Scalar subqueries are a performance pitfall with a clear optimization path (rewrite as JOIN), not a data safety / spec compliance violation. R001 remains Prohibition (GaussDB spec explicitly prohibits `SELECT *`).

## Changes

| Commit | Scope | Files |
|--------|-------|-------|
| `efa3101` | R005 skip + R009 level + tests | `rules_prohibition.rs`, `tests.rs` |
| `5f2a8f7` | User-guide sync | `user-guide.md` |
| `2179e58` | Ecosystem mapping doc (new) | `ecosystem-rule-mapping.md` |

## Verification

- [x] `cargo fmt --all -- --check` — CLEAN
- [x] `cargo clippy --all-features -- -D warnings` — 0 warnings
- [x] `cargo test --all-features` — **1834 passed, 0 failed**
- [x] R005 schema-aware tests still pass (same-family skip, cross-family warn)
- [x] R005 no-schema tests updated to assert skip behavior
- [x] R009 tests pass (presence-only assertions, severity-neutral)