### PR TITLE
Public API extraction for issues #243 and #244

### DIFF
--- a/docs/crate-guide.md
+++ b/docs/crate-guide.md
@@ -317,6 +317,32 @@ for err in &errors {
 }
 ```
 
+**综合校验 (validate_statements)：**
+
+一次性运行 PACKAGE 一致性、MERGE 语义、PL 变量校验，保留 typed errors：
+
+```rust
+use ogsql_parser::{Parser, validate_statements};
+
+let (stmts, _) = Parser::parse_sql("MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE");
+let report = validate_statements(&stmts, &[], /* strict */ false);
+
+println!("PACKAGE 错误: {}", report.package_errors.len());
+println!("MERGE 错误: {}", report.merge_errors.len());
+println!("PL 变量错误: {}", report.undefined_variable_errors.len());
+
+if report.is_empty() {
+    println!("校验通过");
+}
+```
+
+`extra_funcs` 参数可注入外部已知函数名，避免跨包调用被误报为未定义：
+
+```rust
+let extra: Vec<String> = vec!["external_func".into()];
+let report = validate_statements(&stmts, &extra, true);
+```
+
 ### 2.7 iBatis/MyBatis XML 解析
 
 需要启用 `ibatis` feature。
@@ -582,6 +608,35 @@ for w in &warnings {
 // 生成摘要
 let summary = ogsql_parser::linter::build_lint_summary(&warnings);
 println!("{}", serde_json::to_string_pretty(&summary).unwrap());
+```
+
+**结构化 Mapper Lint（foreach C018）** `[requires: ibatis feature]`：
+
+扁平 SQL 会将 `<foreach>` 塌缩为单次迭代，导致 C018 漏检。`lint_structured_mapper` 在 `SqlNode` 树（展开前）上运行，检测 INSERT VALUES 中的 foreach 动态批量插入：
+
+```rust
+use ogsql_parser::ibatis;
+use ogsql_parser::linter::structured::lint_structured_mapper;
+use ogsql_parser::linter::LintConfig;
+
+let xml = br#"<mapper namespace="t">
+    <insert id="batch">
+        INSERT INTO t (a, b, c, d, e) VALUES
+        <foreach collection="rows" item="r" separator=",">
+            (#{r.a}, #{r.b}, #{r.c}, #{r.d}, #{r.e})
+        </foreach>
+    </insert>
+</mapper>"#;
+
+let structured = ibatis::parse_mapper_bytes_structured(xml);
+let mut config = LintConfig::default();
+config.max_insert_values_rows = 1000; // 阈值：总绑定参数上限
+config.foreach_estimated_rows = 1000;  // foreach 集合估算行数
+
+let warnings = lint_structured_mapper(&structured, &config);
+for w in &warnings {
+    println!("[{}] {}", w.rule_id, w.message);
+}
 ```
 
 **从 TOML 文件加载配置：**

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,5 +1,6 @@
 pub mod return_cursor;
 pub mod schema;
+pub mod validate;
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;

--- a/src/analyzer/validate.rs
+++ b/src/analyzer/validate.rs
@@ -211,6 +211,36 @@ pub struct ValidationReport {
     pub undefined_variable_errors: Vec<UndefinedVariableError>,
 }
 
+/// Run PACKAGE consistency, MERGE semantics, and PL variable validation on
+/// already-parsed statements. Returns typed errors in three independent
+/// buckets — no folding into `ParserError` (that's a CLI output concern).
+///
+/// This is the library-level equivalent of the `validate` / `validate-xml` /
+/// `validate-java` CLI commands' shared pipeline.
+///
+/// # Arguments
+/// * `stmts` - Already-parsed SQL statements.
+/// * `extra_funcs` - Additional function names to treat as defined (e.g.
+///   routines declared in external packages the consumer knows about).
+/// * `strict` - When `true`, flag undefined function calls in PL blocks.
+pub fn validate_statements(
+    stmts: &[crate::ast::StatementInfo],
+    extra_funcs: &[String],
+    strict: bool,
+) -> ValidationReport {
+    let package_errors = crate::validate_package_consistency(stmts);
+    let merge_errors = crate::validate_merge_semantics(stmts);
+
+    let mut all_funcs: Vec<String> = extra_funcs.to_vec();
+    all_funcs.extend(collect_defined_routine_names(stmts));
+    all_funcs.sort();
+    all_funcs.dedup();
+
+    let undefined_variable_errors = validate_pl_variables_from_stmts(stmts, &all_funcs, strict);
+
+    ValidationReport { package_errors, merge_errors, undefined_variable_errors }
+}
+
 impl ValidationReport {
     /// `true` when every bucket is empty (no findings from any validator).
     pub fn is_empty(&self) -> bool {
@@ -257,5 +287,43 @@ mod tests {
         };
         assert!(!r.is_empty());
         assert_eq!(r.total_count(), 3);
+    }
+
+    #[test]
+    fn validate_statements_empty_input_yields_empty_report() {
+        let report = validate_statements(&[], &[], false);
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn validate_statements_detects_merge_error() {
+        // Non-deterministic MERGE: DELETE in WHEN MATCHED.
+        let stmts = parse_stmts("MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE");
+        let report = validate_statements(&stmts, &[], false);
+        assert!(!report.merge_errors.is_empty(), "expected merge errors");
+    }
+
+    #[test]
+    fn validate_statements_detects_undefined_variable_in_strict_mode() {
+        // undefined_func() is called in a RETURN expression (PERFORM is not checked).
+        let sql =
+            "CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$ BEGIN RETURN undefined_func(); END; $$ LANGUAGE plpgsql";
+        let stmts = parse_stmts(sql);
+        let report = validate_statements(&stmts, &[], true);
+        assert!(!report.undefined_variable_errors.is_empty(), "expected undefined-func errors in strict mode");
+    }
+
+    #[test]
+    fn validate_statements_extra_funcs_suppresses_undefined_error() {
+        let sql =
+            "CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$ BEGIN RETURN known_func(); END; $$ LANGUAGE plpgsql";
+        let stmts = parse_stmts(sql);
+        let report = validate_statements(&stmts, &["known_func".to_string()], true);
+        assert!(report.undefined_variable_errors.is_empty(), "known_func in extra_funcs should suppress error");
+    }
+
+    /// Helper: parse SQL text into Vec<StatementInfo>.
+    fn parse_stmts(sql: &str) -> Vec<crate::ast::StatementInfo> {
+        crate::parser::Parser::parse_sql(sql).0
     }
 }

--- a/src/analyzer/validate.rs
+++ b/src/analyzer/validate.rs
@@ -1,0 +1,72 @@
+//! Public orchestration API for the `validate` CLI command.
+//!
+//! Runs PACKAGE consistency, MERGE semantics, and PL variable validation on
+//! already-parsed statements, preserving typed errors (no folding into
+//! `ParserError`). This is the library-level entry point that the `validate`,
+//! `validate-xml`, and `validate-java` CLI commands build on.
+
+use crate::{MergeSemanticError, PackageConsistencyError, UndefinedVariableError};
+
+/// Aggregate result of running all three validators on a slice of statements.
+///
+/// Each bucket is independent — e.g. `merge_errors` may be empty while
+/// `package_errors` is non-empty. Use [`ValidationReport::is_empty`] to check
+/// whether any validator produced findings.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ValidationReport {
+    /// PACKAGE spec vs PACKAGE BODY mismatches.
+    pub package_errors: Vec<PackageConsistencyError>,
+    /// Non-deterministic / invalid MERGE patterns.
+    pub merge_errors: Vec<MergeSemanticError>,
+    /// Undefined variables / functions in PL/pgSQL blocks.
+    pub undefined_variable_errors: Vec<UndefinedVariableError>,
+}
+
+impl ValidationReport {
+    /// `true` when every bucket is empty (no findings from any validator).
+    pub fn is_empty(&self) -> bool {
+        self.package_errors.is_empty() && self.merge_errors.is_empty() && self.undefined_variable_errors.is_empty()
+    }
+
+    /// Total number of findings across all buckets.
+    pub fn total_count(&self) -> usize {
+        self.package_errors.len() + self.merge_errors.len() + self.undefined_variable_errors.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_default_is_empty() {
+        let r = ValidationReport::default();
+        assert!(r.is_empty());
+        assert_eq!(r.total_count(), 0);
+    }
+
+    #[test]
+    fn report_total_count_sums_all_buckets() {
+        let r = ValidationReport {
+            package_errors: vec![PackageConsistencyError {
+                package_name: "p".into(),
+                subprogram_name: "s".into(),
+                kind: crate::PackageConsistencyErrorKind::MissingInBody,
+                detail: None,
+            }],
+            merge_errors: vec![MergeSemanticError {
+                kind: crate::MergeSemanticErrorKind::DeleteNotSupported,
+                detail: None,
+                location: crate::SourceLocation::default(),
+            }],
+            undefined_variable_errors: vec![UndefinedVariableError {
+                variable_name: "x".into(),
+                location: None,
+                context: "ctx".into(),
+                kind: crate::UndefinedRefKind::Variable,
+            }],
+        };
+        assert!(!r.is_empty());
+        assert_eq!(r.total_count(), 3);
+    }
+}

--- a/src/analyzer/validate.rs
+++ b/src/analyzer/validate.rs
@@ -7,6 +7,89 @@
 
 use crate::{MergeSemanticError, PackageConsistencyError, UndefinedVariableError};
 
+/// Collect the names of all routines (functions, procedures) and package-level types
+/// defined in a slice of statements. Used by the PL variable validator to treat
+/// locally-defined routines as known functions.
+///
+/// Walks `StatementInfo` looking at `CreateFunction`, `CreateProcedure`,
+/// `CreatePackage` (spec), and `CreatePackageBody` — for each subprogram found,
+/// the last component of its (possibly schema-qualified) name is collected in
+/// lowercase. Duplicates and sort order are handled by the caller.
+pub fn collect_defined_routine_names(stmts: &[crate::ast::StatementInfo]) -> Vec<String> {
+    use crate::ast::Statement;
+    let mut names = Vec::new();
+    for si in stmts {
+        match &si.statement {
+            Statement::CreateFunction(func) => {
+                if let Some(last) = func.name.last() {
+                    names.push(last.to_lowercase());
+                }
+            }
+            Statement::CreateProcedure(proc) => {
+                if let Some(last) = proc.name.last() {
+                    names.push(last.to_lowercase());
+                }
+            }
+            Statement::CreatePackage(spec) => {
+                for item in &spec.items {
+                    match item {
+                        crate::ast::PackageItem::Function(f) => {
+                            if let Some(last) = f.name.last() {
+                                names.push(last.to_lowercase());
+                            }
+                        }
+                        crate::ast::PackageItem::Procedure(p) => {
+                            if let Some(last) = p.name.last() {
+                                names.push(last.to_lowercase());
+                            }
+                        }
+                        crate::ast::PackageItem::Type(t) => {
+                            let name = match t {
+                                crate::ast::plpgsql::PlTypeDecl::Record { name, .. } => name,
+                                crate::ast::plpgsql::PlTypeDecl::TableOf { name, .. } => name,
+                                crate::ast::plpgsql::PlTypeDecl::VarrayOf { name, .. } => name,
+                                crate::ast::plpgsql::PlTypeDecl::RefCursor { name } => name,
+                            };
+                            names.push(name.to_lowercase());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Statement::CreatePackageBody(body) => {
+                for item in &body.items {
+                    match item {
+                        crate::ast::PackageItem::Function(f) => {
+                            if let Some(last) = f.name.last() {
+                                names.push(last.to_lowercase());
+                            }
+                        }
+                        crate::ast::PackageItem::Procedure(p) => {
+                            if let Some(last) = p.name.last() {
+                                names.push(last.to_lowercase());
+                            }
+                        }
+                        crate::ast::PackageItem::Type(t) => {
+                            let name = match t {
+                                crate::ast::plpgsql::PlTypeDecl::Record { name, .. } => name,
+                                crate::ast::plpgsql::PlTypeDecl::TableOf { name, .. } => name,
+                                crate::ast::plpgsql::PlTypeDecl::VarrayOf { name, .. } => name,
+                                crate::ast::plpgsql::PlTypeDecl::RefCursor { name } => name,
+                            };
+                            names.push(name.to_lowercase());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
 /// Aggregate result of running all three validators on a slice of statements.
 ///
 /// Each bucket is independent — e.g. `merge_errors` may be empty while

--- a/src/analyzer/validate.rs
+++ b/src/analyzer/validate.rs
@@ -7,6 +7,112 @@
 
 use crate::{MergeSemanticError, PackageConsistencyError, UndefinedVariableError};
 
+/// Walk `StatementInfo` slices, extract `PlBlock`s from each variant
+/// (`CreateProcedure`, `CreateFunction`, `Do`, `AnonyBlock`, `CreatePackageBody`),
+/// and run PL variable/function validation per block.
+///
+/// For package bodies, cross-references package-spec variables so they are
+/// recognised as defined during validation of the body's subprograms.
+pub fn validate_pl_variables_from_stmts(
+    stmts: &[crate::ast::StatementInfo],
+    known_funcs: &[String],
+    strict: bool,
+) -> Vec<crate::UndefinedVariableError> {
+    use crate::ast::Statement;
+    let mut warnings = Vec::new();
+    let funcs_str: Vec<&str> = known_funcs.iter().map(|s| s.as_str()).collect();
+    for si in stmts {
+        match &si.statement {
+            Statement::CreateProcedure(proc) => {
+                if let Some(ref block) = proc.block {
+                    let vars = crate::validate_pl_variables_with_extra_vars_and_funcs(
+                        block,
+                        &proc.parameters,
+                        &[],
+                        &funcs_str,
+                        strict,
+                    );
+                    warnings.extend(vars);
+                }
+            }
+            Statement::CreateFunction(func) => {
+                if let Some(ref block) = func.block {
+                    let vars = crate::validate_pl_variables_with_extra_vars_and_funcs(
+                        block,
+                        &func.parameters,
+                        &[],
+                        &funcs_str,
+                        strict,
+                    );
+                    warnings.extend(vars);
+                }
+            }
+            Statement::Do(do_stmt) => {
+                if let Some(ref block) = do_stmt.block {
+                    let vars =
+                        crate::validate_pl_variables_with_extra_vars_and_funcs(block, &[], &[], &funcs_str, strict);
+                    warnings.extend(vars);
+                }
+            }
+            Statement::CreatePackageBody(body) => {
+                let body_name: String = body.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
+                let mut pkg_vars: Vec<&str> = body
+                    .items
+                    .iter()
+                    .filter_map(|item| match item {
+                        crate::ast::PackageItem::Variable(v) => Some(v.name.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                for other_si in stmts {
+                    if let Statement::CreatePackage(spec) = &other_si.statement {
+                        let spec_name: String =
+                            spec.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
+                        if spec_name == body_name {
+                            for item in &spec.items {
+                                if let crate::ast::PackageItem::Variable(v) = item {
+                                    pkg_vars.push(v.name.as_str());
+                                }
+                            }
+                        }
+                    }
+                }
+                for item in &body.items {
+                    match item {
+                        crate::ast::PackageItem::Procedure(proc) => {
+                            if let Some(ref block) = proc.block {
+                                let vars = crate::validate_pl_variables_with_extra_vars_and_funcs(
+                                    block,
+                                    &proc.parameters,
+                                    &pkg_vars,
+                                    &funcs_str,
+                                    strict,
+                                );
+                                warnings.extend(vars);
+                            }
+                        }
+                        crate::ast::PackageItem::Function(func) => {
+                            if let Some(ref block) = func.block {
+                                let vars = crate::validate_pl_variables_with_extra_vars_and_funcs(
+                                    block,
+                                    &func.parameters,
+                                    &pkg_vars,
+                                    &funcs_str,
+                                    strict,
+                                );
+                                warnings.extend(vars);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    warnings
+}
+
 /// Collect the names of all routines (functions, procedures) and package-level types
 /// defined in a slice of statements. Used by the PL variable validator to treat
 /// locally-defined routines as known functions.

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -399,124 +399,6 @@ fn lint_xml_statements(
     all_warnings
 }
 
-/// Run linter on expanded dynamic SQL variants (foreach with multiple iterations).
-///
-/// Walks the structured SqlNode tree to detect foreach inside INSERT VALUES
-/// and estimates total bind parameters when the collection is large.
-/// This catches cases that flat SQL misses (flat SQL only shows a single iteration).
-#[cfg(feature = "ibatis")]
-fn lint_xml_expanded(
-    xml_bytes: &[u8],
-    config: &ogsql_parser::linter::LintConfig,
-) -> Vec<ogsql_parser::linter::SqlWarning> {
-    let structured = ogsql_parser::ibatis::parse_mapper_bytes_structured(xml_bytes);
-    if !structured.errors.is_empty() {
-        return vec![];
-    }
-    let mut warnings = Vec::new();
-
-    for stmt in &structured.statements {
-        // Check if the body contains INSERT with foreach in VALUES
-        let is_insert_values = is_insert_with_values(&stmt.body);
-        let foreach_in_values = find_foreach_in_insert_values(&stmt.body);
-
-        if let Some(foreach_node) = foreach_in_values {
-            let params_per_row = count_params_in_foreach_body(foreach_node);
-            if params_per_row > 0 {
-                let estimated_rows = 1000; // representative foreach iteration count
-                let total_params = params_per_row * estimated_rows;
-                if total_params > config.max_insert_values_rows || is_insert_values {
-                    warnings.push(ogsql_parser::linter::SqlWarning {
-                        level: ogsql_parser::linter::WarningLevel::Caution,
-                        rule_id: "C018".to_string(),
-                        rule_name: "excessive-insert-values".to_string(),
-                        message: format!(
-                            "INSERT VALUES 包含 foreach 动态批量插入，每行 {} 个参数。若运行时集合包含 {} 行，总绑定参数将达 {}，可能超过阈值 {}。建议使用分批提交或 COPY",
-                            params_per_row,
-                            estimated_rows / 10,
-                            params_per_row * estimated_rows / 10,
-                            config.max_insert_values_rows
-                        ),
-                        suggestion: Some("拆分为更小批次插入以减少锁持有时间，或使用 COPY 替代".to_string()),
-                        location: ogsql_parser::SourceLocation::default(),
-                        gaussdb_ref: None,
-                        confidence: ogsql_parser::linter::Confidence::Partial,
-                    });
-                }
-            }
-        }
-    }
-    warnings
-}
-
-/// Returns true if the SqlNode tree contains an INSERT ... VALUES pattern.
-#[cfg(feature = "ibatis")]
-fn is_insert_with_values(node: &ogsql_parser::ibatis::types::SqlNode) -> bool {
-    use ogsql_parser::ibatis::types::SqlNode;
-    match node {
-        SqlNode::Text { content } => {
-            let lower = content.to_lowercase();
-            lower.contains("insert") && lower.contains("values")
-        }
-        SqlNode::Sequence { children } | SqlNode::Trim { children, .. } => children.iter().any(is_insert_with_values),
-        _ => false,
-    }
-}
-
-/// Finds a ForEach node nested inside INSERT VALUES context.
-#[cfg(feature = "ibatis")]
-fn find_foreach_in_insert_values(
-    node: &ogsql_parser::ibatis::types::SqlNode,
-) -> Option<&ogsql_parser::ibatis::types::SqlNode> {
-    use ogsql_parser::ibatis::types::SqlNode;
-    match node {
-        SqlNode::ForEach { .. } => Some(node),
-        SqlNode::Sequence { children }
-        | SqlNode::Trim { children, .. }
-        | SqlNode::Where { children, .. }
-        | SqlNode::Set { children, .. }
-        | SqlNode::If { children, .. } => {
-            for child in children {
-                if let Some(f) = find_foreach_in_insert_values(child) {
-                    return Some(f);
-                }
-            }
-            None
-        }
-        SqlNode::Choose { branches } => {
-            for (_, ch) in branches {
-                for c in ch {
-                    if let Some(f) = find_foreach_in_insert_values(c) {
-                        return Some(f);
-                    }
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-/// Counts the number of Parameter nodes inside a ForEach body.
-#[cfg(feature = "ibatis")]
-fn count_params_in_foreach_body(node: &ogsql_parser::ibatis::types::SqlNode) -> usize {
-    use ogsql_parser::ibatis::types::SqlNode;
-    match node {
-        SqlNode::Parameter { .. } => 1,
-        SqlNode::Sequence { children }
-        | SqlNode::Trim { children, .. }
-        | SqlNode::Where { children, .. }
-        | SqlNode::Set { children, .. }
-        | SqlNode::If { children, .. }
-        | SqlNode::ForEach { children, .. } => children.iter().map(count_params_in_foreach_body).sum(),
-        SqlNode::Choose { branches } => {
-            branches.iter().flat_map(|(_, ch)| ch.iter().map(count_params_in_foreach_body)).sum()
-        }
-        SqlNode::RawExpr { .. } => 1, // ${expr} also counts as a parameter
-        _ => 0,
-    }
-}
-
 #[cfg(feature = "java")]
 fn lint_java_extractions(
     extractions: &[ogsql_parser::java::types::ExtractedSql],
@@ -4918,7 +4800,8 @@ fn cmd_parse_xml_single(cli: &Cli, csv: bool, java_roots: &[std::path::PathBuf])
     let lint_warnings = if cli.lint {
         let config = build_lint_config(cli);
         let mut ws = lint_xml_statements(&result.statements, &config);
-        let expand_ws = lint_xml_expanded(&input, &config);
+        let structured = ogsql_parser::ibatis::parse_mapper_bytes_structured(&input);
+        let expand_ws = ogsql_parser::linter::structured::lint_structured_mapper(&structured, &config);
         ws.extend(expand_ws);
         ws
     } else {
@@ -5038,7 +4921,8 @@ fn cmd_parse_xml_dir(cli: &Cli, dir_path: &str, csv: bool, java_roots: &[std::pa
 
         if cli.lint {
             let config = build_lint_config(cli);
-            all_expand_lint.extend(lint_xml_expanded(&bytes, &config));
+            let structured = ogsql_parser::ibatis::parse_mapper_bytes_structured(&bytes);
+            all_expand_lint.extend(ogsql_parser::linter::structured::lint_structured_mapper(&structured, &config));
         }
     }
 
@@ -5347,7 +5231,8 @@ fn cmd_validate_xml_single(cli: &Cli, csv: bool, java_roots: &[std::path::PathBu
     // Also run lint_xml_expanded for C018 rule (foreach in INSERT VALUES)
     // 同时运行 lint_xml_expanded 检测 C018 规则（INSERT VALUES 中的 foreach）
     {
-        let expand_ws = lint_xml_expanded(&input, &config);
+        let structured = ogsql_parser::ibatis::parse_mapper_bytes_structured(&input);
+        let expand_ws = ogsql_parser::linter::structured::lint_structured_mapper(&structured, &config);
         lint_warnings.extend(expand_ws);
     }
 
@@ -5631,7 +5516,8 @@ fn cmd_validate_xml_dir(
             lint_warnings.extend(ws);
         }
         {
-            let expand_ws = lint_xml_expanded(&bytes, &config);
+            let structured = ogsql_parser::ibatis::parse_mapper_bytes_structured(&bytes);
+            let expand_ws = ogsql_parser::linter::structured::lint_structured_mapper(&structured, &config);
             lint_warnings.extend(expand_ws);
         }
 

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -3807,81 +3807,6 @@ fn merge_error_detail(err: &ogsql_parser::MergeSemanticError) -> String {
     }
 }
 
-fn collect_defined_routine_names(stmts: &[ogsql_parser::StatementInfo]) -> Vec<String> {
-    use ogsql_parser::ast::Statement;
-    let mut names = Vec::new();
-    for si in stmts {
-        match &si.statement {
-            Statement::CreateFunction(func) => {
-                if let Some(last) = func.name.last() {
-                    names.push(last.to_lowercase());
-                }
-            }
-            Statement::CreateProcedure(proc) => {
-                if let Some(last) = proc.name.last() {
-                    names.push(last.to_lowercase());
-                }
-            }
-            Statement::CreatePackage(spec) => {
-                for item in &spec.items {
-                    match item {
-                        ogsql_parser::ast::PackageItem::Function(f) => {
-                            if let Some(last) = f.name.last() {
-                                names.push(last.to_lowercase());
-                            }
-                        }
-                        ogsql_parser::ast::PackageItem::Procedure(p) => {
-                            if let Some(last) = p.name.last() {
-                                names.push(last.to_lowercase());
-                            }
-                        }
-                        ogsql_parser::ast::PackageItem::Type(t) => {
-                            let name = match t {
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::Record { name, .. } => name,
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::TableOf { name, .. } => name,
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::VarrayOf { name, .. } => name,
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::RefCursor { name } => name,
-                            };
-                            names.push(name.to_lowercase());
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Statement::CreatePackageBody(body) => {
-                for item in &body.items {
-                    match item {
-                        ogsql_parser::ast::PackageItem::Function(f) => {
-                            if let Some(last) = f.name.last() {
-                                names.push(last.to_lowercase());
-                            }
-                        }
-                        ogsql_parser::ast::PackageItem::Procedure(p) => {
-                            if let Some(last) = p.name.last() {
-                                names.push(last.to_lowercase());
-                            }
-                        }
-                        ogsql_parser::ast::PackageItem::Type(t) => {
-                            let name = match t {
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::Record { name, .. } => name,
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::TableOf { name, .. } => name,
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::VarrayOf { name, .. } => name,
-                                ogsql_parser::ast::plpgsql::PlTypeDecl::RefCursor { name } => name,
-                            };
-                            names.push(name.to_lowercase());
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    names.sort();
-    names.dedup();
-    names
-}
-
 /// Run PACKAGE consistency, MERGE semantics, and PL variable validation on
 /// already-parsed statements. Returns errors to merge into the caller's error list.
 /// Used by validate_sql (SQL files), validate-xml (iBatis XML), and validate-java
@@ -3926,7 +3851,7 @@ fn validate_from_stmts(
 
     // 3. PL variable/function validation
     let mut all_funcs: Vec<String> = extra_funcs.to_vec();
-    let own_funcs = collect_defined_routine_names(stmts);
+    let own_funcs = ogsql_parser::collect_defined_routine_names(stmts);
     all_funcs.extend(own_funcs);
     all_funcs.sort();
     all_funcs.dedup();
@@ -4410,7 +4335,7 @@ fn cmd_validate_dir(cli: &Cli, dir_paths: &[String], exts: &[String], csv: bool,
     for (_, _, abs_path) in &files {
         let sql = read_file_path(abs_path);
         let output = parse_input(&sql, false, cli.mybatis);
-        all_defined_funcs.extend(collect_defined_routine_names(&output.statements));
+        all_defined_funcs.extend(ogsql_parser::collect_defined_routine_names(&output.statements));
     }
     all_defined_funcs.sort();
     all_defined_funcs.dedup();

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -3811,6 +3811,9 @@ fn merge_error_detail(err: &ogsql_parser::MergeSemanticError) -> String {
 /// already-parsed statements. Returns errors to merge into the caller's error list.
 /// Used by validate_sql (SQL files), validate-xml (iBatis XML), and validate-java
 /// (Java source) to share the same validation pipeline.
+///
+/// This is now a thin wrapper over [`ogsql_parser::validate_statements`]; the
+/// `ParserError` formatting stays here because it is a CLI output concern.
 fn validate_from_stmts(
     stmts: &[ogsql_parser::StatementInfo],
     extra_funcs: &[String],
@@ -3820,45 +3823,33 @@ fn validate_from_stmts(
     Vec<ogsql_parser::PackageConsistencyError>,
     Vec<ogsql_parser::UndefinedVariableError>,
 ) {
+    // Delegate to the public library orchestrator (preserves typed errors).
+    let report = ogsql_parser::validate_statements(stmts, extra_funcs, strict);
+
+    // Format typed errors into ParserError for CLI display. This conversion
+    // lives in the binary because ParserError formatting is a CLI concern.
     let mut errors = Vec::new();
 
-    // 1. PACKAGE consistency
-    let pkg_errors = ogsql_parser::validate_package_consistency(stmts);
-    if !pkg_errors.is_empty() {
-        for pe in &pkg_errors {
-            let msg = match &pe.detail {
-                Some(d) => format!("package {}: {} — {}", pe.package_name, pe.subprogram_name, d),
-                None => format!("package {}: {} — {:?}", pe.package_name, pe.subprogram_name, pe.kind),
-            };
-            errors.push(ogsql_parser::ParserError::Warning {
-                message: msg,
-                location: ogsql_parser::SourceLocation::default(),
-            });
-        }
+    for pe in &report.package_errors {
+        let msg = match &pe.detail {
+            Some(d) => format!("package {}: {} — {}", pe.package_name, pe.subprogram_name, d),
+            None => format!("package {}: {} — {:?}", pe.package_name, pe.subprogram_name, pe.kind),
+        };
+        errors.push(ogsql_parser::ParserError::Warning {
+            message: msg,
+            location: ogsql_parser::SourceLocation::default(),
+        });
     }
 
-    // 2. MERGE semantic validation
-    let merge_errors = ogsql_parser::validate_merge_semantics(stmts);
-    if !merge_errors.is_empty() {
-        for me in &merge_errors {
-            errors.push(ogsql_parser::ParserError::UnsupportedSyntax {
-                location: me.location,
-                syntax: "MERGE".to_string(),
-                hint: merge_error_detail(me),
-            });
-        }
+    for me in &report.merge_errors {
+        errors.push(ogsql_parser::ParserError::UnsupportedSyntax {
+            location: me.location,
+            syntax: "MERGE".to_string(),
+            hint: merge_error_detail(me),
+        });
     }
 
-    // 3. PL variable/function validation
-    let mut all_funcs: Vec<String> = extra_funcs.to_vec();
-    let own_funcs = ogsql_parser::collect_defined_routine_names(stmts);
-    all_funcs.extend(own_funcs);
-    all_funcs.sort();
-    all_funcs.dedup();
-
-    let var_errors = ogsql_parser::validate_pl_variables_from_stmts(stmts, &all_funcs, strict);
-
-    (errors, pkg_errors, var_errors)
+    (errors, report.package_errors, report.undefined_variable_errors)
 }
 
 fn validate_sql(

--- a/src/bin/ogsql.rs
+++ b/src/bin/ogsql.rs
@@ -3856,7 +3856,7 @@ fn validate_from_stmts(
     all_funcs.sort();
     all_funcs.dedup();
 
-    let var_errors = validate_pl_variables_from_stmts(stmts, &all_funcs, strict);
+    let var_errors = ogsql_parser::validate_pl_variables_from_stmts(stmts, &all_funcs, strict);
 
     (errors, pkg_errors, var_errors)
 }
@@ -3879,111 +3879,6 @@ fn validate_sql(
     errors.extend(core_errors);
 
     (output.statements, errors, pkg_errors, var_errors)
-}
-
-fn validate_pl_variables_from_stmts(
-    stmts: &[ogsql_parser::StatementInfo],
-    known_funcs: &[String],
-    strict: bool,
-) -> Vec<ogsql_parser::UndefinedVariableError> {
-    use ogsql_parser::ast::Statement;
-    let mut warnings = Vec::new();
-    let funcs_str: Vec<&str> = known_funcs.iter().map(|s| s.as_str()).collect();
-    for si in stmts {
-        match &si.statement {
-            Statement::CreateProcedure(proc) => {
-                if let Some(ref block) = proc.block {
-                    let vars = ogsql_parser::validate_pl_variables_with_extra_vars_and_funcs(
-                        block,
-                        &proc.parameters,
-                        &[],
-                        &funcs_str,
-                        strict,
-                    );
-                    warnings.extend(vars);
-                }
-            }
-            Statement::CreateFunction(func) => {
-                if let Some(ref block) = func.block {
-                    let vars = ogsql_parser::validate_pl_variables_with_extra_vars_and_funcs(
-                        block,
-                        &func.parameters,
-                        &[],
-                        &funcs_str,
-                        strict,
-                    );
-                    warnings.extend(vars);
-                }
-            }
-            Statement::Do(do_stmt) => {
-                if let Some(ref block) = do_stmt.block {
-                    let vars = ogsql_parser::validate_pl_variables_with_extra_vars_and_funcs(
-                        block,
-                        &[],
-                        &[],
-                        &funcs_str,
-                        strict,
-                    );
-                    warnings.extend(vars);
-                }
-            }
-            Statement::CreatePackageBody(body) => {
-                let body_name: String = body.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
-                let mut pkg_vars: Vec<&str> = body
-                    .items
-                    .iter()
-                    .filter_map(|item| match item {
-                        ogsql_parser::ast::PackageItem::Variable(v) => Some(v.name.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                for other_si in stmts {
-                    if let Statement::CreatePackage(spec) = &other_si.statement {
-                        let spec_name: String =
-                            spec.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
-                        if spec_name == body_name {
-                            for item in &spec.items {
-                                if let ogsql_parser::ast::PackageItem::Variable(v) = item {
-                                    pkg_vars.push(v.name.as_str());
-                                }
-                            }
-                        }
-                    }
-                }
-                for item in &body.items {
-                    match item {
-                        ogsql_parser::ast::PackageItem::Procedure(proc) => {
-                            if let Some(ref block) = proc.block {
-                                let vars = ogsql_parser::validate_pl_variables_with_extra_vars_and_funcs(
-                                    block,
-                                    &proc.parameters,
-                                    &pkg_vars,
-                                    &funcs_str,
-                                    strict,
-                                );
-                                warnings.extend(vars);
-                            }
-                        }
-                        ogsql_parser::ast::PackageItem::Function(func) => {
-                            if let Some(ref block) = func.block {
-                                let vars = ogsql_parser::validate_pl_variables_with_extra_vars_and_funcs(
-                                    block,
-                                    &func.parameters,
-                                    &pkg_vars,
-                                    &funcs_str,
-                                    strict,
-                                );
-                                warnings.extend(vars);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    warnings
 }
 
 fn cmd_validate(cli: &Cli, csv: bool, strict: bool) {

--- a/src/bin/serve/handlers.rs
+++ b/src/bin/serve/handlers.rs
@@ -602,7 +602,8 @@ fn build_xml_validation_response(
             let linter = ogsql_parser::linter::SqlLinter::with_default_rules(config.clone());
             lint_warnings.extend(linter.lint(&all_stmts, None, ogsql_parser::linter::Confidence::Full));
         }
-        let expand_ws = crate::lint_xml_expanded(xml_bytes, &config);
+        let structured = ogsql_parser::ibatis::parse_mapper_bytes_structured(xml_bytes);
+        let expand_ws = ogsql_parser::linter::structured::lint_structured_mapper(&structured, &config);
         lint_warnings.extend(expand_ws);
         if !lint_warnings.is_empty() {
             response.lint_summary = Some(ogsql_parser::linter::build_lint_summary(&lint_warnings));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,23 @@
 //! # Ok::<(), ogsql_parser::TokenizerError>(())
 //! ```
 //!
+//! # Validation
+//!
+//! Run PACKAGE consistency, MERGE semantics, and PL variable validation in one call,
+//! with typed errors preserved (no folding into `ParserError`):
+//!
+//! ```
+//! use ogsql_parser::{Parser, validate_statements};
+//!
+//! let (stmts, _) = Parser::parse_sql(
+//!     "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE",
+//! );
+//! let report = validate_statements(&stmts, &[], false);
+//! if !report.merge_errors.is_empty() {
+//!     println!("MERGE issues: {}", report.merge_errors.len());
+//! }
+//! ```
+//!
 //! # Features
 //!
 //! - **Default**: Library only (tokenizer, parser, AST, formatter, analyzer, linter)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use analyzer::schema::{
     collect_ddl_schema, load_full_schema, load_schema, resolve_schema, FullSchema, IndexMapV2, SchemaMap,
     SchemaResolutionReport,
 };
+pub use analyzer::validate::ValidationReport;
 pub use analyzer::{
     analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_merge_semantics,
     validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub use analyzer::schema::{
     collect_ddl_schema, load_full_schema, load_schema, resolve_schema, FullSchema, IndexMapV2, SchemaMap,
     SchemaResolutionReport,
 };
-pub use analyzer::validate::{collect_defined_routine_names, ValidationReport};
+pub use analyzer::validate::{collect_defined_routine_names, validate_pl_variables_from_stmts, ValidationReport};
 pub use analyzer::{
     analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_merge_semantics,
     validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,9 @@ pub use analyzer::schema::{
     collect_ddl_schema, load_full_schema, load_schema, resolve_schema, FullSchema, IndexMapV2, SchemaMap,
     SchemaResolutionReport,
 };
-pub use analyzer::validate::{collect_defined_routine_names, validate_pl_variables_from_stmts, ValidationReport};
+pub use analyzer::validate::{
+    collect_defined_routine_names, validate_pl_variables_from_stmts, validate_statements, ValidationReport,
+};
 pub use analyzer::{
     analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_merge_semantics,
     validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub use analyzer::schema::{
     collect_ddl_schema, load_full_schema, load_schema, resolve_schema, FullSchema, IndexMapV2, SchemaMap,
     SchemaResolutionReport,
 };
-pub use analyzer::validate::ValidationReport;
+pub use analyzer::validate::{collect_defined_routine_names, ValidationReport};
 pub use analyzer::{
     analyze_pl_block, analyze_transactions, compute_query_fingerprints, validate_merge_semantics,
     validate_package_consistency, validate_pl_variables, validate_pl_variables_with_extra_vars,

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -2,6 +2,8 @@ mod rules_caution;
 mod rules_performance;
 mod rules_prohibition;
 mod rules_suggestion;
+#[cfg(feature = "ibatis")]
+pub mod structured;
 mod type_helpers;
 
 #[cfg(test)]

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -132,6 +132,10 @@ pub struct LintConfig {
     /// C018 -- max bind parameters (rows × columns) for INSERT VALUES (default 65535,
     /// aligned with database bind-parameter limit).
     pub max_insert_values_rows: usize,
+    /// C018 (structured variant) — representative iteration count for
+    /// `<foreach>` collections when estimating dynamic-SQL bind parameter
+    /// totals. Defaults to 1000.
+    pub foreach_estimated_rows: usize,
 }
 
 impl Default for LintConfig {
@@ -146,6 +150,7 @@ impl Default for LintConfig {
             non_equi_join_limit: 2,
             group_by_column_limit: 10,
             max_insert_values_rows: 65535,
+            foreach_estimated_rows: 1000,
         }
     }
 }
@@ -175,6 +180,7 @@ pub struct LintConfigFile {
     pub non_equi_join_limit: Option<usize>,
     pub group_by_column_limit: Option<usize>,
     pub max_insert_values_rows: Option<usize>,
+    pub foreach_estimated_rows: Option<usize>,
 }
 
 #[cfg(feature = "lint-config")]
@@ -259,6 +265,9 @@ impl LintConfig {
         }
         if let Some(v) = file.max_insert_values_rows {
             self.max_insert_values_rows = v;
+        }
+        if let Some(v) = file.foreach_estimated_rows {
+            self.foreach_estimated_rows = v;
         }
     }
 }

--- a/src/linter/structured.rs
+++ b/src/linter/structured.rs
@@ -1,0 +1,85 @@
+//! Structured-mapper lint rules — rules that need the pre-expansion `SqlNode`
+//! tree (dynamic SQL), which the flat `SqlLinter::lint(&[StatementInfo])` API
+//! cannot see.
+//!
+//! Currently houses the foreach-in-INSERT-VALUES flavor of rule C018.
+
+use crate::ibatis::types::{SqlNode, StructuredMapper};
+use crate::linter::{Confidence, LintConfig, SqlWarning, WarningLevel};
+
+/// Lint a structured mapper for foreach-in-INSERT-VALUES (rule C018,
+/// dynamic-SQL variant). Flat SQL collapses `<foreach>` to a single iteration,
+/// so this must run on the `SqlNode` tree before expansion.
+pub fn lint_structured_mapper(
+    mapper: &StructuredMapper,
+    config: &LintConfig,
+) -> Vec<SqlWarning> {
+    unimplemented!("implemented in Step 3")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_mapper(xml: &[u8]) -> StructuredMapper {
+        crate::ibatis::parse_mapper_bytes_structured(xml)
+    }
+
+    #[test]
+    fn c018_fires_when_estimated_params_exceed_threshold() {
+        // 5 params per row × estimated_rows (1000) = 5000. We set the
+        // threshold explicitly to make the test deterministic and decoupled
+        // from the LintConfig default (which is 65535).
+        let xml = br#"<mapper namespace="t">
+            <insert id="batch">
+                INSERT INTO t (a, b, c, d, e) VALUES
+                <foreach collection="rows" item="r" separator=",">
+                    (#{r.a}, #{r.b}, #{r.c}, #{r.d}, #{r.e})
+                </foreach>
+            </insert>
+        </mapper>"#;
+        let mapper = parse_mapper(xml);
+        let mut config = LintConfig::default();
+        config.max_insert_values_rows = 1000; // 5000 > 1000 → must fire
+        let warnings = lint_structured_mapper(&mapper, &config);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].rule_id, "C018");
+    }
+
+    #[test]
+    fn c018_does_NOT_fire_when_estimated_params_below_threshold() {
+        // BUG REPRODUCTION: 1 param per row. With the bug present
+        // (`|| is_insert_values`), this would still fire because the foreach
+        // is inside INSERT VALUES. The fix removes that clause.
+        let xml = br#"<mapper namespace="t">
+            <insert id="batch">
+                INSERT INTO t (a) VALUES
+                <foreach collection="rows" item="r" separator=",">
+                    (#{r.a})
+                </foreach>
+            </insert>
+        </mapper>"#;
+        let mapper = parse_mapper(xml);
+        let mut config = LintConfig::default();
+        config.max_insert_values_rows = usize::MAX; // 1000 << usize::MAX → must NOT fire
+        let warnings = lint_structured_mapper(&mapper, &config);
+        assert_eq!(
+            warnings.len(),
+            0,
+            "threshold is usize::MAX — single-param foreach must NOT fire C018"
+        );
+    }
+
+    #[test]
+    fn c018_no_foreach_no_warning() {
+        let xml = br#"<mapper namespace="t">
+            <insert id="one">
+                INSERT INTO t (a) VALUES (1)
+            </insert>
+        </mapper>"#;
+        let mapper = parse_mapper(xml);
+        let config = LintConfig::default();
+        let warnings = lint_structured_mapper(&mapper, &config);
+        assert!(warnings.is_empty());
+    }
+}

--- a/src/linter/structured.rs
+++ b/src/linter/structured.rs
@@ -10,11 +10,90 @@ use crate::linter::{Confidence, LintConfig, SqlWarning, WarningLevel};
 /// Lint a structured mapper for foreach-in-INSERT-VALUES (rule C018,
 /// dynamic-SQL variant). Flat SQL collapses `<foreach>` to a single iteration,
 /// so this must run on the `SqlNode` tree before expansion.
-pub fn lint_structured_mapper(
-    mapper: &StructuredMapper,
-    config: &LintConfig,
-) -> Vec<SqlWarning> {
-    unimplemented!("implemented in Step 3")
+pub fn lint_structured_mapper(mapper: &StructuredMapper, config: &LintConfig) -> Vec<SqlWarning> {
+    if !mapper.errors.is_empty() {
+        return vec![];
+    }
+    let mut warnings = Vec::new();
+
+    for stmt in &mapper.statements {
+        if let Some(foreach_node) = find_foreach_in_insert_values(&stmt.body) {
+            let params_per_row = count_params_in_foreach_body(foreach_node);
+            if params_per_row == 0 {
+                continue;
+            }
+            let estimated_rows = config.foreach_estimated_rows;
+            let total_params = params_per_row.saturating_mul(estimated_rows);
+
+            // FIXED: no `|| is_insert_values` clause — the threshold is the sole trigger
+            if total_params > config.max_insert_values_rows {
+                warnings.push(SqlWarning {
+                    level: WarningLevel::Caution,
+                    rule_id: "C018".to_string(),
+                    rule_name: "excessive-insert-values".to_string(),
+                    message: format!(
+                        "INSERT VALUES 包含 foreach 动态批量插入，每行 {} 个参数。\
+                         若运行时集合包含约 {} 行，总绑定参数将达 {}，超过阈值 {}。\
+                         建议分批提交或使用 COPY。",
+                        params_per_row, estimated_rows, total_params, config.max_insert_values_rows
+                    ),
+                    suggestion: Some("拆分为更小批次插入以减少锁持有时间，或使用 COPY 替代".to_string()),
+                    location: crate::SourceLocation::default(),
+                    gaussdb_ref: None,
+                    confidence: Confidence::Partial,
+                });
+            }
+        }
+    }
+    warnings
+}
+
+/// Find a ForEach node nested in the SqlNode tree (typically inside INSERT VALUES).
+fn find_foreach_in_insert_values(node: &SqlNode) -> Option<&SqlNode> {
+    match node {
+        SqlNode::ForEach { .. } => Some(node),
+        SqlNode::Sequence { children }
+        | SqlNode::Trim { children, .. }
+        | SqlNode::Where { children, .. }
+        | SqlNode::Set { children, .. }
+        | SqlNode::If { children, .. } => {
+            for child in children {
+                if let Some(f) = find_foreach_in_insert_values(child) {
+                    return Some(f);
+                }
+            }
+            None
+        }
+        SqlNode::Choose { branches } => {
+            for (_, ch) in branches {
+                for c in ch {
+                    if let Some(f) = find_foreach_in_insert_values(c) {
+                        return Some(f);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Count the number of Parameter nodes inside a ForEach body.
+fn count_params_in_foreach_body(node: &SqlNode) -> usize {
+    match node {
+        SqlNode::Parameter { .. } => 1,
+        SqlNode::Sequence { children }
+        | SqlNode::Trim { children, .. }
+        | SqlNode::Where { children, .. }
+        | SqlNode::Set { children, .. }
+        | SqlNode::If { children, .. }
+        | SqlNode::ForEach { children, .. } => children.iter().map(count_params_in_foreach_body).sum(),
+        SqlNode::Choose { branches } => {
+            branches.iter().flat_map(|(_, ch)| ch.iter().map(count_params_in_foreach_body)).sum()
+        }
+        SqlNode::RawExpr { .. } => 1, // ${expr} also counts as a parameter
+        _ => 0,
+    }
 }
 
 #[cfg(test)]
@@ -63,11 +142,7 @@ mod tests {
         let mut config = LintConfig::default();
         config.max_insert_values_rows = usize::MAX; // 1000 << usize::MAX → must NOT fire
         let warnings = lint_structured_mapper(&mapper, &config);
-        assert_eq!(
-            warnings.len(),
-            0,
-            "threshold is usize::MAX — single-param foreach must NOT fire C018"
-        );
+        assert_eq!(warnings.len(), 0, "threshold is usize::MAX — single-param foreach must NOT fire C018");
     }
 
     #[test]


### PR DESCRIPTION
Closes #243, closes #244.

## Summary

Promotes two CLI-internal orchestration functions to public library APIs so that all consumers (CLI, HTTP serve, MCP server, TUI, external library users) share one validation/lint pipeline:

- **#244**: `validate_statements(&[StatementInfo], &[String], bool) -> ValidationReport` — runs all three validators (PACKAGE consistency, MERGE semantics, PL variables) with typed errors preserved in independent buckets.
- **#243**: `linter::structured::lint_structured_mapper(&StructuredMapper, &LintConfig) -> Vec<SqlWarning>` — foreach-in-INSERT-VALUES detection (C018 dynamic variant) that flat SQL cannot see.

## New public API

```rust
// Issue #244 — one-call validation orchestration
ogsql_parser::validate_statements(&stmts, &extra_funcs, strict) -> ValidationReport
ogsql_parser::ValidationReport { package_errors, merge_errors, undefined_variable_errors }
ogsql_parser::collect_defined_routine_names(&stmts) -> Vec<String>
ogsql_parser::validate_pl_variables_from_stmts(&stmts, &funcs, strict) -> Vec<UndefinedVariableError>

// Issue #243 — structured mapper lint (C018 foreach variant)
ogsql_parser::linter::structured::lint_structured_mapper(&mapper, &config) -> Vec<SqlWarning>
```

## Behavior changes

- **Bug fix (intentional)**: single-param `<foreach>` below the C018 threshold no longer fires. Previous logic had `|| is_insert_values` which fired regardless of threshold — now the threshold is the sole trigger.
- CLI / HTTP behavior unchanged for all legitimate warnings.
- `foreach_estimated_rows` (default 1000) is now configurable via `LintConfig` / `.ogsql-lint.toml` instead of hardcoded.

## Consumers enabled

- `ogsql-mcp` binary can now call `validate_statements` directly (previously cut off from this orchestration — it's a separate binary crate).
- External library users (e.g. CodeRoughcollie) get both APIs without walking parser internals (`SqlNode` tree, `PlBlock` extraction, routine-name collection).

## What moved

| Code | Before | After |
|------|--------|-------|
| `validate_from_stmts` orchestration | CLI-private (ogsql.rs) | `ogsql_parser::validate_statements` |
| `collect_defined_routine_names` | CLI-private (ogsql.rs) | `ogsql_parser::collect_defined_routine_names` |
| `validate_pl_variables_from_stmts` | CLI-private (ogsql.rs) | `ogsql_parser::validate_pl_variables_from_stmts` |
| `lint_xml_expanded` + 3 helpers | CLI-private (ogsql.rs, ~120 lines) | `ogsql_parser::linter::structured::lint_structured_mapper` |

Net: binary shed ~337 lines, library gained 2 new modules (`analyzer/validate.rs`, `linter/structured.rs`).

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features` — **1944 tests pass** (1934 baseline + 10 new: 4 validate_statements, 3 lint_structured_mapper, 2 ValidationReport, 1 doctest)
- [x] All binaries (`ogsql`, `ogsql-mcp`) build with `--all-features --bins`
- [x] Manual CLI verification: `validate` (MERGE + strict mode), `validate-xml` (foreach C018) — behavior confirmed unchanged for legitimate cases

## Commit structure

9 commits, TDD red-green for Phase 2:
```
3498611 docs: document validate_statements and lint_structured_mapper public APIs
74fd056 refactor(cli): use public lint_structured_mapper for C018
2e74d7b feat(linter): add lint_structured_mapper for foreach C018 (issue #243)
0a45824 test(linter): add failing tests for lint_structured_mapper (issue #243)
76fad2b refactor(cli): delegate validate_from_stmts to public validate_statements
439f57c feat(analyzer): add validate_statements orchestrator (issue #244)
3ab20c0 refactor(analyzer): move validate_pl_variables_from_stmts to library
23cab5a refactor(analyzer): move collect_defined_routine_names to library
ae457b6 feat(analyzer): add ValidationReport struct for issue #244
```