### PR TITLE
fix(linter): eliminate double-iteration warning duplication (issue #246)

### DIFF
--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -287,8 +287,15 @@ pub struct LintRuleEntry {
     pub name: &'static str,
     pub level: WarningLevel,
     pub stmt_kind: StatementKind,
-    pub check_fn:
-        fn(&[StatementInfo], Option<&SchemaMap>, Option<&IndexInfo>, &LintConfig, Confidence, &mut Vec<SqlWarning>),
+    pub check_fn: fn(
+        curr_stmt: &StatementInfo,
+        stmts: &[StatementInfo],
+        Option<&SchemaMap>,
+        Option<&IndexInfo>,
+        &LintConfig,
+        Confidence,
+        &mut Vec<SqlWarning>,
+    ),
 }
 
 /// Build a JSON summary of lint warnings, grouped by level and rule.
@@ -361,7 +368,7 @@ impl SqlLinter {
                 if rule.level < self.config.min_level {
                     continue;
                 }
-                (rule.check_fn)(stmts, schema, self.index_info.as_ref(), &self.config, confidence, &mut warnings);
+                (rule.check_fn)(info, stmts, schema, self.index_info.as_ref(), &self.config, confidence, &mut warnings);
             }
         }
 
@@ -758,7 +765,7 @@ pub fn collect_nested_selects(stmts: &[StatementInfo]) -> Vec<(&SelectStatement,
     results
 }
 
-fn collect_selects_from_stmt<'a>(
+pub(crate) fn collect_selects_from_stmt<'a>(
     stmt: &'a Statement,
     loc: SourceLocation,
     out: &mut Vec<(&'a SelectStatement, SourceLocation)>,

--- a/src/linter/rules_caution.rs
+++ b/src/linter/rules_caution.rs
@@ -133,33 +133,32 @@ fn extract_hints(stmt: &Statement) -> Vec<&String> {
 // ── C001: Unknown hint ──
 
 fn check_c001(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        for hint in extract_hints(&info.statement) {
-            let parsed = parse_hint_names(hint);
-            for name in parsed {
-                let lower = name.to_lowercase();
-                let base = lower.strip_prefix("no_").or_else(|| lower.strip_prefix("no"));
-                let known = KNOWN_HINTS.contains(&lower.as_str()) || base.is_some_and(|b| KNOWN_HINTS.contains(&b));
-                if !known {
-                    warnings.push(make_warning(
-                        WarningLevel::Caution,
-                        "C001",
-                        "hint-unknown",
-                        format!("Hint '{name}' \u{4e0d}\u{5728} GaussDB \u{5df2}\u{77e5} Hint \u{5217}\u{8868}\u{4e2d}\u{ff0c}\u{5c06}\u{88ab}\u{9759}\u{9ed8}\u{5ffd}\u{7565}"),
-                        Some("\u{68c0}\u{67e5} Hint \u{62fc}\u{5199}\u{662f}\u{5426}\u{6b63}\u{786e}"),
-                        loc,
-                        Some("Hint \u{4f7f}\u{7528}\u{89c4}\u{8303}"),
-                        confidence,
-                    ));
-                }
+    let loc = stmt_location(curr_stmt);
+    for hint in extract_hints(&curr_stmt.statement) {
+        let parsed = parse_hint_names(hint);
+        for name in parsed {
+            let lower = name.to_lowercase();
+            let base = lower.strip_prefix("no_").or_else(|| lower.strip_prefix("no"));
+            let known = KNOWN_HINTS.contains(&lower.as_str()) || base.is_some_and(|b| KNOWN_HINTS.contains(&b));
+            if !known {
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C001",
+                    "hint-unknown",
+                    format!("Hint '{name}' \u{4e0d}\u{5728} GaussDB \u{5df2}\u{77e5} Hint \u{5217}\u{8868}\u{4e2d}\u{ff0c}\u{5c06}\u{88ab}\u{9759}\u{9ed8}\u{5ffd}\u{7565}"),
+                    Some("\u{68c0}\u{67e5} Hint \u{62fc}\u{5199}\u{662f}\u{5426}\u{6b63}\u{786e}"),
+                    loc,
+                    Some("Hint \u{4f7f}\u{7528}\u{89c4}\u{8303}"),
+                    confidence,
+                ));
             }
         }
     }
@@ -182,7 +181,8 @@ fn parse_hint_names(hint: &str) -> Vec<&str> {
 // ── C005: Contradictory hints ──
 
 fn check_c005(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
@@ -203,41 +203,38 @@ fn check_c005(
         ("gather", "redistribute"),
     ];
 
-    for info in stmts {
-        let loc = stmt_location(info);
-        for hint in extract_hints(&info.statement) {
-            let resolved = resolve_hints(hint);
-            let mut seen = std::collections::HashSet::new();
-            for (name, _) in &resolved {
-                let lower = name.to_lowercase();
-                if seen.contains(&lower) {
-                    continue;
-                }
-                let has_pos = resolved.iter().any(|(n, neg)| n == &lower && !neg);
-                let has_neg = resolved.iter().any(|(n, neg)| n == &lower && *neg);
-                if has_pos && has_neg {
-                    warnings.push(make_warning(
-                        WarningLevel::Caution,
-                        "C005",
-                        "hint-contradictory",
-                        format!(
-                            "Hint \u{77db}\u{76fe}: '{lower}' \u{4e0e} 'no_{lower}' \u{540c}\u{65f6}\u{5b58}\u{5728}"
-                        ),
-                        Some("\u{79fb}\u{9664}\u{77db}\u{76fe}\u{7684} Hint"),
-                        loc,
-                        None,
-                        confidence,
-                    ));
-                    seen.insert(lower);
-                }
+    let loc = stmt_location(curr_stmt);
+    for hint in extract_hints(&curr_stmt.statement) {
+        let resolved = resolve_hints(hint);
+        let mut seen = std::collections::HashSet::new();
+        for (name, _) in &resolved {
+            let lower = name.to_lowercase();
+            if seen.contains(&lower) {
+                continue;
             }
+            let has_pos = resolved.iter().any(|(n, neg)| n == &lower && !neg);
+            let has_neg = resolved.iter().any(|(n, neg)| n == &lower && *neg);
+            if has_pos && has_neg {
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C005",
+                    "hint-contradictory",
+                    format!("Hint \u{77db}\u{76fe}: '{lower}' \u{4e0e} 'no_{lower}' \u{540c}\u{65f6}\u{5b58}\u{5728}"),
+                    Some("\u{79fb}\u{9664}\u{77db}\u{76fe}\u{7684} Hint"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+                seen.insert(lower);
+            }
+        }
 
-            // Check mutually exclusive pairs
-            for (a, b) in contradictory_pairs {
-                let has_a = resolved.iter().any(|(n, _)| n == a);
-                let has_b = resolved.iter().any(|(n, _)| n == b);
-                if has_a && has_b {
-                    warnings.push(make_warning(
+        // Check mutually exclusive pairs
+        for (a, b) in contradictory_pairs {
+            let has_a = resolved.iter().any(|(n, _)| n == a);
+            let has_b = resolved.iter().any(|(n, _)| n == b);
+            if has_a && has_b {
+                warnings.push(make_warning(
                         WarningLevel::Caution,
                         "C005",
                         "hint-contradictory",
@@ -247,7 +244,6 @@ fn check_c005(
                         None,
                         confidence,
                     ));
-                }
             }
         }
     }
@@ -279,35 +275,34 @@ fn resolve_hints(hint: &str) -> Vec<(String, bool)> {
 // ── C006: Hint table not in FROM ──
 
 fn check_c006(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let from_tables = collect_from_table_names(&info.statement);
-        if from_tables.is_empty() {
-            continue;
-        }
-        for hint in extract_hints(&info.statement) {
-            let hint_tables = extract_hint_table_refs(hint);
-            for ht in hint_tables {
-                let lower = ht.to_lowercase();
-                if !from_tables.contains(&lower) {
-                    warnings.push(make_warning(
-                        WarningLevel::Caution,
-                        "C006",
-                        "hint-table-not-in-from",
-                        format!("Hint \u{5f15}\u{7528}\u{7684}\u{8868} '{ht}' \u{4e0d}\u{5728} FROM \u{5b50}\u{53e5}\u{4e2d}"),
-                        Some("\u{68c0}\u{67e5} Hint \u{4e2d}\u{7684}\u{8868}\u{540d}\u{662f}\u{5426}\u{4e0e} FROM \u{5b50}\u{53e5}\u{4e00}\u{81f4}"),
-                        loc,
-                        None,
-                        confidence,
-                    ));
-                }
+    let loc = stmt_location(curr_stmt);
+    let from_tables = collect_from_table_names(&curr_stmt.statement);
+    if from_tables.is_empty() {
+        return;
+    }
+    for hint in extract_hints(&curr_stmt.statement) {
+        let hint_tables = extract_hint_table_refs(hint);
+        for ht in hint_tables {
+            let lower = ht.to_lowercase();
+            if !from_tables.contains(&lower) {
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C006",
+                    "hint-table-not-in-from",
+                    format!("Hint \u{5f15}\u{7528}\u{7684}\u{8868} '{ht}' \u{4e0d}\u{5728} FROM \u{5b50}\u{53e5}\u{4e2d}"),
+                    Some("\u{68c0}\u{67e5} Hint \u{4e2d}\u{7684}\u{8868}\u{540d}\u{662f}\u{5426}\u{4e0e} FROM \u{5b50}\u{53e5}\u{4e00}\u{81f4}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
             }
         }
     }
@@ -401,28 +396,27 @@ fn extract_hint_table_refs(hint: &str) -> Vec<&str> {
 // ── C007: UPDATE without WHERE ──
 
 fn check_c007(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Update(s) = &info.statement {
-            if s.where_clause.is_none() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Caution,
-                    "C007",
-                    "update-without-where",
-                    "UPDATE \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{53ef}\u{80fd}\u{5f71}\u{54cd}\u{5168}\u{8868}\u{6570}\u{636e}".into(),
-                    Some("\u{786e}\u{8ba4}\u{662f}\u{5426}\u{771f}\u{7684}\u{9700}\u{8981}\u{66f4}\u{65b0}\u{5168}\u{8868}"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
+    if let Statement::Update(s) = &curr_stmt.statement {
+        if s.where_clause.is_none() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C007",
+                "update-without-where",
+                "UPDATE \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{53ef}\u{80fd}\u{5f71}\u{54cd}\u{5168}\u{8868}\u{6570}\u{636e}".into(),
+                Some("\u{786e}\u{8ba4}\u{662f}\u{5426}\u{771f}\u{7684}\u{9700}\u{8981}\u{66f4}\u{65b0}\u{5168}\u{8868}"),
+                loc,
+                None,
+                confidence,
+            ));
         }
     }
 }
@@ -430,28 +424,27 @@ fn check_c007(
 // ── C008: DELETE without WHERE ──
 
 fn check_c008(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Delete(s) = &info.statement {
-            if s.where_clause.is_none() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Caution,
-                    "C008",
-                    "delete-without-where",
-                    "DELETE \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{5c06}\u{5220}\u{9664}\u{5168}\u{8868}\u{6570}\u{636e}".into(),
-                    Some("\u{786e}\u{8ba4}\u{662f}\u{5426}\u{5e94}\u{4f7f}\u{7528} TRUNCATE \u{6216}\u{6dfb}\u{52a0} WHERE \u{6761}\u{4ef6}"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
+    if let Statement::Delete(s) = &curr_stmt.statement {
+        if s.where_clause.is_none() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C008",
+                "delete-without-where",
+                "DELETE \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{5c06}\u{5220}\u{9664}\u{5168}\u{8868}\u{6570}\u{636e}".into(),
+                Some("\u{786e}\u{8ba4}\u{662f}\u{5426}\u{5e94}\u{4f7f}\u{7528} TRUNCATE \u{6216}\u{6dfb}\u{52a0} WHERE \u{6761}\u{4ef6}"),
+                loc,
+                None,
+                confidence,
+            ));
         }
     }
 }
@@ -459,28 +452,27 @@ fn check_c008(
 // ── C009: INSERT without column list ──
 
 fn check_c009(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Insert(s) = &info.statement {
-            if s.columns.is_empty() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Caution,
-                    "C009",
-                    "insert-no-column-list",
-                    "INSERT \u{672a}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{ff0c}\u{4f9d}\u{8d56}\u{8868}\u{5b9a}\u{4e49}\u{987a}\u{5e8f}".into(),
-                    Some("\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{4ee5}\u{907f}\u{514d}\u{8868}\u{7ed3}\u{6784}\u{53d8}\u{5316}\u{5bfc}\u{81f4}\u{6570}\u{636e}\u{9519}\u{8bef}"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
+    if let Statement::Insert(s) = &curr_stmt.statement {
+        if s.columns.is_empty() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C009",
+                "insert-no-column-list",
+                "INSERT \u{672a}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{ff0c}\u{4f9d}\u{8d56}\u{8868}\u{5b9a}\u{4e49}\u{987a}\u{5e8f}".into(),
+                Some("\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{4ee5}\u{907f}\u{514d}\u{8868}\u{7ed3}\u{6784}\u{53d8}\u{5316}\u{5bfc}\u{81f4}\u{6570}\u{636e}\u{9519}\u{8bef}"),
+                loc,
+                None,
+                confidence,
+            ));
         }
     }
 }
@@ -488,71 +480,69 @@ fn check_c009(
 // ── C010: Unlogged table ──
 
 fn check_c010(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        match &info.statement {
-            Statement::CreateTable(s) if s.unlogged => {
-                warnings.push(make_warning(
-                    WarningLevel::Caution,
-                    "C010",
-                    "unlogged-table",
-                    "UNLOGGED TABLE \u{5728}\u{6545}\u{969c}\u{6062}\u{590d}\u{65f6}\u{6570}\u{636e}\u{4f1a}\u{4e22}\u{5931}".into(),
-                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{8868}\u{66ff}\u{4ee3}"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
-            Statement::CreateTableAs(s) if s.unlogged => {
-                warnings.push(make_warning(
-                    WarningLevel::Caution,
-                    "C010",
-                    "unlogged-table",
-                    "UNLOGGED TABLE AS \u{5728}\u{6545}\u{969c}\u{6062}\u{590d}\u{65f6}\u{6570}\u{636e}\u{4f1a}\u{4e22}\u{5931}".into(),
-                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{8868}\u{66ff}\u{4ee3}"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
-            _ => {}
+    let loc = stmt_location(curr_stmt);
+    match &curr_stmt.statement {
+        Statement::CreateTable(s) if s.unlogged => {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C010",
+                "unlogged-table",
+                "UNLOGGED TABLE \u{5728}\u{6545}\u{969c}\u{6062}\u{590d}\u{65f6}\u{6570}\u{636e}\u{4f1a}\u{4e22}\u{5931}".into(),
+                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{8868}\u{66ff}\u{4ee3}"),
+                loc,
+                None,
+                confidence,
+            ));
         }
+        Statement::CreateTableAs(s) if s.unlogged => {
+            warnings.push(make_warning(
+                WarningLevel::Caution,
+                "C010",
+                "unlogged-table",
+                "UNLOGGED TABLE AS \u{5728}\u{6545}\u{969c}\u{6062}\u{590d}\u{65f6}\u{6570}\u{636e}\u{4f1a}\u{4e22}\u{5931}".into(),
+                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{8868}\u{66ff}\u{4ee3}"),
+                loc,
+                None,
+                confidence,
+            ));
+        }
+        _ => {}
     }
 }
 
 // ── C011: GOTO statement ──
 
 fn check_c011(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_block_for_goto(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Caution,
-                "C011",
-                "goto-statement",
-                "PL/pgSQL \u{4e2d}\u{4f7f}\u{7528}\u{4e86} GOTO \u{8bed}\u{53e5}\u{ff0c}\u{4e0d}\u{7b26}\u{5408}\u{7ed3}\u{6784}\u{5316}\u{7f16}\u{7a0b}\u{5efa}\u{8bae}".into(),
-                Some("\u{4f7f}\u{7528} IF/EXIT/CONTINUE \u{66ff}\u{4ee3} GOTO"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_block_for_goto(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Caution,
+            "C011",
+            "goto-statement",
+            "PL/pgSQL \u{4e2d}\u{4f7f}\u{7528}\u{4e86} GOTO \u{8bed}\u{53e5}\u{ff0c}\u{4e0d}\u{7b26}\u{5408}\u{7ed3}\u{6784}\u{5316}\u{7f16}\u{7a0b}\u{5efa}\u{8bae}".into(),
+            Some("\u{4f7f}\u{7528} IF/EXIT/CONTINUE \u{66ff}\u{4ee3} GOTO"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -622,29 +612,28 @@ fn check_pl_stmts_for_goto(stmts: &[PlStatement], found: &mut bool) {
 // ── C012: EXECUTE with string concatenation (SQL injection risk) ──
 
 fn check_c012(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_execute_concat(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Caution,
-                "C012",
-                "execute-concat-sql-injection",
-                "EXECUTE IMMEDIATE \u{4e2d}\u{4f7f}\u{7528}\u{5b57}\u{7b26}\u{4e32}\u{62fc}\u{63a5}\u{ff0c}\u{53ef}\u{80fd}\u{5b58}\u{5728} SQL \u{6ce8}\u{5165}\u{98ce}\u{9669}".into(),
-                Some("\u{4f7f}\u{7528} USING \u{53c2}\u{6570}\u{5316}\u{67e5}\u{8be2}\u{66ff}\u{4ee3}\u{5b57}\u{7b26}\u{4e32}\u{62fc}\u{63a5}"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_execute_concat(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Caution,
+            "C012",
+            "execute-concat-sql-injection",
+            "EXECUTE IMMEDIATE \u{4e2d}\u{4f7f}\u{7528}\u{5b57}\u{7b26}\u{4e32}\u{62fc}\u{63a5}\u{ff0c}\u{53ef}\u{80fd}\u{5b58}\u{5728} SQL \u{6ce8}\u{5165}\u{98ce}\u{9669}".into(),
+            Some("\u{4f7f}\u{7528} USING \u{53c2}\u{6570}\u{5316}\u{67e5}\u{8be2}\u{66ff}\u{4ee3}\u{5b57}\u{7b26}\u{4e32}\u{62fc}\u{63a5}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -723,29 +712,28 @@ fn has_string_concat(expr: &Expr) -> bool {
 // ── C013: Exception handler swallows errors ──
 
 fn check_c013(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_exception_swallow(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Caution,
-                "C013",
-                "exception-swallow",
-                "WHEN OTHERS THEN \u{5f02}\u{5e38}\u{5904}\u{7406}\u{4e2d}\u{672a}\u{91cd}\u{65b0}\u{629b}\u{51fa}\u{5f02}\u{5e38}\u{ff0c}\u{53ef}\u{80fd}\u{9759}\u{9ed8}\u{541e}\u{9519}".into(),
-                Some("\u{5728} WHEN OTHERS \u{5904}\u{7406}\u{4e2d}\u{6dfb}\u{52a0} RAISE \u{91cd}\u{65b0}\u{629b}\u{51fa}\u{5f02}\u{5e38}"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_exception_swallow(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Caution,
+            "C013",
+            "exception-swallow",
+            "WHEN OTHERS THEN \u{5f02}\u{5e38}\u{5904}\u{7406}\u{4e2d}\u{672a}\u{91cd}\u{65b0}\u{629b}\u{51fa}\u{5f02}\u{5e38}\u{ff0c}\u{53ef}\u{80fd}\u{9759}\u{9ed8}\u{541e}\u{9519}".into(),
+            Some("\u{5728} WHEN OTHERS \u{5904}\u{7406}\u{4e2d}\u{6dfb}\u{52a0} RAISE \u{91cd}\u{65b0}\u{629b}\u{51fa}\u{5f02}\u{5e38}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -820,29 +808,28 @@ fn has_raise(s: &PlStatement) -> bool {
 // ── C014: PL block COMMIT/ROLLBACK ──
 
 fn check_c014(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_commit_rollback(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Caution,
-                "C014",
-                "pl-commit-rollback",
-                "PL/pgSQL \u{5757}\u{4e2d}\u{5305}\u{542b} COMMIT/ROLLBACK\u{ff0c}\u{53ef}\u{80fd}\u{590d}\u{6742}\u{5316}\u{4e8b}\u{52a1}\u{63a7}\u{5236}".into(),
-                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{5c06}\u{4e8b}\u{52a1}\u{63a7}\u{5236}\u{4ea4}\u{7ed9}\u{5916}\u{5c42}"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_commit_rollback(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Caution,
+            "C014",
+            "pl-commit-rollback",
+            "PL/pgSQL \u{5757}\u{4e2d}\u{5305}\u{542b} COMMIT/ROLLBACK\u{ff0c}\u{53ef}\u{80fd}\u{590d}\u{6742}\u{5316}\u{4e8b}\u{52a1}\u{63a7}\u{5236}".into(),
+            Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{4ee5}\u{5c06}\u{4e8b}\u{52a1}\u{63a7}\u{5236}\u{4ea4}\u{7ed9}\u{5916}\u{5c42}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -901,36 +888,35 @@ fn check_pl_stmts_for_commit_rollback(pl_stmts: &[PlStatement], found: &mut bool
 // ── C015: SELECT FOR UPDATE blocking ──
 
 fn check_c015(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            if let Some(ref lock) = s.lock_clause {
-                let is_blocking = match lock {
-                    LockClause::Update { nowait: false, skip_locked: false, wait, .. }
-                    | LockClause::Share { nowait: false, skip_locked: false, wait, .. }
-                    | LockClause::NoKeyUpdate { nowait: false, skip_locked: false, wait, .. }
-                    | LockClause::KeyShare { nowait: false, skip_locked: false, wait, .. } => wait.is_none(),
-                    _ => false,
-                };
-                if is_blocking {
-                    let loc = loc_from_spanned(s, stmt_location(info));
-                    warnings.push(make_warning(
-                        WarningLevel::Caution,
-                        "C015",
-                        "select-for-update-blocking",
-                        "SELECT ... FOR UPDATE \u{672a}\u{4f7f}\u{7528} NOWAIT/SKIP LOCKED\u{ff0c}\u{53ef}\u{80fd}\u{957f}\u{65f6}\u{95f4}\u{963b}\u{585e}".into(),
-                        Some("\u{8003}\u{8651}\u{4f7f}\u{7528} NOWAIT \u{6216} SKIP LOCKED"),
-                        loc,
-                        None,
-                        confidence,
-                    ));
-                }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        if let Some(ref lock) = s.lock_clause {
+            let is_blocking = match lock {
+                LockClause::Update { nowait: false, skip_locked: false, wait, .. }
+                | LockClause::Share { nowait: false, skip_locked: false, wait, .. }
+                | LockClause::NoKeyUpdate { nowait: false, skip_locked: false, wait, .. }
+                | LockClause::KeyShare { nowait: false, skip_locked: false, wait, .. } => wait.is_none(),
+                _ => false,
+            };
+            if is_blocking {
+                let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C015",
+                    "select-for-update-blocking",
+                    "SELECT ... FOR UPDATE \u{672a}\u{4f7f}\u{7528} NOWAIT/SKIP LOCKED\u{ff0c}\u{53ef}\u{80fd}\u{957f}\u{65f6}\u{95f4}\u{963b}\u{585e}".into(),
+                    Some("\u{8003}\u{8651}\u{4f7f}\u{7528} NOWAIT \u{6216} SKIP LOCKED"),
+                    loc,
+                    None,
+                    confidence,
+                ));
             }
         }
     }
@@ -939,29 +925,28 @@ fn check_c015(
 // ── C016: Autonomous transaction pragma ──
 
 fn check_c016(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_autonomous(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Caution,
-                "C016",
-                "autonomous-transaction",
-                "PRAGMA AUTONOMOUS_TRANSACTION \u{4f1a}\u{521b}\u{5efa}\u{72ec}\u{7acb}\u{4e8b}\u{52a1}\u{ff0c}\u{6027}\u{80fd}\u{5f00}\u{9500}\u{8f83}\u{5927}".into(),
-                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{771f}\u{7684}\u{9700}\u{8981}\u{72ec}\u{7acb}\u{4e8b}\u{52a1}"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_autonomous(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Caution,
+            "C016",
+            "autonomous-transaction",
+            "PRAGMA AUTONOMOUS_TRANSACTION \u{4f1a}\u{521b}\u{5efa}\u{72ec}\u{7acb}\u{4e8b}\u{52a1}\u{ff0c}\u{6027}\u{80fd}\u{5f00}\u{9500}\u{8f83}\u{5927}".into(),
+            Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{771f}\u{7684}\u{9700}\u{8981}\u{72ec}\u{7acb}\u{4e8b}\u{52a1}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -1014,29 +999,28 @@ fn check_pl_stmts_for_autonomous(pl_stmts: &[PlStatement], found: &mut bool) {
 // ── C017: RAISE in EXCEPTION clears variables ──
 
 fn check_c017(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_raise_in_exception(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Caution,
-                "C017",
-                "raise-in-exception-clears-variables",
-                "RAISE \u{5728} EXCEPTION \u{5757}\u{4e2d}\u{4f1a}\u{6e05}\u{7a7a}\u{6240}\u{6709}\u{5c40}\u{90e8}\u{53d8}\u{91cf}\u{503c}\u{ff08}\u{5305}\u{62ec} OUT \u{53c2}\u{6570}\u{ff09}\u{ff0c}\u{5bfc}\u{81f4}\u{8c03}\u{7528}\u{65b9}\u{65e0}\u{6cd5}\u{83b7}\u{53d6}\u{9519}\u{8bef}\u{4fe1}\u{606f}".into(),
-                Some("\u{4f7f}\u{7528} RAISE INFO \u{4f20}\u{9012}\u{5177}\u{4f53}\u{9519}\u{8bef}\u{4fe1}\u{606f}\u{ff0c}\u{6216}\u{5728} RAISE \u{524d}\u{5c06}\u{8f93}\u{51fa}\u{503c}\u{4fdd}\u{5b58}\u{5230}\u{4e34}\u{65f6}\u{8868}/\u{5168}\u{5c40}\u{53d8}\u{91cf}"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_raise_in_exception(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Caution,
+            "C017",
+            "raise-in-exception-clears-variables",
+            "RAISE \u{5728} EXCEPTION \u{5757}\u{4e2d}\u{4f1a}\u{6e05}\u{7a7a}\u{6240}\u{6709}\u{5c40}\u{90e8}\u{53d8}\u{91cf}\u{503c}\u{ff08}\u{5305}\u{62ec} OUT \u{53c2}\u{6570}\u{ff09}\u{ff0c}\u{5bfc}\u{81f4}\u{8c03}\u{7528}\u{65b9}\u{65e0}\u{6cd5}\u{83b7}\u{53d6}\u{9519}\u{8bef}\u{4fe1}\u{606f}".into(),
+            Some("\u{4f7f}\u{7528} RAISE INFO \u{4f20}\u{9012}\u{5177}\u{4f53}\u{9519}\u{8bef}\u{4fe1}\u{606f}\u{ff0c}\u{6216}\u{5728} RAISE \u{524d}\u{5c06}\u{8f93}\u{51fa}\u{503c}\u{4fdd}\u{5b58}\u{5230}\u{4e34}\u{65f6}\u{8868}/\u{5168}\u{5c40}\u{53d8}\u{91cf}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -1115,43 +1099,42 @@ fn has_reraise(s: &PlStatement) -> bool {
 // ── C018: Excessive INSERT VALUES rows ──
 
 fn check_c018(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Statement::Insert(insert) = &info.statement {
-            if let InsertSource::Values(values) = &insert.source {
-                let row_count = values.len();
-                let col_count = if !insert.columns.is_empty() {
-                    insert.columns.len()
-                } else if let Some(first) = values.first() {
-                    first.len()
-                } else {
-                    0
-                };
-                let total_params = row_count * col_count;
-                if total_params > config.max_insert_values_rows {
-                    warnings.push(make_warning(
-                        WarningLevel::Caution,
-                        "C018",
-                        "excessive-insert-values",
-                        format!(
-                            "INSERT VALUES {row_count} 行 × {col_count} 列 = {total_params} 个绑定参数，超过阈值 {}。大批量可能导致长事务、锁竞争和回滚代价过高。建议每批插入 {}—{} 行，或使用 COPY",
-                            config.max_insert_values_rows,
-                            config.max_insert_values_rows / col_count.max(1) / 5,
-                            config.max_insert_values_rows / col_count.max(1),
-                        ),
-                        Some("拆分为更小批次插入以减少锁持有时间"),
-                        loc,
-                        None,
-                        confidence,
-                    ));
-                }
+    let loc = stmt_location(curr_stmt);
+    if let Statement::Insert(insert) = &curr_stmt.statement {
+        if let InsertSource::Values(values) = &insert.source {
+            let row_count = values.len();
+            let col_count = if !insert.columns.is_empty() {
+                insert.columns.len()
+            } else if let Some(first) = values.first() {
+                first.len()
+            } else {
+                0
+            };
+            let total_params = row_count * col_count;
+            if total_params > config.max_insert_values_rows {
+                warnings.push(make_warning(
+                    WarningLevel::Caution,
+                    "C018",
+                    "excessive-insert-values",
+                    format!(
+                        "INSERT VALUES {row_count} 行 × {col_count} 列 = {total_params} 个绑定参数，超过阈值 {}。大批量可能导致长事务、锁竞争和回滚代价过高。建议每批插入 {}—{} 行，或使用 COPY",
+                        config.max_insert_values_rows,
+                        config.max_insert_values_rows / col_count.max(1) / 5,
+                        config.max_insert_values_rows / col_count.max(1),
+                    ),
+                    Some("拆分为更小批次插入以减少锁持有时间"),
+                    loc,
+                    None,
+                    confidence,
+                ));
             }
         }
     }

--- a/src/linter/rules_performance.rs
+++ b/src/linter/rules_performance.rs
@@ -1,9 +1,10 @@
 use crate::ast::plpgsql::PlStatement;
-use crate::ast::{Expr, InsertSource, SelectTarget, SetOperation, Statement, StatementInfo, TableRef};
+use crate::ast::{Expr, InsertSource, SelectStatement, SelectTarget, SetOperation, Statement, StatementInfo, TableRef};
 use crate::linter::{
-    collect_nested_selects, loc_from_spanned, make_warning, stmt_location, walk_expr, walk_select_exprs, Confidence,
+    collect_selects_from_stmt, loc_from_spanned, make_warning, stmt_location, walk_expr, walk_select_exprs, Confidence,
     LintConfig, LintRuleEntry, SqlLinter, SqlWarning, StatementKind, WarningLevel,
 };
+use crate::token::SourceLocation;
 
 pub fn register(linter: &mut SqlLinter) {
     let rules: Vec<LintRuleEntry> = vec![
@@ -185,18 +186,17 @@ fn extract_where(stmt: &Statement) -> Option<&Expr> {
 
 // P001: UNION without ALL
 fn check_p001(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            check_select_union(s, loc, confidence, warnings);
-        }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        check_select_union(s, loc, confidence, warnings);
     }
 }
 
@@ -236,220 +236,221 @@ fn check_select_union(
 
 // P002: NOT IN (subquery) -- use NOT EXISTS instead
 fn check_p002(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where(&info.statement) {
-            walk_expr(where_clause, &mut |e| match e {
-                Expr::InSubquery { negated: true, .. } => {
-                    warnings.push(make_warning(
+    let loc = stmt_location(curr_stmt);
+    if let Some(where_clause) = extract_where(&curr_stmt.statement) {
+        walk_expr(where_clause, &mut |e| match e {
+            Expr::InSubquery { negated: true, .. } => {
+                warnings.push(make_warning(
                             WarningLevel::Performance, "P002", "not-in-subquery",
                             "NOT IN (\u{5b50}\u{67e5}\u{8be2}) \u{6027}\u{80fd}\u{8f83}\u{5dee}\u{ff0c}\u{5e76}\u{4e14} NULL \u{503c}\u{4f1a}\u{5bfc}\u{81f4}\u{7ed3}\u{679c}\u{4e0d}\u{7b26}\u{9884}\u{671f}".into(),
                             Some("\u{6539}\u{4e3a} NOT EXISTS"), loc,
                             None, confidence,
                         ));
-                    false
-                }
-                Expr::ScalarSublink { op, sublink_type, .. } => {
-                    let is_not_in = op == "<>" || op == "!=" || op == "NOT IN";
-                    if is_not_in && matches!(sublink_type, crate::ast::ScalarSublinkType::All) {
-                        warnings.push(make_warning(
+                false
+            }
+            Expr::ScalarSublink { op, sublink_type, .. } => {
+                let is_not_in = op == "<>" || op == "!=" || op == "NOT IN";
+                if is_not_in && matches!(sublink_type, crate::ast::ScalarSublinkType::All) {
+                    warnings.push(make_warning(
                                 WarningLevel::Performance, "P002", "not-in-subquery",
                                 "\u{6807}\u{91cf}\u{5b50}\u{94fe}\u{63a5} NOT IN/<> ALL \u{6a21}\u{5f0f}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}".into(),
                                 Some("\u{6539}\u{4e3a} NOT EXISTS"), loc,
                                 None, confidence,
                             ));
-                    }
-                    true
                 }
-                Expr::InList { negated: true, list, .. } if list.len() > 10 => {
-                    warnings.push(make_warning(
-                            WarningLevel::Performance, "P002", "not-in-subquery",
-                            format!("NOT IN \u{5217}\u{8868}\u{542b} {} \u{4e2a}\u{503c}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}", list.len()),
-                            Some("\u{6539}\u{4e3a} NOT EXISTS \u{6216} LEFT JOIN ... WHERE ... IS NULL"), loc,
-                            None, confidence,
-                        ));
-                    true
-                }
-                _ => true,
-            });
-        }
+                true
+            }
+            Expr::InList { negated: true, list, .. } if list.len() > 10 => {
+                warnings.push(make_warning(
+                    WarningLevel::Performance,
+                    "P002",
+                    "not-in-subquery",
+                    format!(
+                        "NOT IN \u{5217}\u{8868}\u{542b} {} \u{4e2a}\u{503c}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}",
+                        list.len()
+                    ),
+                    Some("\u{6539}\u{4e3a} NOT EXISTS \u{6216} LEFT JOIN ... WHERE ... IS NULL"),
+                    loc,
+                    None,
+                    confidence,
+                ));
+                true
+            }
+            _ => true,
+        });
     }
 }
 
 // P003: IN list too large
 fn check_p003(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where(&info.statement) {
-            walk_expr(where_clause, &mut |e| {
-                if let Expr::InList { list, .. } = e {
-                    if list.len() > config.in_list_threshold {
-                        warnings.push(make_warning(
-                            WarningLevel::Performance, "P003", "in-list-too-large",
-                            format!("IN \u{5217}\u{8868}\u{542b} {} \u{4e2a}\u{503c}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{5bfc}\u{81f4}\u{89e3}\u{6790}\u{7f13}\u{6162}", list.len(), config.in_list_threshold),
-                            Some("\u{6539}\u{7528} INNER JOIN \u{6216}\u{4e34}\u{65f6}\u{8868}"), loc,
-                            None, confidence,
-                        ));
-                    }
+    let loc = stmt_location(curr_stmt);
+    if let Some(where_clause) = extract_where(&curr_stmt.statement) {
+        walk_expr(where_clause, &mut |e| {
+            if let Expr::InList { list, .. } = e {
+                if list.len() > config.in_list_threshold {
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "P003", "in-list-too-large",
+                        format!("IN \u{5217}\u{8868}\u{542b} {} \u{4e2a}\u{503c}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{5bfc}\u{81f4}\u{89e3}\u{6790}\u{7f13}\u{6162}", list.len(), config.in_list_threshold),
+                        Some("\u{6539}\u{7528} INNER JOIN \u{6216}\u{4e34}\u{65f6}\u{8868}"), loc,
+                        None, confidence,
+                    ));
                 }
-                true
-            });
-        }
+            }
+            true
+        });
     }
 }
 
 // P004: OR as top-level WHERE condition
 fn check_p004(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Some(Expr::BinaryOp { op, .. }) = extract_where(&info.statement) {
-            if op.eq_ignore_ascii_case("OR") {
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P004", "or-to-union-all",
-                    "WHERE \u{9876}\u{5c42}\u{4e3a} OR \u{6761}\u{4ef6}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{4f18}\u{5316}\u{5660}\u{653e}\u{5f03}\u{7d22}\u{5f15}".into(),
-                    Some("\u{8003}\u{8651}\u{5c06} OR \u{6539}\u{5199}\u{4e3a} UNION ALL"), loc,
-                    None, confidence,
-                ));
-            }
+    let loc = stmt_location(curr_stmt);
+    if let Some(Expr::BinaryOp { op, .. }) = extract_where(&curr_stmt.statement) {
+        if op.eq_ignore_ascii_case("OR") {
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P004", "or-to-union-all",
+                "WHERE \u{9876}\u{5c42}\u{4e3a} OR \u{6761}\u{4ef6}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{4f18}\u{5316}\u{5660}\u{653e}\u{5f03}\u{7d22}\u{5f15}".into(),
+                Some("\u{8003}\u{8651}\u{5c06} OR \u{6539}\u{5199}\u{4e3a} UNION ALL"), loc,
+                None, confidence,
+            ));
         }
     }
 }
 
 // P005: now() function -- non-pushable in distributed queries
 fn check_p005(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut check_fn = |e: &Expr| {
-            if let Expr::FunctionCall { name, .. } = e {
-                let fn_name = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
-                if fn_name == "now" || fn_name == "current_timestamp" || fn_name == "sysdate" {
-                    warnings.push(make_warning(
-                        WarningLevel::Performance, "P005", "now-function-non-pushable",
-                        format!("\u{51fd}\u{6570} {fn_name}() \u{4e0d}\u{53ef}\u{4e0b}\u{63a8}\u{ff0c}\u{5c06}\u{5bfc}\u{81f4}\u{5206}\u{5e03}\u{5f0f}\u{67e5}\u{8be2}\u{6027}\u{80fd}\u{4e0b}\u{964d}"),
-                        Some("\u{7528}\u{65f6}\u{95f4}\u{5b8f}\u{6216}\u{53c2}\u{6570}\u{5316}\u{67e5}\u{8be2}\u{66ff}\u{4ee3}"), loc,
-                        Some("SQL \u{67e5}\u{8be2}\u{6700}\u{4f73}\u{5b9e}\u{8df5}"), confidence,
-                    ));
-                }
+    let loc = stmt_location(curr_stmt);
+    let mut check_fn = |e: &Expr| {
+        if let Expr::FunctionCall { name, .. } = e {
+            let fn_name = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+            if fn_name == "now" || fn_name == "current_timestamp" || fn_name == "sysdate" {
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P005", "now-function-non-pushable",
+                    format!("\u{51fd}\u{6570} {fn_name}() \u{4e0d}\u{53ef}\u{4e0b}\u{63a8}\u{ff0c}\u{5c06}\u{5bfc}\u{81f4}\u{5206}\u{5e03}\u{5f0f}\u{67e5}\u{8be2}\u{6027}\u{80fd}\u{4e0b}\u{964d}"),
+                    Some("\u{7528}\u{65f6}\u{95f4}\u{5b8f}\u{6216}\u{53c2}\u{6570}\u{5316}\u{67e5}\u{8be2}\u{66ff}\u{4ee3}"), loc,
+                    Some("SQL \u{67e5}\u{8be2}\u{6700}\u{4f73}\u{5b9e}\u{8df5}"), confidence,
+                ));
             }
-        };
-        match &info.statement {
-            Statement::Select(s) => walk_select_exprs(s, &mut |e| {
-                check_fn(e);
-                true
-            }),
-            Statement::Update(s) => {
-                for a in &s.assignments {
-                    walk_expr(&a.value, &mut |e| {
-                        check_fn(e);
-                        true
-                    });
-                }
-                if let Some(ref w) = s.where_clause {
-                    walk_expr(w, &mut |e| {
-                        check_fn(e);
-                        true
-                    });
-                }
-            }
-            Statement::Delete(s) => {
-                if let Some(ref w) = s.where_clause {
-                    walk_expr(w, &mut |e| {
-                        check_fn(e);
-                        true
-                    });
-                }
-            }
-            _ => {}
         }
+    };
+    match &curr_stmt.statement {
+        Statement::Select(s) => walk_select_exprs(s, &mut |e| {
+            check_fn(e);
+            true
+        }),
+        Statement::Update(s) => {
+            for a in &s.assignments {
+                walk_expr(&a.value, &mut |e| {
+                    check_fn(e);
+                    true
+                });
+            }
+            if let Some(ref w) = s.where_clause {
+                walk_expr(w, &mut |e| {
+                    check_fn(e);
+                    true
+                });
+            }
+        }
+        Statement::Delete(s) => {
+            if let Some(ref w) = s.where_clause {
+                walk_expr(w, &mut |e| {
+                    check_fn(e);
+                    true
+                });
+            }
+        }
+        _ => {}
     }
 }
 
 // P006: COUNT(*) on large table
 fn check_p006(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            walk_select_exprs(s, &mut |e| {
-                if let Expr::FunctionCall { name, args, .. } = e {
-                    let fn_name = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
-                    if fn_name == "count" {
-                        let is_star = args.iter().any(|a| {
-                            matches!(a, Expr::ColumnRef(n) if n.len() == 1 && n[0] == "*")
-                                || matches!(a, Expr::QualifiedStar(_))
-                        });
-                        if is_star || args.is_empty() {
-                            warnings.push(make_warning(
-                                WarningLevel::Performance, "P006", "count-star-large-table",
-                                "COUNT(*) \u{5728}\u{5927}\u{8868}\u{4e0a}\u{6027}\u{80fd}\u{8f83}\u{5dee}".into(),
-                                Some("\u{8003}\u{8651}\u{4f7f}\u{7528} pg_class.reltuples \u{6216}\u{8fd1}\u{4f3c}\u{7edf}\u{8ba1}\u{4fe1}\u{606f}"), loc,
-                                None, confidence,
-                            ));
-                        }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        walk_select_exprs(s, &mut |e| {
+            if let Expr::FunctionCall { name, args, .. } = e {
+                let fn_name = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                if fn_name == "count" {
+                    let is_star = args.iter().any(|a| {
+                        matches!(a, Expr::ColumnRef(n) if n.len() == 1 && n[0] == "*")
+                            || matches!(a, Expr::QualifiedStar(_))
+                    });
+                    if is_star || args.is_empty() {
+                        warnings.push(make_warning(
+                            WarningLevel::Performance, "P006", "count-star-large-table",
+                            "COUNT(*) \u{5728}\u{5927}\u{8868}\u{4e0a}\u{6027}\u{80fd}\u{8f83}\u{5dee}".into(),
+                            Some("\u{8003}\u{8651}\u{4f7f}\u{7528} pg_class.reltuples \u{6216}\u{8fd1}\u{4f3c}\u{7edf}\u{8ba1}\u{4fe1}\u{606f}"), loc,
+                            None, confidence,
+                        ));
                     }
                 }
-                true
-            });
-        }
+            }
+            true
+        });
     }
 }
 
 // P007: Too many non-equi joins
 fn check_p007(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            let mut count = 0usize;
-            count_non_equi_joins_in_from(&s.from, &mut count);
-            if count > config.non_equi_join_limit {
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P007", "too-many-non-equi-joins",
-                    format!("\u{975e}\u{7b49}\u{503c} JOIN \u{6761}\u{4ef6} {count} \u{4e2a}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}", config.non_equi_join_limit),
-                    Some("\u{4f18}\u{5148}\u{4f7f}\u{7528}\u{7b49}\u{503c}\u{67e5}\u{8be2}"), loc,
-                    None, confidence,
-                ));
-            }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        let mut count = 0usize;
+        count_non_equi_joins_in_from(&s.from, &mut count);
+        if count > config.non_equi_join_limit {
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P007", "too-many-non-equi-joins",
+                format!("\u{975e}\u{7b49}\u{503c} JOIN \u{6761}\u{4ef6} {count} \u{4e2a}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{6027}\u{80fd}\u{8f83}\u{5dee}", config.non_equi_join_limit),
+                Some("\u{4f18}\u{5148}\u{4f7f}\u{7528}\u{7b49}\u{503c}\u{67e5}\u{8be2}"), loc,
+                None, confidence,
+            ));
         }
     }
 }
@@ -475,29 +476,28 @@ fn count_non_equi_in_expr(expr: &Expr, count: &mut usize) {
 
 // P008: GROUP BY without hash_agg hint
 fn check_p008(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            if !s.group_by.is_empty() {
-                let has_hashagg = s
-                    .hints
-                    .iter()
-                    .any(|h| h.to_lowercase().contains("hashagg") || h.to_lowercase().contains("use_hash_agg"));
-                if !has_hashagg {
-                    let loc = loc_from_spanned(s, stmt_location(info));
-                    warnings.push(make_warning(
-                        WarningLevel::Performance, "P008", "group-by-without-hashagg",
-                        "GROUP BY \u{64cd}\u{4f5c}\u{672a}\u{4f7f}\u{7528} hash_agg \u{63d0}\u{793a}\u{ff0c}\u{53ef}\u{80fd}\u{9700}\u{8981}\u{8c03}\u{5927} work_mem".into(),
-                        Some("\u{8003}\u{8651}\u{6dfb}\u{52a0} /*+ hash_agg */ \u{63d0}\u{793a}\u{6216}\u{8c03}\u{5927} work_mem"), loc,
-                        None, confidence,
-                    ));
-                }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        if !s.group_by.is_empty() {
+            let has_hashagg = s
+                .hints
+                .iter()
+                .any(|h| h.to_lowercase().contains("hashagg") || h.to_lowercase().contains("use_hash_agg"));
+            if !has_hashagg {
+                let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+                warnings.push(make_warning(
+                    WarningLevel::Performance, "P008", "group-by-without-hashagg",
+                    "GROUP BY \u{64cd}\u{4f5c}\u{672a}\u{4f7f}\u{7528} hash_agg \u{63d0}\u{793a}\u{ff0c}\u{53ef}\u{80fd}\u{9700}\u{8981}\u{8c03}\u{5927} work_mem".into(),
+                    Some("\u{8003}\u{8651}\u{6dfb}\u{52a0} /*+ hash_agg */ \u{63d0}\u{793a}\u{6216}\u{8c03}\u{5927} work_mem"), loc,
+                    None, confidence,
+                ));
             }
         }
     }
@@ -505,32 +505,31 @@ fn check_p008(
 
 // P010: Multi-column UPDATE from subquery
 fn check_p010(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Update(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            for assignment in &s.assignments {
-                if assignment.columns.len() > 1 && matches!(&assignment.value, Expr::Subquery(_)) {
-                    warnings.push(make_warning(
-                        WarningLevel::Performance,
-                        "P010",
-                        "multi-column-update-subquery",
-                        format!(
-                            "UPDATE SET ({}\u{5217}) = (SELECT ...) \u{6548}\u{7387}\u{8f83}\u{4f4e}",
-                            assignment.columns.len()
-                        ),
-                        Some("\u{6539}\u{7528} UPDATE ... FROM ... WHERE ... \u{7684} JOIN \u{98ce}\u{683c}"),
-                        loc,
-                        None,
-                        confidence,
-                    ));
-                }
+    if let Statement::Update(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        for assignment in &s.assignments {
+            if assignment.columns.len() > 1 && matches!(&assignment.value, Expr::Subquery(_)) {
+                warnings.push(make_warning(
+                    WarningLevel::Performance,
+                    "P010",
+                    "multi-column-update-subquery",
+                    format!(
+                        "UPDATE SET ({}\u{5217}) = (SELECT ...) \u{6548}\u{7387}\u{8f83}\u{4f4e}",
+                        assignment.columns.len()
+                    ),
+                    Some("\u{6539}\u{7528} UPDATE ... FROM ... WHERE ... \u{7684} JOIN \u{98ce}\u{683c}"),
+                    loc,
+                    None,
+                    confidence,
+                ));
             }
         }
     }
@@ -538,50 +537,47 @@ fn check_p010(
 
 // P011: Correlated subquery (basic AST-only detection)
 fn check_p011(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let outer_tables = collect_from_tables(&info.statement);
-        if outer_tables.is_empty() {
-            continue;
-        }
-        if let Some(where_clause) = extract_where(&info.statement) {
-            let mut found = false;
-            walk_expr(where_clause, &mut |e| {
-                if found {
-                    return false;
-                }
-                match e {
-                    Expr::InSubquery { subquery, .. } | Expr::Exists(subquery) | Expr::Subquery(subquery) => {
-                        if has_correlated_ref(&subquery.where_clause, &outer_tables) {
-                            found = true;
-                            return false;
-                        }
-                    }
-                    Expr::ScalarSublink { subquery, .. }
-                        if has_correlated_ref(&subquery.where_clause, &outer_tables) =>
-                    {
+    let loc = stmt_location(curr_stmt);
+    let outer_tables = collect_from_tables(&curr_stmt.statement);
+    if outer_tables.is_empty() {
+        return;
+    }
+    if let Some(where_clause) = extract_where(&curr_stmt.statement) {
+        let mut found = false;
+        walk_expr(where_clause, &mut |e| {
+            if found {
+                return false;
+            }
+            match e {
+                Expr::InSubquery { subquery, .. } | Expr::Exists(subquery) | Expr::Subquery(subquery) => {
+                    if has_correlated_ref(&subquery.where_clause, &outer_tables) {
                         found = true;
                         return false;
                     }
-                    _ => {}
                 }
-                true
-            });
-            if found {
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P011", "correlated-subquery",
-                    "\u{5173}\u{8054}\u{5b50}\u{67e5}\u{8be2}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6bcf}\u{884c}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
-                    Some("\u{6539}\u{5199}\u{4e3a}\u{7b49}\u{503c} JOIN"), loc,
-                    None, confidence,
-                ));
+                Expr::ScalarSublink { subquery, .. } if has_correlated_ref(&subquery.where_clause, &outer_tables) => {
+                    found = true;
+                    return false;
+                }
+                _ => {}
             }
+            true
+        });
+        if found {
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P011", "correlated-subquery",
+                "\u{5173}\u{8054}\u{5b50}\u{67e5}\u{8be2}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6bcf}\u{884c}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
+                Some("\u{6539}\u{5199}\u{4e3a}\u{7b49}\u{503c} JOIN"), loc,
+                None, confidence,
+            ));
         }
     }
 }
@@ -647,42 +643,40 @@ fn has_correlated_ref(expr: &Option<Expr>, outer_tables: &[String]) -> bool {
 
 // P012: Unnecessary DISTINCT (basic -- warns on all DISTINCT)
 fn check_p012(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            if s.distinct {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P012", "unnecessary-distinct",
-                    "DISTINCT \u{5b58}\u{5728}\u{ff0c}\u{9700}\u{7ed3}\u{5408}\u{552f}\u{4e00}\u{952e}\u{5224}\u{65ad}\u{662f}\u{5426}\u{5fc5}\u{8981}\u{ff08}\u{9700} schema \u{4fe1}\u{606f}\u{8fdb}\u{4e00}\u{6b65}\u{786e}\u{8ba4}\u{ff09}".into(),
-                    Some("\u{68c0}\u{67e5}\u{53bb}\u{91cd}\u{5fc5}\u{8981}\u{6027}\u{ff0c}\u{5982}\u{679c}\u{5df2}\u{542b}\u{552f}\u{4e00}\u{5217}\u{5219}\u{53ef}\u{79fb}\u{9664}"), loc,
-                    None, confidence,
-                ));
-            }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        if s.distinct {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P012", "unnecessary-distinct",
+                "DISTINCT \u{5b58}\u{5728}\u{ff0c}\u{9700}\u{7ed3}\u{5408}\u{552f}\u{4e00}\u{952e}\u{5224}\u{65ad}\u{662f}\u{5426}\u{5fc5}\u{8981}\u{ff08}\u{9700} schema \u{4fe1}\u{606f}\u{8fdb}\u{4e00}\u{6b65}\u{786e}\u{8ba4}\u{ff09}".into(),
+                Some("\u{68c0}\u{67e5}\u{53bb}\u{91cd}\u{5fc5}\u{8981}\u{6027}\u{ff0c}\u{5982}\u{679c}\u{5df2}\u{542b}\u{552f}\u{4e00}\u{5217}\u{5219}\u{53ef}\u{79fb}\u{9664}"), loc,
+                None, confidence,
+            ));
         }
     }
 }
 
 // P013: Cartesian product (CROSS JOIN or missing join condition)
 fn check_p013(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            check_cartesian_in_from(&s.from, loc, confidence, warnings);
-        }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        check_cartesian_in_from(&s.from, loc, confidence, warnings);
     }
 }
 
@@ -721,44 +715,43 @@ fn check_cartesian_in_from(
 
 // P014: Deeply nested subquery
 fn check_p014(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let max_depth = match &info.statement {
-            Statement::Select(s) => subquery_depth_select(s),
-            Statement::Update(u) => {
-                let mut d = 0;
-                for a in &u.assignments {
-                    d = d.max(subquery_depth_expr(&a.value));
-                }
-                if let Some(ref w) = u.where_clause {
-                    d = d.max(subquery_depth_expr(w));
-                }
-                d
+    let loc = stmt_location(curr_stmt);
+    let max_depth = match &curr_stmt.statement {
+        Statement::Select(s) => subquery_depth_select(s),
+        Statement::Update(u) => {
+            let mut d = 0;
+            for a in &u.assignments {
+                d = d.max(subquery_depth_expr(&a.value));
             }
-            Statement::Delete(de) => {
-                if let Some(ref w) = de.where_clause {
-                    subquery_depth_expr(w)
-                } else {
-                    0
-                }
+            if let Some(ref w) = u.where_clause {
+                d = d.max(subquery_depth_expr(w));
             }
-            _ => 0,
-        };
-        if max_depth >= config.subquery_depth_limit {
-            warnings.push(make_warning(
+            d
+        }
+        Statement::Delete(de) => {
+            if let Some(ref w) = de.where_clause {
+                subquery_depth_expr(w)
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    };
+    if max_depth >= config.subquery_depth_limit {
+        warnings.push(make_warning(
                 WarningLevel::Performance, "P014", "deeply-nested-subquery",
                 format!("\u{5b50}\u{67e5}\u{8be2}\u{5d4c}\u{5957}\u{6df1}\u{5ea6} {max_depth} \u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{6027}\u{80fd}\u{53ef}\u{80fd}\u{8f83}\u{5dee}", config.subquery_depth_limit),
                 Some("\u{62c6}\u{5206}\u{4e3a}\u{4e34}\u{65f6}\u{8868}\u{6216} CTE"), loc,
                 None, confidence,
             ));
-        }
     }
 }
 
@@ -852,30 +845,29 @@ fn subquery_depth_expr(expr: &Expr) -> usize {
 
 // P015: Range equals same value (col >= x AND col <= x where x == x)
 fn check_p015(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where(&info.statement) {
-            walk_expr(where_clause, &mut |e| {
-                if let Expr::Between { low, high, negated: false, .. } = e {
-                    if literals_equal(low, high) {
-                        warnings.push(make_warning(
-                            WarningLevel::Performance, "P015", "range-equals-same-value",
-                            "BETWEEN \u{4e0a}\u{4e0b}\u{754c}\u{76f8}\u{540c}\u{ff0c}\u{5e94}\u{7b80}\u{5316}\u{4e3a} \u{7b49}\u{4e8e}\u{6761}\u{4ef6}".into(),
-                            Some("\u{7b80}\u{5316}\u{4e3a} ="), loc,
-                            None, confidence,
-                        ));
-                    }
+    let loc = stmt_location(curr_stmt);
+    if let Some(where_clause) = extract_where(&curr_stmt.statement) {
+        walk_expr(where_clause, &mut |e| {
+            if let Expr::Between { low, high, negated: false, .. } = e {
+                if literals_equal(low, high) {
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "P015", "range-equals-same-value",
+                        "BETWEEN \u{4e0a}\u{4e0b}\u{754c}\u{76f8}\u{540c}\u{ff0c}\u{5e94}\u{7b80}\u{5316}\u{4e3a} \u{7b49}\u{4e8e}\u{6761}\u{4ef6}".into(),
+                        Some("\u{7b80}\u{5316}\u{4e3a} ="), loc,
+                        None, confidence,
+                    ));
                 }
-                true
-            });
-        }
+            }
+            true
+        });
     }
 }
 
@@ -888,151 +880,150 @@ fn literals_equal(a: &Expr, b: &Expr) -> bool {
 
 // P016: UPDATE FROM without join condition in WHERE
 fn check_p016(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Update(s) = &info.statement {
-            if !s.from.is_empty() && s.where_clause.is_none() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P016", "update-from-no-join-condition",
-                    "UPDATE FROM \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{7b1b}\u{5361}\u{5c14}\u{79ef}\u{66f4}\u{65b0}".into(),
-                    Some("WHERE \u{4e2d}\u{5173}\u{8054} FROM \u{8868}"), loc,
-                    None, confidence,
-                ));
-            }
+    if let Statement::Update(s) = &curr_stmt.statement {
+        if !s.from.is_empty() && s.where_clause.is_none() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P016", "update-from-no-join-condition",
+                "UPDATE FROM \u{65e0} WHERE \u{5b50}\u{53e5}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{7b1b}\u{5361}\u{5c14}\u{79ef}\u{66f4}\u{65b0}".into(),
+                Some("WHERE \u{4e2d}\u{5173}\u{8054} FROM \u{8868}"), loc,
+                None, confidence,
+            ));
         }
     }
 }
 
 // P017: MERGE without unique index (basic -- always warns)
 fn check_p017(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Merge(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            warnings.push(make_warning(
-                WarningLevel::Performance, "P017", "merge-without-unique-index",
-                "MERGE \u{8bed}\u{53e5} ON \u{6761}\u{4ef6}\u{9700}\u{8981}\u{552f}\u{4e00}\u{7d22}\u{5f15}\u{4fdd}\u{8bc1}\u{786e}\u{5b9a}\u{6027}\u{ff08}\u{9700} schema \u{4fe1}\u{606f}\u{786e}\u{8ba4}\u{ff09}".into(),
-                Some("\u{786e}\u{4fdd} ON \u{6761}\u{4ef6}\u{5217}\u{6709}\u{552f}\u{4e00}\u{7d22}\u{5f15}"), loc,
-                None, confidence,
-            ));
-        }
+    if let Statement::Merge(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        warnings.push(make_warning(
+            WarningLevel::Performance, "P017", "merge-without-unique-index",
+            "MERGE \u{8bed}\u{53e5} ON \u{6761}\u{4ef6}\u{9700}\u{8981}\u{552f}\u{4e00}\u{7d22}\u{5f15}\u{4fdd}\u{8bc1}\u{786e}\u{5b9a}\u{6027}\u{ff08}\u{9700} schema \u{4fe1}\u{606f}\u{786e}\u{8ba4}\u{ff09}".into(),
+            Some("\u{786e}\u{4fdd} ON \u{6761}\u{4ef6}\u{5217}\u{6709}\u{552f}\u{4e00}\u{7d22}\u{5f15}"), loc,
+            None, confidence,
+        ));
     }
 }
 
 // P018: INSERT SELECT without column list
 fn check_p018(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Insert(s) = &info.statement {
-            if s.columns.is_empty() && matches!(&s.source, InsertSource::Select(_)) {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                        WarningLevel::Performance, "P018", "insert-select-no-columns",
-                        "INSERT INTO ... SELECT \u{672a}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{ff0c}\u{4f9d}\u{8d56}\u{5217}\u{987a}\u{5e8f}".into(),
-                        Some("\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}"), loc,
-                        None, confidence,
-                    ));
-            }
+    if let Statement::Insert(s) = &curr_stmt.statement {
+        if s.columns.is_empty() && matches!(&s.source, InsertSource::Select(_)) {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                    WarningLevel::Performance, "P018", "insert-select-no-columns",
+                    "INSERT INTO ... SELECT \u{672a}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}\u{ff0c}\u{4f9d}\u{8d56}\u{5217}\u{987a}\u{5e8f}".into(),
+                    Some("\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{76ee}\u{6807}\u{5217}\u{540d}"), loc,
+                    None, confidence,
+                ));
         }
     }
 }
 
 // P019: Multi-table UPDATE
 fn check_p019(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Update(s) = &info.statement {
-            if s.tables.len() > 1 {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P019", "multi-table-update",
-                    format!("\u{591a}\u{8868} UPDATE \u{5305}\u{542b} {} \u{4e2a}\u{8868}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{975e}\u{9884}\u{671f}\u{7ed3}\u{679c}", s.tables.len()),
-                    Some("\u{62c6}\u{5206}\u{4e3a}\u{591a}\u{6761}\u{5355}\u{8868} UPDATE"), loc,
-                    None, confidence,
-                ));
-            }
+    if let Statement::Update(s) = &curr_stmt.statement {
+        if s.tables.len() > 1 {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P019", "multi-table-update",
+                format!("\u{591a}\u{8868} UPDATE \u{5305}\u{542b} {} \u{4e2a}\u{8868}\u{ff0c}\u{53ef}\u{80fd}\u{4ea7}\u{751f}\u{975e}\u{9884}\u{671f}\u{7ed3}\u{679c}", s.tables.len()),
+                Some("\u{62c6}\u{5206}\u{4e3a}\u{591a}\u{6761}\u{5355}\u{8868} UPDATE"), loc,
+                None, confidence,
+            ));
         }
     }
 }
 
 // P020: INSERT ALL / INSERT FIRST multi-table
 fn check_p020(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        match &info.statement {
-            Statement::InsertAll(s) => {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P020", "insert-all-multi-table",
-                    "INSERT ALL \u{591a}\u{8868}\u{63d2}\u{5165}\u{ff0c}\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT".into(),
-                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT \u{66ff}\u{4ee3}"), loc,
-                    None, confidence,
-                ));
-            }
-            Statement::InsertFirst(s) => {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Performance, "P020", "insert-all-multi-table",
-                    "INSERT FIRST \u{591a}\u{8868}\u{63d2}\u{5165}\u{ff0c}\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT".into(),
-                    Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT \u{66ff}\u{4ee3}"), loc,
-                    None, confidence,
-                ));
-            }
-            _ => {}
+    match &curr_stmt.statement {
+        Statement::InsertAll(s) => {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P020", "insert-all-multi-table",
+                "INSERT ALL \u{591a}\u{8868}\u{63d2}\u{5165}\u{ff0c}\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT".into(),
+                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT \u{66ff}\u{4ee3}"), loc,
+                None, confidence,
+            ));
         }
+        Statement::InsertFirst(s) => {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Performance, "P020", "insert-all-multi-table",
+                "INSERT FIRST \u{591a}\u{8868}\u{63d2}\u{5165}\u{ff0c}\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT".into(),
+                Some("\u{8bc4}\u{4f30}\u{662f}\u{5426}\u{53ef}\u{7528}\u{5355}\u{6761} INSERT...SELECT \u{66ff}\u{4ee3}"), loc,
+                None, confidence,
+            ));
+        }
+        _ => {}
     }
 }
 
 // P022: EXPLAIN in production code
 fn check_p022(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Explain(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            warnings.push(make_warning(
-                WarningLevel::Performance, "P022", "explain-in-production",
-                "EXPLAIN \u{8bed}\u{53e5}\u{4e0d}\u{5e94}\u{51fa}\u{73b0}\u{5728}\u{751f}\u{4ea7}\u{4ee3}\u{7801}\u{4e2d}".into(),
-                Some("\u{79fb}\u{9664} EXPLAIN \u{6216}\u{4ec5}\u{7528}\u{4e8e}\u{8c03}\u{8bd5}"), loc,
-                None, confidence,
-            ));
-        }
+    if let Statement::Explain(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        warnings.push(make_warning(
+            WarningLevel::Performance,
+            "P022",
+            "explain-in-production",
+            "EXPLAIN \u{8bed}\u{53e5}\u{4e0d}\u{5e94}\u{51fa}\u{73b0}\u{5728}\u{751f}\u{4ea7}\u{4ee3}\u{7801}\u{4e2d}"
+                .into(),
+            Some("\u{79fb}\u{9664} EXPLAIN \u{6216}\u{4ec5}\u{7528}\u{4e8e}\u{8c03}\u{8bd5}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -1041,67 +1032,65 @@ fn check_p022(
 const CASE_REPLACEABLE_FUNCTIONS: &[&str] = &["nvl", "nvl2", "decode", "iif"];
 
 fn check_p009(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where(&info.statement) {
-            walk_expr(where_clause, &mut |e| {
-                if let Expr::FunctionCall { name, .. } = e {
-                    if let Some(fn_name) = name.last() {
-                        let lower = fn_name.to_lowercase();
-                        if CASE_REPLACEABLE_FUNCTIONS.contains(&lower.as_str()) {
-                            warnings.push(make_warning(
-                                WarningLevel::Performance,
-                                "P009",
-                                "function-instead-of-case",
-                                format!("\u{51fd}\u{6570} {fn_name}() \u{53ef}\u{4ee5}\u{7528} CASE \u{8868}\u{8fbe}\u{5f0f}\u{66ff}\u{4ee3}\u{ff0c}\u{53ef}\u{80fd}\u{66f4}\u{9ad8}\u{6548}"),
-                                Some("\u{4f7f}\u{7528} CASE WHEN ... THEN ... ELSE ... END \u{66ff}\u{4ee3}"),
-                                loc,
-                                None,
-                                confidence,
-                            ));
-                            return false;
-                        }
+    let loc = stmt_location(curr_stmt);
+    if let Some(where_clause) = extract_where(&curr_stmt.statement) {
+        walk_expr(where_clause, &mut |e| {
+            if let Expr::FunctionCall { name, .. } = e {
+                if let Some(fn_name) = name.last() {
+                    let lower = fn_name.to_lowercase();
+                    if CASE_REPLACEABLE_FUNCTIONS.contains(&lower.as_str()) {
+                        warnings.push(make_warning(
+                            WarningLevel::Performance,
+                            "P009",
+                            "function-instead-of-case",
+                            format!("\u{51fd}\u{6570} {fn_name}() \u{53ef}\u{4ee5}\u{7528} CASE \u{8868}\u{8fbe}\u{5f0f}\u{66ff}\u{4ee3}\u{ff0c}\u{53ef}\u{80fd}\u{66f4}\u{9ad8}\u{6548}"),
+                            Some("\u{4f7f}\u{7528} CASE WHEN ... THEN ... ELSE ... END \u{66ff}\u{4ee3}"),
+                            loc,
+                            None,
+                            confidence,
+                        ));
+                        return false;
                     }
                 }
-                true
-            });
-        }
+            }
+            true
+        });
     }
 }
 
 // ── P021: Row-by-row INSERT in PL/pgSQL loop ──
 
 fn check_p021(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_loop_insert(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Performance,
-                "P021",
-                "row-by-row-insert-in-loop",
-                "\u{5faa}\u{73af}\u{4f53}\u{5185}\u{5305}\u{542b} INSERT\u{ff0c}\u{5e94}\u{4f7f}\u{7528} FORALL \u{6279}\u{91cf}\u{64cd}\u{4f5c}\u{66ff}\u{4ee3}".into(),
-                Some("\u{4f7f}\u{7528} FORALL \u{6279}\u{91cf}\u{63d2}\u{5165}\u{6216} INSERT ... SELECT \u{66ff}\u{4ee3}\u{5faa}\u{73af} INSERT"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_loop_insert(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Performance,
+            "P021",
+            "row-by-row-insert-in-loop",
+            "\u{5faa}\u{73af}\u{4f53}\u{5185}\u{5305}\u{542b} INSERT\u{ff0c}\u{5e94}\u{4f7f}\u{7528} FORALL \u{6279}\u{91cf}\u{64cd}\u{4f5c}\u{66ff}\u{4ee3}".into(),
+            Some("\u{4f7f}\u{7528} FORALL \u{6279}\u{91cf}\u{63d2}\u{5165}\u{6216} INSERT ... SELECT \u{66ff}\u{4ee3}\u{5faa}\u{73af} INSERT"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -1178,14 +1167,17 @@ fn check_pl_stmts_for_loop_insert(pl_stmts: &[crate::ast::plpgsql::PlStatement],
 // recursion.  GaussDB's WITH RECURSIVE CTE often provides better optimization
 // and clearer semantics for complex traversals.
 fn check_p023(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for (s, loc) in collect_nested_selects(stmts) {
+    let mut selects: Vec<(&SelectStatement, SourceLocation)> = Vec::new();
+    collect_selects_from_stmt(&curr_stmt.statement, stmt_location(curr_stmt), &mut selects);
+    for (s, loc) in selects {
         if s.connect_by.is_some() {
             let mut msg = String::from("CONNECT BY 层级查询在数据量大或递归层次深时性能可能显著下降");
             if s.connect_by.as_ref().is_some_and(|cb| cb.start_with.is_none()) {

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -80,25 +80,24 @@ pub fn register(linter: &mut SqlLinter) {
 
 // R001: SELECT * (unqualified)
 fn check_r001(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            for target in &s.targets {
-                if let SelectTarget::Star(None) = target {
-                    warnings.push(make_warning(
-                        WarningLevel::Prohibition, "R001", "select-star",
-                        "SELECT * \u{8fdd}\u{53cd} GaussDB \u{7f16}\u{7801}\u{89c4}\u{8303}\u{ff1a}\u{8868}\u{7ed3}\u{6784}\u{53d8}\u{5316}\u{65f6}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{4e0d}\u{517c}\u{5bb9}".into(),
-                        Some("\u{660e}\u{786e}\u{5217}\u{51fa}\u{6240}\u{9700}\u{5b57}\u{6bb5}\u{540d}"), loc,
-                        Some("\u{5f00}\u{53d1}\u{8bbe}\u{8ba1}\u{5efa}\u{8bae} > SELECT \u{89c4}\u{8303}"), confidence,
-                    ));
-                }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        for target in &s.targets {
+            if let SelectTarget::Star(None) = target {
+                warnings.push(make_warning(
+                    WarningLevel::Prohibition, "R001", "select-star",
+                    "SELECT * \u{8fdd}\u{53cd} GaussDB \u{7f16}\u{7801}\u{89c4}\u{8303}\u{ff1a}\u{8868}\u{7ed3}\u{6784}\u{53d8}\u{5316}\u{65f6}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{4e0d}\u{517c}\u{5bb9}".into(),
+                    Some("\u{660e}\u{786e}\u{5217}\u{51fa}\u{6240}\u{9700}\u{5b57}\u{6bb5}\u{540d}"), loc,
+                    Some("\u{5f00}\u{53d1}\u{8bbe}\u{8ba1}\u{5efa}\u{8bae} > SELECT \u{89c4}\u{8303}"), confidence,
+                ));
             }
         }
     }
@@ -106,85 +105,82 @@ fn check_r001(
 
 // R002: Large column sort / group by / distinct
 fn check_r002(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            let group_count = s.group_by.len();
-            let order_count = s.order_by.len();
-            if group_count > config.group_by_column_limit {
-                warnings.push(make_warning(
-                    WarningLevel::Prohibition, "R002", "large-column-sort",
-                    format!("GROUP BY \u{5305}\u{542b} {group_count} \u{4e2a}\u{8868}\u{8fbe}\u{5f0f}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {} \u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6027}\u{80fd}\u{95ee}\u{9898}", config.group_by_column_limit),
-                    Some("\u{7b80}\u{5316} GROUP BY\u{ff0c}\u{51cf}\u{5c11}\u{5206}\u{7ec4}\u{5217}\u{6570}\u{91cf}"), loc,
-                    Some("SELECT \u{89c4}\u{8303}"), confidence,
-                ));
-            }
-            if order_count > config.group_by_column_limit {
-                warnings.push(make_warning(
-                    WarningLevel::Prohibition, "R002", "large-column-sort",
-                    format!("ORDER BY \u{5305}\u{542b} {order_count} \u{4e2a}\u{8868}\u{8fbe}\u{5f0f}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {} \u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6027}\u{80fd}\u{95ee}\u{9898}", config.group_by_column_limit),
-                    Some("\u{7b80}\u{5316} ORDER BY\u{ff0c}\u{51cf}\u{5c11}\u{6392}\u{5e8f}\u{5217}\u{6570}\u{91cf}"), loc,
-                    Some("SELECT \u{89c4}\u{8303}"), confidence,
-                ));
-            }
-        }
-    }
-}
-
-// R003: LOCK TABLE
-fn check_r003(
-    stmts: &[StatementInfo],
-    _schema: Option<&crate::analyzer::schema::SchemaMap>,
-    _indexes: Option<&crate::linter::IndexInfo>,
-    _config: &LintConfig,
-    confidence: Confidence,
-    warnings: &mut Vec<SqlWarning>,
-) {
-    for info in stmts {
-        if let Statement::Lock(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        let group_count = s.group_by.len();
+        let order_count = s.order_by.len();
+        if group_count > config.group_by_column_limit {
             warnings.push(make_warning(
-                WarningLevel::Prohibition, "R003", "lock-table",
-                "LOCK TABLE \u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6b7b}\u{9501}\u{98ce}\u{9669}".into(),
-                Some("\u{907f}\u{514d}\u{5728}\u{4e8b}\u{52a1}\u{4e2d}\u{4f7f}\u{7528} LOCK TABLE\u{ff0c}\u{4f18}\u{5148}\u{4f7f}\u{7528} SELECT ... FOR UPDATE"), loc,
+                WarningLevel::Prohibition, "R002", "large-column-sort",
+                format!("GROUP BY \u{5305}\u{542b} {group_count} \u{4e2a}\u{8868}\u{8fbe}\u{5f0f}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {} \u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6027}\u{80fd}\u{95ee}\u{9898}", config.group_by_column_limit),
+                Some("\u{7b80}\u{5316} GROUP BY\u{ff0c}\u{51cf}\u{5c11}\u{5206}\u{7ec4}\u{5217}\u{6570}\u{91cf}"), loc,
+                Some("SELECT \u{89c4}\u{8303}"), confidence,
+            ));
+        }
+        if order_count > config.group_by_column_limit {
+            warnings.push(make_warning(
+                WarningLevel::Prohibition, "R002", "large-column-sort",
+                format!("ORDER BY \u{5305}\u{542b} {order_count} \u{4e2a}\u{8868}\u{8fbe}\u{5f0f}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {} \u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6027}\u{80fd}\u{95ee}\u{9898}", config.group_by_column_limit),
+                Some("\u{7b80}\u{5316} ORDER BY\u{ff0c}\u{51cf}\u{5c11}\u{6392}\u{5e8f}\u{5217}\u{6570}\u{91cf}"), loc,
                 Some("SELECT \u{89c4}\u{8303}"), confidence,
             ));
         }
     }
 }
 
-// R004: DROP ... CASCADE
-fn check_r004(
-    stmts: &[StatementInfo],
+// R003: LOCK TABLE
+fn check_r003(
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Drop(s) = &info.statement {
-            if s.cascade {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                let obj_type = object_type_str(&s.object_type);
-                warnings.push(make_warning(
-                    WarningLevel::Prohibition,
-                    "R004",
-                    "drop-cascade",
-                    format!("DROP {obj_type} CASCADE \u{53ef}\u{80fd}\u{8bef}\u{5220}\u{4f9d}\u{8d56}\u{5bf9}\u{8c61}"),
-                    Some("\u{786e}\u{8ba4}\u{4f9d}\u{8d56}\u{5173}\u{7cfb}\u{540e}\u{518d}\u{4f7f}\u{7528} CASCADE"),
-                    loc,
-                    Some("SQL \u{7f16}\u{5199}"),
-                    confidence,
-                ));
-            }
+    if let Statement::Lock(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        warnings.push(make_warning(
+            WarningLevel::Prohibition, "R003", "lock-table",
+            "LOCK TABLE \u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{6b7b}\u{9501}\u{98ce}\u{9669}".into(),
+            Some("\u{907f}\u{514d}\u{5728}\u{4e8b}\u{52a1}\u{4e2d}\u{4f7f}\u{7528} LOCK TABLE\u{ff0c}\u{4f18}\u{5148}\u{4f7f}\u{7528} SELECT ... FOR UPDATE"), loc,
+            Some("SELECT \u{89c4}\u{8303}"), confidence,
+        ));
+    }
+}
+
+// R004: DROP ... CASCADE
+fn check_r004(
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    if let Statement::Drop(s) = &curr_stmt.statement {
+        if s.cascade {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            let obj_type = object_type_str(&s.object_type);
+            warnings.push(make_warning(
+                WarningLevel::Prohibition,
+                "R004",
+                "drop-cascade",
+                format!("DROP {obj_type} CASCADE \u{53ef}\u{80fd}\u{8bef}\u{5220}\u{4f9d}\u{8d56}\u{5bf9}\u{8c61}"),
+                Some("\u{786e}\u{8ba4}\u{4f9d}\u{8d56}\u{5173}\u{7cfb}\u{540e}\u{518d}\u{4f7f}\u{7528} CASCADE"),
+                loc,
+                Some("SQL \u{7f16}\u{5199}"),
+                confidence,
+            ));
         }
     }
 }
@@ -209,7 +205,8 @@ fn object_type_str(ot: &crate::ast::ObjectType) -> &'static str {
 
 // R005: Implicit type conversion (schema-aware)
 fn check_r005(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
@@ -225,58 +222,58 @@ fn check_r005(
         return;
     };
 
-    for info in stmts {
-        let loc = stmt_location(info);
-        let (where_clause, tables) = match &info.statement {
-            Statement::Select(s) => (s.where_clause.as_ref(), &s.from),
-            Statement::Update(s) => (s.where_clause.as_ref(), &s.tables),
-            Statement::Delete(s) => (s.where_clause.as_ref(), &s.tables),
-            _ => {
-                let Some(wc) = extract_where_clause(&info.statement) else { continue };
-                check_r005_fallback(wc, loc, confidence, warnings);
-                continue;
-            }
-        };
-        let Some(where_clause) = where_clause else { continue };
+    let loc = stmt_location(curr_stmt);
+    // Handle non-SELECT/UPDATE/DELETE statements with fallback check
+    if !matches!(curr_stmt.statement, Statement::Select(_) | Statement::Update(_) | Statement::Delete(_)) {
+        let Some(wc) = extract_where_clause(&curr_stmt.statement) else { return };
+        check_r005_fallback(wc, loc, confidence, warnings);
+        return;
+    }
+    let (where_clause, tables) = match &curr_stmt.statement {
+        Statement::Select(s) => (s.where_clause.as_ref(), &s.from),
+        Statement::Update(s) => (s.where_clause.as_ref(), &s.tables),
+        Statement::Delete(s) => (s.where_clause.as_ref(), &s.tables),
+        _ => unreachable!(),
+    };
+    let Some(where_clause) = where_clause else { return };
 
-        let col_types = build_column_type_map(schema, tables);
+    let col_types = build_column_type_map(schema, tables);
 
-        let mut found = false;
-        walk_expr(where_clause, &mut |e| {
-            if found {
-                return false;
+    let mut found = false;
+    walk_expr(where_clause, &mut |e| {
+        if found {
+            return false;
+        }
+        if let Expr::BinaryOp { left, right, .. } = e {
+            let l_lit = matches!(left.as_ref(), Expr::Literal(_));
+            let r_lit = matches!(right.as_ref(), Expr::Literal(_));
+            let l_col = matches!(left.as_ref(), Expr::ColumnRef(_));
+            let r_col = matches!(right.as_ref(), Expr::ColumnRef(_));
+            if !((l_lit && r_col) || (l_col && r_lit)) {
+                return true;
             }
-            if let Expr::BinaryOp { left, right, .. } = e {
-                let l_lit = matches!(left.as_ref(), Expr::Literal(_));
-                let r_lit = matches!(right.as_ref(), Expr::Literal(_));
-                let l_col = matches!(left.as_ref(), Expr::ColumnRef(_));
-                let r_col = matches!(right.as_ref(), Expr::ColumnRef(_));
-                if !((l_lit && r_col) || (l_col && r_lit)) {
+
+            let (lit_expr, col_expr) =
+                if l_lit { (left.as_ref(), right.as_ref()) } else { (right.as_ref(), left.as_ref()) };
+            if let (Expr::Literal(lit), Some(col_type)) = (lit_expr, resolve_column_type(col_expr, &col_types)) {
+                let lit_family = literal_type_family(lit);
+                let col_family = classify_type_family(&col_type);
+                if lit_family == col_family {
                     return true;
                 }
-
-                let (lit_expr, col_expr) =
-                    if l_lit { (left.as_ref(), right.as_ref()) } else { (right.as_ref(), left.as_ref()) };
-                if let (Expr::Literal(lit), Some(col_type)) = (lit_expr, resolve_column_type(col_expr, &col_types)) {
-                    let lit_family = literal_type_family(lit);
-                    let col_family = classify_type_family(&col_type);
-                    if lit_family == col_family {
-                        return true;
-                    }
-                }
-                found = true;
-                return false;
             }
-            true
-        });
-        if found {
-            warnings.push(make_warning(
+            found = true;
+            return false;
+        }
+        true
+    });
+    if found {
+        warnings.push(make_warning(
                 WarningLevel::Prohibition, "R005", "implicit-type-conversion",
                 "WHERE \u{4e2d}\u{53ef}\u{80fd}\u{5b58}\u{5728}\u{9690}\u{5f0f}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{7d22}\u{5f15}\u{5931}\u{6548}".into(),
                 Some("\u{663e}\u{5f0f}\u{6dfb}\u{52a0}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff0c}\u{907f}\u{514d}\u{9690}\u{5f0f}\u{8f6c}\u{6362}\u{5bfc}\u{81f4}\u{7d22}\u{5f15}\u{5931}\u{6548}"), loc,
                 Some("WHERE \u{89c4}\u{8303}"), confidence,
             ));
-        }
     }
 }
 
@@ -317,69 +314,55 @@ fn check_r005_fallback(
 const SAFE_FUNCTIONS_ON_COLUMNS: &[&str] = &["coalesce", "nvl", "nvl2", "ifnull", "isnull", "greatest", "least"];
 
 fn check_r006(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let (where_clause, tables) = where_and_tables(&info.statement);
-        let Some(where_clause) = where_clause else { continue };
+    let loc = stmt_location(curr_stmt);
+    let (where_clause, tables) = where_and_tables(&curr_stmt.statement);
+    let Some(where_clause) = where_clause else { return };
 
-        walk_expr(where_clause, &mut |e| {
-            if let Expr::FunctionCall { name, args, .. } = e {
-                let fn_lower = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
-                if SAFE_FUNCTIONS_ON_COLUMNS.contains(&fn_lower.as_str()) {
-                    return true;
-                }
-                for arg in args {
-                    if let Expr::ColumnRef(col_ref) = arg {
-                        match _indexes {
-                            Some(idx_info) => {
-                                let table = resolve_table_from_column(col_ref, tables);
-                                let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
+    walk_expr(where_clause, &mut |e| {
+        if let Expr::FunctionCall { name, args, .. } = e {
+            let fn_lower = name.last().map(|s| s.to_lowercase()).unwrap_or_default();
+            if SAFE_FUNCTIONS_ON_COLUMNS.contains(&fn_lower.as_str()) {
+                return true;
+            }
+            for arg in args {
+                if let Expr::ColumnRef(col_ref) = arg {
+                    match _indexes {
+                        Some(idx_info) => {
+                            let table = resolve_table_from_column(col_ref, tables);
+                            let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
 
-                                let has_index = table
-                                    .as_ref()
-                                    .and_then(|t| idx_info.column_indexes.get(t))
-                                    .map(|cols| cols.contains(&col_lower))
-                                    .unwrap_or(false);
+                            let has_index = table
+                                .as_ref()
+                                .and_then(|t| idx_info.column_indexes.get(t))
+                                .map(|cols| cols.contains(&col_lower))
+                                .unwrap_or(false);
 
-                                let has_func_index = table
-                                    .as_ref()
-                                    .map(|t| {
-                                        crate::analyzer::schema::matches_function_index(
-                                            &idx_info.indexes,
-                                            t,
-                                            &fn_lower,
-                                            &col_lower,
-                                        )
-                                    })
-                                    .unwrap_or(false);
+                            let has_func_index = table
+                                .as_ref()
+                                .map(|t| {
+                                    crate::analyzer::schema::matches_function_index(
+                                        &idx_info.indexes,
+                                        t,
+                                        &fn_lower,
+                                        &col_lower,
+                                    )
+                                })
+                                .unwrap_or(false);
 
-                                if has_index && !has_func_index {
-                                    warnings.push(make_warning(
-                                        WarningLevel::Prohibition,
-                                        "R006",
-                                        "function-on-where-column",
-                                        "WHERE 中对有索引的列使用函数，将导致索引失效".into(),
-                                        Some("将函数运算移到等号另一侧或使用函数索引"),
-                                        loc,
-                                        Some("WHERE 规范"),
-                                        confidence,
-                                    ));
-                                    return false;
-                                }
-                            }
-                            None => {
+                            if has_index && !has_func_index {
                                 warnings.push(make_warning(
                                     WarningLevel::Prohibition,
                                     "R006",
                                     "function-on-where-column",
-                                    "WHERE 中对列使用函数，可能导致索引失效".into(),
+                                    "WHERE 中对有索引的列使用函数，将导致索引失效".into(),
                                     Some("将函数运算移到等号另一侧或使用函数索引"),
                                     loc,
                                     Some("WHERE 规范"),
@@ -388,27 +371,40 @@ fn check_r006(
                                 return false;
                             }
                         }
+                        None => {
+                            warnings.push(make_warning(
+                                WarningLevel::Prohibition,
+                                "R006",
+                                "function-on-where-column",
+                                "WHERE 中对列使用函数，可能导致索引失效".into(),
+                                Some("将函数运算移到等号另一侧或使用函数索引"),
+                                loc,
+                                Some("WHERE 规范"),
+                                confidence,
+                            ));
+                            return false;
+                        }
                     }
                 }
             }
-            if let Expr::TypeCast { expr, .. } = e {
-                if let Expr::ColumnRef(col_ref) = expr.as_ref() {
+        }
+        if let Expr::TypeCast { expr, .. } = e {
+            if let Expr::ColumnRef(col_ref) = expr.as_ref() {
+                emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
+            }
+        }
+        if let Expr::BinaryOp { op, left, right, .. } = e {
+            if is_sargability_breaking_op(op) {
+                if let Expr::ColumnRef(col_ref) = left.as_ref() {
+                    emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
+                }
+                if let Expr::ColumnRef(col_ref) = right.as_ref() {
                     emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
                 }
             }
-            if let Expr::BinaryOp { op, left, right, .. } = e {
-                if is_sargability_breaking_op(op) {
-                    if let Expr::ColumnRef(col_ref) = left.as_ref() {
-                        emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
-                    }
-                    if let Expr::ColumnRef(col_ref) = right.as_ref() {
-                        emit_index_aware_r006(col_ref, tables, _indexes, loc, confidence, warnings);
-                    }
-                }
-            }
-            true
-        });
-    }
+        }
+        true
+    });
 }
 
 fn is_sargability_breaking_op(op: &str) -> bool {
@@ -496,44 +492,73 @@ fn table_name(tref: &crate::ast::TableRef) -> Option<&str> {
 
 // R007: LIKE with leading wildcard
 fn check_r007(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let (where_clause, tables) = where_and_tables(&info.statement);
-        let Some(where_clause) = where_clause else { continue };
-        walk_expr(where_clause, &mut |e| {
-            if let Expr::Like { expr, pattern, negated: false, .. } = e {
-                if let Expr::Literal(crate::ast::Literal::String(s)) = pattern.as_ref() {
-                    if s.starts_with('%') || s.starts_with('_') {
-                        let should_warn = match _indexes {
-                            Some(idx_info) => {
-                                if let Expr::ColumnRef(col_ref) = expr.as_ref() {
-                                    let table = resolve_table_from_column(col_ref, tables);
-                                    let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
-                                    table
-                                        .and_then(|t| idx_info.column_indexes.get(&t))
-                                        .map(|cols| cols.contains(&col_lower))
-                                        .unwrap_or(false)
-                                } else {
-                                    true
-                                }
+    let loc = stmt_location(curr_stmt);
+    let (where_clause, tables) = where_and_tables(&curr_stmt.statement);
+    let Some(where_clause) = where_clause else { return };
+    walk_expr(where_clause, &mut |e| {
+        if let Expr::Like { expr, pattern, negated: false, .. } = e {
+            if let Expr::Literal(crate::ast::Literal::String(s)) = pattern.as_ref() {
+                if s.starts_with('%') || s.starts_with('_') {
+                    let should_warn = match _indexes {
+                        Some(idx_info) => {
+                            if let Expr::ColumnRef(col_ref) = expr.as_ref() {
+                                let table = resolve_table_from_column(col_ref, tables);
+                                let col_lower = col_ref.last().map(|s| s.to_lowercase()).unwrap_or_default();
+                                table
+                                    .and_then(|t| idx_info.column_indexes.get(&t))
+                                    .map(|cols| cols.contains(&col_lower))
+                                    .unwrap_or(false)
+                            } else {
+                                true
                             }
-                            None => true,
-                        };
-                        if should_warn {
-                            warnings.push(make_warning(
-                                WarningLevel::Prohibition, "R007", "like-leading-wildcard",
-                                format!("LIKE '\u{524d}\u{5bfc}\u{901a}\u{914d}\u{7b26} {s}' \u{5c06}\u{5bfc}\u{81f4}\u{65e0}\u{6cd5}\u{4f7f}\u{7528}\u{7d22}\u{5f15}\u{ff0c}\u{89e6}\u{53d1}\u{5168}\u{8868}\u{626b}\u{63cf}"),
-                                Some("\u{907f}\u{514d}\u{4ee5}\u{901a}\u{914d}\u{7b26}\u{5f00}\u{5934}\u{7684} LIKE \u{6a21}\u{5f0f}"), loc,
-                                Some("WHERE \u{89c4}\u{8303}"), confidence,
-                            ));
                         }
+                        None => true,
+                    };
+                    if should_warn {
+                        warnings.push(make_warning(
+                            WarningLevel::Prohibition, "R007", "like-leading-wildcard",
+                            format!("LIKE '\u{524d}\u{5bfc}\u{901a}\u{914d}\u{7b26} {s}' \u{5c06}\u{5bfc}\u{81f4}\u{65e0}\u{6cd5}\u{4f7f}\u{7528}\u{7d22}\u{5f15}\u{ff0c}\u{89e6}\u{53d1}\u{5168}\u{8868}\u{626b}\u{63cf}"),
+                            Some("\u{907f}\u{514d}\u{4ee5}\u{901a}\u{914d}\u{7b26}\u{5f00}\u{5934}\u{7684} LIKE \u{6a21}\u{5f0f}"), loc,
+                            Some("WHERE \u{89c4}\u{8303}"), confidence,
+                        ));
+                    }
+                }
+            }
+        }
+        true
+    });
+}
+
+// R008: Same-table column comparison in WHERE
+fn check_r008(
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    let loc = stmt_location(curr_stmt);
+    if let Some(where_clause) = extract_where_clause(&curr_stmt.statement) {
+        walk_expr(where_clause, &mut |e| {
+            if let Expr::BinaryOp { left, right, .. } = e {
+                if let (Expr::ColumnRef(l), Expr::ColumnRef(r)) = (left.as_ref(), right.as_ref()) {
+                    if l.len() >= 2 && r.len() >= 2 && l[0] == r[0] {
+                        warnings.push(make_warning(
+                            WarningLevel::Caution, "R008", "same-table-column-compare",
+                            format!("\u{540c}\u{8868}\u{5217}\u{6bd4}\u{8f83}: {}.{} \u{4e0e} {}.{}\u{ff0c}\u{53ef}\u{80fd}\u{672a}\u{6b63}\u{786e}\u{4f7f}\u{7528}\u{7d22}\u{5f15}", l[0], l.last().unwrap_or(&"".into()), r[0], r.last().unwrap_or(&"".into())),
+                            Some("\u{68c0}\u{67e5}\u{662f}\u{5426}\u{5e94}\u{4f7f}\u{7528}\u{4e0d}\u{540c}\u{8868}\u{7684}\u{5217}\u{8fdb}\u{884c}\u{6bd4}\u{8f83}"), loc,
+                            Some("WHERE \u{89c4}\u{8303}"), confidence,
+                        ));
                     }
                 }
             }
@@ -542,70 +567,38 @@ fn check_r007(
     }
 }
 
-// R008: Same-table column comparison in WHERE
-fn check_r008(
-    stmts: &[StatementInfo],
-    _schema: Option<&crate::analyzer::schema::SchemaMap>,
-    _indexes: Option<&crate::linter::IndexInfo>,
-    _config: &LintConfig,
-    confidence: Confidence,
-    warnings: &mut Vec<SqlWarning>,
-) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        if let Some(where_clause) = extract_where_clause(&info.statement) {
-            walk_expr(where_clause, &mut |e| {
-                if let Expr::BinaryOp { left, right, .. } = e {
-                    if let (Expr::ColumnRef(l), Expr::ColumnRef(r)) = (left.as_ref(), right.as_ref()) {
-                        if l.len() >= 2 && r.len() >= 2 && l[0] == r[0] {
-                            warnings.push(make_warning(
-                                WarningLevel::Caution, "R008", "same-table-column-compare",
-                                format!("\u{540c}\u{8868}\u{5217}\u{6bd4}\u{8f83}: {}.{} \u{4e0e} {}.{}\u{ff0c}\u{53ef}\u{80fd}\u{672a}\u{6b63}\u{786e}\u{4f7f}\u{7528}\u{7d22}\u{5f15}", l[0], l.last().unwrap_or(&"".into()), r[0], r.last().unwrap_or(&"".into())),
-                                Some("\u{68c0}\u{67e5}\u{662f}\u{5426}\u{5e94}\u{4f7f}\u{7528}\u{4e0d}\u{540c}\u{8868}\u{7684}\u{5217}\u{8fdb}\u{884c}\u{6bd4}\u{8f83}"), loc,
-                                Some("WHERE \u{89c4}\u{8303}"), confidence,
-                            ));
-                        }
-                    }
-                }
-                true
-            });
-        }
-    }
-}
-
 // R009: Scalar subquery in SELECT target list
 fn check_r009(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let loc = loc_from_spanned(s, stmt_location(info));
-            for target in &s.targets {
-                if let SelectTarget::Expr(e, _) = target {
-                    let mut found = false;
-                    walk_expr(e, &mut |inner| {
-                        if found {
-                            return false;
-                        }
-                        if matches!(inner, Expr::Subquery(_)) {
-                            found = true;
-                            return false;
-                        }
-                        true
-                    });
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+        for target in &s.targets {
+            if let SelectTarget::Expr(e, _) = target {
+                let mut found = false;
+                walk_expr(e, &mut |inner| {
                     if found {
-                        warnings.push(make_warning(
-                            WarningLevel::Performance, "R009", "scalar-subquery-in-select",
-                            "SELECT \u{5217}\u{4e2d}\u{5305}\u{542b}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}\u{ff0c}\u{6bcf}\u{884c}\u{90fd}\u{4f1a}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
-                            Some("\u{6539}\u{7528} JOIN \u{66ff}\u{4ee3}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}"), loc,
-                            Some("SQL \u{7f16}\u{5199}"), confidence,
-                        ));
+                        return false;
                     }
+                    if matches!(inner, Expr::Subquery(_)) {
+                        found = true;
+                        return false;
+                    }
+                    true
+                });
+                if found {
+                    warnings.push(make_warning(
+                        WarningLevel::Performance, "R009", "scalar-subquery-in-select",
+                        "SELECT \u{5217}\u{4e2d}\u{5305}\u{542b}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}\u{ff0c}\u{6bcf}\u{884c}\u{90fd}\u{4f1a}\u{6267}\u{884c}\u{4e00}\u{6b21}\u{5b50}\u{67e5}\u{8be2}".into(),
+                        Some("\u{6539}\u{7528} JOIN \u{66ff}\u{4ee3}\u{6807}\u{91cf}\u{5b50}\u{67e5}\u{8be2}"), loc,
+                        Some("SQL \u{7f16}\u{5199}"), confidence,
+                    ));
                 }
             }
         }

--- a/src/linter/rules_suggestion.rs
+++ b/src/linter/rules_suggestion.rs
@@ -59,28 +59,27 @@ pub fn register(linter: &mut SqlLinter) {
 // ── S001: DELETE full table → use TRUNCATE ──
 
 fn check_s001(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Delete(s) = &info.statement {
-            if s.where_clause.is_none() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Suggestion,
-                    "S001",
-                    "delete-full-table-use-truncate",
-                    "DELETE \u{5168}\u{8868}\u{53ef}\u{7528} TRUNCATE \u{66ff}\u{4ee3}\u{ff0c}\u{91ca}\u{653e}\u{7a7a}\u{95f4}\u{66f4}\u{5feb}".into(),
-                    Some("\u{4f7f}\u{7528} TRUNCATE TABLE \u{66ff}\u{4ee3} DELETE \u{65e0} WHERE"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
+    if let Statement::Delete(s) = &curr_stmt.statement {
+        if s.where_clause.is_none() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Suggestion,
+                "S001",
+                "delete-full-table-use-truncate",
+                "DELETE \u{5168}\u{8868}\u{53ef}\u{7528} TRUNCATE \u{66ff}\u{4ee3}\u{ff0c}\u{91ca}\u{653e}\u{7a7a}\u{95f4}\u{66f4}\u{5feb}".into(),
+                Some("\u{4f7f}\u{7528} TRUNCATE TABLE \u{66ff}\u{4ee3} DELETE \u{65e0} WHERE"),
+                loc,
+                None,
+                confidence,
+            ));
         }
     }
 }
@@ -88,31 +87,28 @@ fn check_s001(
 // ── S002: LIMIT + OFFSET → use cursor ──
 
 fn check_s002(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            if s.offset.is_some() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Suggestion,
-                    "S002",
-                    "limit-offset-use-cursor",
-                    "OFFSET \u{5206}\u{9875}\u{5728}\u{5927}\u{504f}\u{79fb}\u{65f6}\u{6027}\u{80fd}\u{8f83}\u{5dee}"
-                        .into(),
-                    Some(
-                        "\u{8003}\u{8651}\u{4f7f}\u{7528}\u{6e38}\u{6807}\u{7ffb}\u{9875}\u{66ff}\u{4ee3} LIMIT/OFFSET",
-                    ),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        if s.offset.is_some() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Suggestion,
+                "S002",
+                "limit-offset-use-cursor",
+                "OFFSET \u{5206}\u{9875}\u{5728}\u{5927}\u{504f}\u{79fb}\u{65f6}\u{6027}\u{80fd}\u{8f83}\u{5dee}"
+                    .into(),
+                Some("\u{8003}\u{8651}\u{4f7f}\u{7528}\u{6e38}\u{6807}\u{7ffb}\u{9875}\u{66ff}\u{4ee3} LIMIT/OFFSET"),
+                loc,
+                None,
+                confidence,
+            ));
         }
     }
 }
@@ -120,29 +116,28 @@ fn check_s002(
 // ── S005: Prefer %TYPE anchored types ──
 
 fn check_s005(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let mut found = false;
-        walk_pl_for_type_name(&info.statement, &mut found);
-        if found {
-            warnings.push(make_warning(
-                WarningLevel::Suggestion,
-                "S005",
-                "prefer-percent-type",
-                "PL/pgSQL \u{53d8}\u{91cf}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{7c7b}\u{578b}\u{800c}\u{975e} %TYPE/%ROWTYPE \u{951a}\u{5b9a}".into(),
-                Some("\u{4f7f}\u{7528} table.column%TYPE \u{6216} table%ROWTYPE \u{951a}\u{5b9a}\u{7c7b}\u{578b}\u{4ee5}\u{63d0}\u{9ad8}\u{53ef}\u{7ef4}\u{62a4}\u{6027}"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    let loc = stmt_location(curr_stmt);
+    let mut found = false;
+    walk_pl_for_type_name(&curr_stmt.statement, &mut found);
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Suggestion,
+            "S005",
+            "prefer-percent-type",
+            "PL/pgSQL \u{53d8}\u{91cf}\u{4f7f}\u{7528}\u{666e}\u{901a}\u{7c7b}\u{578b}\u{800c}\u{975e} %TYPE/%ROWTYPE \u{951a}\u{5b9a}".into(),
+            Some("\u{4f7f}\u{7528} table.column%TYPE \u{6216} table%ROWTYPE \u{951a}\u{5b9a}\u{7c7b}\u{578b}\u{4ee5}\u{63d0}\u{9ad8}\u{53ef}\u{7ef4}\u{62a4}\u{6027}"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
@@ -228,29 +223,28 @@ fn check_pl_stmts_for_type_name(pl_stmts: &[PlStatement], found: &mut bool) {
 // ── S006: LIMIT without ORDER BY ──
 
 fn check_s006(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if let Statement::Select(s) = &info.statement {
-            let has_limit = s.limit.is_some() || s.fetch.is_some() || matches!(&s.fetch, Some(f) if f.count.is_some());
-            if has_limit && s.order_by.is_empty() {
-                let loc = loc_from_spanned(s, stmt_location(info));
-                warnings.push(make_warning(
-                    WarningLevel::Suggestion,
-                    "S006",
-                    "limit-without-order-by",
-                    "LIMIT \u{65e0} ORDER BY\u{ff0c}\u{7ed3}\u{679c}\u{987a}\u{5e8f}\u{4e0d}\u{786e}\u{5b9a}".into(),
-                    Some("\u{6dfb}\u{52a0} ORDER BY \u{4fdd}\u{8bc1}\u{7ed3}\u{679c}\u{786e}\u{5b9a}\u{6027}"),
-                    loc,
-                    None,
-                    confidence,
-                ));
-            }
+    if let Statement::Select(s) = &curr_stmt.statement {
+        let has_limit = s.limit.is_some() || s.fetch.is_some() || matches!(&s.fetch, Some(f) if f.count.is_some());
+        if has_limit && s.order_by.is_empty() {
+            let loc = loc_from_spanned(s, stmt_location(curr_stmt));
+            warnings.push(make_warning(
+                WarningLevel::Suggestion,
+                "S006",
+                "limit-without-order-by",
+                "LIMIT \u{65e0} ORDER BY\u{ff0c}\u{7ed3}\u{679c}\u{987a}\u{5e8f}\u{4e0d}\u{786e}\u{5b9a}".into(),
+                Some("\u{6dfb}\u{52a0} ORDER BY \u{4fdd}\u{8bc1}\u{7ed3}\u{679c}\u{786e}\u{5b9a}\u{6027}"),
+                loc,
+                None,
+                confidence,
+            ));
         }
     }
 }
@@ -258,102 +252,100 @@ fn check_s006(
 // ── S007: Explicit type for literals in WHERE ──
 
 fn check_s007(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     _config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        let loc = stmt_location(info);
-        let (where_clause, tables) = match &info.statement {
-            Statement::Select(s) => (s.where_clause.as_ref(), &s.from),
-            Statement::Update(s) => (s.where_clause.as_ref(), &s.tables),
-            Statement::Delete(s) => (s.where_clause.as_ref(), &s.tables),
-            _ => continue,
-        };
-        let Some(where_clause) = where_clause else { continue };
+    let loc = stmt_location(curr_stmt);
+    let (where_clause, tables) = match &curr_stmt.statement {
+        Statement::Select(s) => (s.where_clause.as_ref(), &s.from),
+        Statement::Update(s) => (s.where_clause.as_ref(), &s.tables),
+        Statement::Delete(s) => (s.where_clause.as_ref(), &s.tables),
+        _ => return,
+    };
+    let Some(where_clause) = where_clause else { return };
 
-        // Only warn when schema is available and provides concrete evidence of
-        // a cross-family comparison (e.g. int_col = 'str'). Without schema or
-        // when the column can't be resolved, skip — no evidence to warn on.
-        let col_types = schema.map(|s| build_column_type_map(s, tables));
+    // Only warn when schema is available and provides concrete evidence of
+    // a cross-family comparison (e.g. int_col = 'str'). Without schema or
+    // when the column can't be resolved, skip — no evidence to warn on.
+    let col_types = schema.map(|s| build_column_type_map(s, tables));
 
-        let mut found = false;
-        walk_expr(where_clause, &mut |e| {
-            if found {
-                return false;
-            }
-            if let Expr::BinaryOp { left, right, op, .. } = e {
-                let is_compare = matches!(op.as_str(), "=" | "<>" | "!=" | ">" | "<" | ">=" | "<=");
-                if !is_compare {
-                    return true;
-                }
-                let l_untyped = matches!(left.as_ref(), Expr::Literal(crate::ast::Literal::String(_)));
-                let r_untyped = matches!(right.as_ref(), Expr::Literal(crate::ast::Literal::String(_)));
-                if !l_untyped && !r_untyped {
-                    return true;
-                }
-
-                let Some(ref ct) = col_types else {
-                    return true; // no schema → skip, no evidence
-                };
-                let col_expr = if l_untyped { right.as_ref() } else { left.as_ref() };
-                let Some(col_type) = resolve_column_type(col_expr, ct) else {
-                    return true; // column unresolved → skip, no evidence
-                };
-                if is_string_type(&col_type) {
-                    return true; // same-family → skip, safe
-                }
-                // Cross-family: concrete evidence of potential implicit conversion.
-                found = true;
-                return false;
-            }
-            true
-        });
+    let mut found = false;
+    walk_expr(where_clause, &mut |e| {
         if found {
-            warnings.push(make_warning(
-                WarningLevel::Suggestion,
-                "S007",
-                "explicit-type-for-literals",
-                "WHERE \u{4e2d}\u{5b57}\u{7b26}\u{4e32}\u{5e38}\u{91cf}\u{672a}\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{7c7b}\u{578b}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{9690}\u{5f0f}\u{8f6c}\u{6362}".into(),
-                Some("\u{4f7f}\u{7528}\u{663e}\u{5f0f}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff1a} 'val'::type \u{6216} CAST('val' AS type)"),
-                loc,
-                None,
-                confidence,
-            ));
+            return false;
         }
+        if let Expr::BinaryOp { left, right, op, .. } = e {
+            let is_compare = matches!(op.as_str(), "=" | "<>" | "!=" | ">" | "<" | ">=" | "<=");
+            if !is_compare {
+                return true;
+            }
+            let l_untyped = matches!(left.as_ref(), Expr::Literal(crate::ast::Literal::String(_)));
+            let r_untyped = matches!(right.as_ref(), Expr::Literal(crate::ast::Literal::String(_)));
+            if !l_untyped && !r_untyped {
+                return true;
+            }
+
+            let Some(ref ct) = col_types else {
+                return true; // no schema → skip, no evidence
+            };
+            let col_expr = if l_untyped { right.as_ref() } else { left.as_ref() };
+            let Some(col_type) = resolve_column_type(col_expr, ct) else {
+                return true; // column unresolved → skip, no evidence
+            };
+            if is_string_type(&col_type) {
+                return true; // same-family → skip, safe
+            }
+            // Cross-family: concrete evidence of potential implicit conversion.
+            found = true;
+            return false;
+        }
+        true
+    });
+    if found {
+        warnings.push(make_warning(
+            WarningLevel::Suggestion,
+            "S007",
+            "explicit-type-for-literals",
+            "WHERE \u{4e2d}\u{5b57}\u{7b26}\u{4e32}\u{5e38}\u{91cf}\u{672a}\u{663e}\u{5f0f}\u{6307}\u{5b9a}\u{7c7b}\u{578b}\u{ff0c}\u{53ef}\u{80fd}\u{5bfc}\u{81f4}\u{9690}\u{5f0f}\u{8f6c}\u{6362}".into(),
+            Some("\u{4f7f}\u{7528}\u{663e}\u{5f0f}\u{7c7b}\u{578b}\u{8f6c}\u{6362}\u{ff1a} 'val'::type \u{6216} CAST('val' AS type)"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }
 
 // ── S008: Complex SQL — consider splitting ──
 
 fn check_s008(
-    stmts: &[StatementInfo],
+    curr_stmt: &StatementInfo,
+    _stmts: &[StatementInfo],
     _schema: Option<&crate::analyzer::schema::SchemaMap>,
     _indexes: Option<&crate::linter::IndexInfo>,
     config: &LintConfig,
     confidence: Confidence,
     warnings: &mut Vec<SqlWarning>,
 ) {
-    for info in stmts {
-        if info.sql_text.len() > config.sql_length_limit {
-            let loc = stmt_location(info);
-            warnings.push(make_warning(
-                WarningLevel::Suggestion,
-                "S008",
-                "complex-sql-consider-split",
-                format!(
-                    "SQL \u{6587}\u{672c}\u{957f}\u{5ea6} {} \u{5b57}\u{7b26}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{5efa}\u{8bae}\u{62c6}\u{5206}\u{7b80}\u{5316}",
-                    info.sql_text.len(),
-                    config.sql_length_limit
-                ),
-                Some("\u{5c06}\u{590d}\u{6742} SQL \u{62c6}\u{5206}\u{4e3a}\u{591a}\u{4e2a}\u{7b80}\u{5355}\u{67e5}\u{8be2}\u{6216}\u{4f7f}\u{7528} CTE"),
-                loc,
-                None,
-                confidence,
-            ));
-        }
+    if curr_stmt.sql_text.len() > config.sql_length_limit {
+        let loc = stmt_location(curr_stmt);
+        warnings.push(make_warning(
+            WarningLevel::Suggestion,
+            "S008",
+            "complex-sql-consider-split",
+            format!(
+                "SQL \u{6587}\u{672c}\u{957f}\u{5ea6} {} \u{5b57}\u{7b26}\u{ff0c}\u{8d85}\u{8fc7}\u{9608}\u{503c} {}\u{ff0c}\u{5efa}\u{8bae}\u{62c6}\u{5206}\u{7b80}\u{5316}",
+                curr_stmt.sql_text.len(),
+                config.sql_length_limit
+            ),
+            Some("\u{5c06}\u{590d}\u{6742} SQL \u{62c6}\u{5206}\u{4e3a}\u{591a}\u{4e2a}\u{7b80}\u{5355}\u{67e5}\u{8be2}\u{6216}\u{4f7f}\u{7528} CTE"),
+            loc,
+            None,
+            confidence,
+        ));
     }
 }

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -1252,3 +1252,82 @@ fn from_toml_str_empty() {
     assert_eq!(config.min_level, WarningLevel::Suggestion);
     assert_eq!(config.min_confidence, Confidence::Partial);
 }
+
+// ════════════════════════════════════════════════════════════════
+// Regression tests for issue #246: double-iteration bug
+// ════════════════════════════════════════════════════════════════
+//
+// Issue #246: SqlLinter::lint had outer loop `for info in stmts` × inner loop
+// `for info in stmts` inside each check_fn. For N statements, every warning
+// was produced N times (N×M instead of M). PR1 fixed this by passing
+// `curr_stmt: &StatementInfo` as first param and removing the inner loop.
+//
+// These tests lock in the fix: if anyone reintroduces the double-iteration,
+// asserting exact counts will fail.
+
+#[test]
+fn test_s006_multi_statement_no_duplicate_warnings_issue_246() {
+    // N=5 statements, M=2 have LIMIT without ORDER BY (stmts 1 and 3).
+    // Without fix: count = N×M = 5×2 = 10. With fix: count = M = 2.
+    let sql = "\
+        SELECT * FROM t1 LIMIT 5;
+        SELECT id FROM t2 WHERE id = 1;
+        SELECT * FROM t3 LIMIT 10;
+        SELECT id FROM t4 ORDER BY id;
+        SELECT id FROM t5 ORDER BY id LIMIT 1";
+    let stmts = parse(sql);
+    let w = lint(&stmts);
+    let count = w.iter().filter(|w| w.rule_id == "S006").count();
+    assert_eq!(count, 2, "without the fix for issue #246, count would be 5×2=10 (N×M)");
+}
+
+#[test]
+fn test_multiple_rules_multi_statement_no_duplication_issue_246() {
+    // 4 statements: SELECT * (R001), DELETE full table (S001/C008),
+    // LIMIT without ORDER BY (S006), and one clean.
+    // Without fix: each rule fires N=4 times for its single matching stmt.
+    let sql = "\
+        SELECT * FROM t1;
+        DELETE FROM t2;
+        SELECT id FROM t3 LIMIT 5;
+        SELECT id FROM t4 WHERE status = 'active' ORDER BY id";
+    let stmts = parse(sql);
+    let w = lint(&stmts);
+    assert_eq!(
+        w.iter().filter(|w| w.rule_id == "R001").count(),
+        1,
+        "without fix for issue #246, R001 would fire 4 times"
+    );
+    assert_eq!(
+        w.iter().filter(|w| w.rule_id == "S006").count(),
+        1,
+        "without fix for issue #246, S006 would fire 4 times"
+    );
+    assert_eq!(
+        w.iter().filter(|w| w.rule_id == "S001").count(),
+        1,
+        "without fix for issue #246, S001 would fire 4 times"
+    );
+}
+
+#[test]
+fn test_s006_single_statement_still_warns_issue_246() {
+    // Single-statement sanity: fix must not break the simple case.
+    let stmts = parse("SELECT * FROM t LIMIT 10");
+    let w = lint(&stmts);
+    assert_eq!(w.iter().filter(|w| w.rule_id == "S006").count(), 1);
+}
+
+#[test]
+fn test_s006_large_n_no_quadratic_explosion_issue_246() {
+    // N=20 identical statements, all with LIMIT without ORDER BY.
+    // Without fix: count = 20×20 = 400. With fix: count = 20.
+    let sql = (0..20).map(|i| format!("SELECT * FROM t{i} LIMIT 5")).collect::<Vec<_>>().join(";\n");
+    let stmts = parse(&sql);
+    let w = lint(&stmts);
+    assert_eq!(
+        w.iter().filter(|w| w.rule_id == "S006").count(),
+        20,
+        "without fix for issue #246, count would be 20×20=400"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #246.

`SqlLinter::lint` had a **double-iteration bug**: an outer `for info in stmts` loop × each `check_fn`'s internal `for info in stmts` loop. For a file with N statements, every warning was produced N times (O(N²R) total work).

Concrete impact reported by downstream [CodeRoughcollie](https://github.com/c2j/CodeRoughcollie): a 179-statement SQL file with 36 real LINT-S006 findings produced **6444 warnings** (= 36 × 179).

## Root cause

```rust
// src/linter/mod.rs:352-366 (before)
for info in stmts {                                          // outer: N times
    let kind = classify_statement(&info.statement);
    for rule in &self.rules {
        if !rule.stmt_kind.matches(kind) { continue; }
        (rule.check_fn)(stmts, schema, ...);                 // passes FULL slice
    }
}
```

Each `check_fn` also did `for info in stmts { ... }` internally, so a rule fired N times and each invocation re-scanned all N statements.

## Fix (option C — dual-param API)

Industry-standard pattern (matches Rust Clippy `check_expr(cx, expr)`, ESLint visitor+context, Biome `RuleContext`). Add `curr_stmt: &StatementInfo` as first param of `check_fn`; the dispatcher passes the current statement once; each rule inspects `curr_stmt` directly.

```rust
pub check_fn: fn(
    curr_stmt: &StatementInfo,   // NEW: current statement
    stmts: &[StatementInfo],      // kept as _stmts for future cross-stmt rules
    Option<&SchemaMap>,
    ...
),
```

The outer dispatch loop is **preserved** — `stmt_kind` pre-filtering and `classify_statement` remain valid (unlike option A which would have made them dead code).

## Audit result

All **53 rules are SINGLE-STMT** (zero CROSS-STMT). The only structural outlier was P023 (`collect_nested_selects(stmts)`), now using the per-statement variant `collect_selects_from_stmt`. PL-block-walking rules (P021, C011–C014, C016, C017, S005) operate within a single `StatementInfo`'s AST subtree — no cross-statement correlation needed.

## Changes

**Commit 1** `fix(linter): ...` — production code (5 files, +1063/-1096):
- `src/linter/mod.rs`: `LintRuleEntry.check_fn` signature + dispatch loop + `collect_selects_from_stmt` promoted to `pub(crate)`
- `src/linter/rules_{prohibition,performance,caution,suggestion}.rs`: 53 `check_fn` bodies migrated (removed inner `for info in stmts` wrapper, `info`→`curr_stmt`)

**Commit 2** `test(linter): ...` — regression tests (1 file, +79):
- `src/linter/tests.rs`: 4 tests covering N=5/M=2, multi-rule, single-stmt sanity, N=20 stress

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | ✅ exit 0 |
| `cargo clippy --all-features -- -D warnings` | ✅ exit 0 |
| `cargo test --all-features` | ✅ **1948 passed; 0 failed** (1944 baseline + 4 new) |
| **Red-green regression proof** | ✅ Stashing the production fix makes 3 of 4 new tests fail with predicted N×M counts (10, 400, 3); restoring makes all 4 pass |
| Behavior preservation | ✅ Zero existing tests modified — the existing suite did not cover multi-statement scenarios (this gap is now filled by commit 2) |

## Design notes

- `stmts` parameter kept as `_stmts` (unused) in all 53 rules — forward-compatible signature for future CROSS-STMT rules
- `collect_nested_selects` remains `pub` (still part of the public API via `pub mod linter`) even though it has no internal callers after this change — removing it would be a breaking SemVer change
- 3 rules needed `continue`→`return` adjustment (R005, S007, C006) since there is no outer loop to skip — semantically equivalent (early-exit the function vs skip to next iteration)

## Related

- Downstream: CodeRoughcollie (consumes `validate_statements` / `SqlLinter`)
- #244 (public `validate_statements` API) — this bug was exposed to downstream via that public API