### PR TITLE
feat: 为 PlProcedureCall 和 CallFuncStatement 附加 builtin 元数据 (#253)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1785,6 +1785,8 @@ pub enum CallArg {
 pub struct CallFuncStatement {
     pub func_name: ObjectName,
     pub args: Vec<CallArg>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builtin: Option<BuiltinFuncMeta>,
 }
 
 macro_rules! stub_struct {

--- a/src/ast/plpgsql.rs
+++ b/src/ast/plpgsql.rs
@@ -225,6 +225,8 @@ pub enum PlStatement {
 pub struct PlProcedureCall {
     pub name: crate::ast::ObjectName,
     pub arguments: Vec<crate::ast::Expr>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builtin: Option<crate::ast::BuiltinFuncMeta>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -1486,6 +1486,7 @@ mod visitor_tests {
                     Expr::Literal(crate::ast::Literal::Integer(1)),
                     Expr::Literal(crate::ast::Literal::Integer(2)),
                 ],
+                builtin: None,
             },
             None,
         ));

--- a/src/ast/visitor_tests.rs
+++ b/src/ast/visitor_tests.rs
@@ -242,13 +242,14 @@ mod visitor_tests {
 
     #[test]
     fn test_walk_pl_statement_procedure_call() {
-        let proc_call = PlStatement::ProcedureCall(PlProcedureCall {
-            name: vec!["schema".to_string(), "proc".to_string()],
-            arguments: vec![
-                Expr::Literal(crate::ast::Literal::Integer(1)),
-                Expr::Literal(crate::ast::Literal::Integer(2)),
-            ],
-        });
+    let proc_call = PlStatement::ProcedureCall(PlProcedureCall {
+        name: vec!["schema".to_string(), "proc".to_string()],
+        arguments: vec![
+            Expr::Literal(crate::ast::Literal::Integer(1)),
+            Expr::Literal(crate::ast::Literal::Integer(2)),
+        ],
+        builtin: None,
+    });
 
         let mut visitor = TestVisitor::default();
         walk_pl_statement(&mut visitor, &proc_call);

--- a/src/ast/visitor_tests.rs
+++ b/src/ast/visitor_tests.rs
@@ -242,14 +242,14 @@ mod visitor_tests {
 
     #[test]
     fn test_walk_pl_statement_procedure_call() {
-    let proc_call = PlStatement::ProcedureCall(PlProcedureCall {
-        name: vec!["schema".to_string(), "proc".to_string()],
-        arguments: vec![
-            Expr::Literal(crate::ast::Literal::Integer(1)),
-            Expr::Literal(crate::ast::Literal::Integer(2)),
-        ],
-        builtin: None,
-    });
+        let proc_call = PlStatement::ProcedureCall(PlProcedureCall {
+            name: vec!["schema".to_string(), "proc".to_string()],
+            arguments: vec![
+                Expr::Literal(crate::ast::Literal::Integer(1)),
+                Expr::Literal(crate::ast::Literal::Integer(2)),
+            ],
+            builtin: None,
+        });
 
         let mut visitor = TestVisitor::default();
         walk_pl_statement(&mut visitor, &proc_call);

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -16,11 +16,10 @@ impl Parser {
         has_over: bool,
         has_variadic: bool,
     ) -> Option<crate::ast::BuiltinFuncMeta> {
+        let builtin = crate::parser::function_registry::resolve_builtin_meta(name);
+
         let full_name = name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
         let last_seg = full_name.split('.').next_back().unwrap_or(&full_name).to_string();
-
-        let builtin = crate::parser::function_registry::lookup_builtin_meta_qualified(&full_name)
-            .or_else(|| crate::parser::function_registry::lookup_builtin_meta(&last_seg));
 
         let warnings = crate::parser::function_registry::validate_function_call(
             &last_seg,

--- a/src/parser/function_registry.rs
+++ b/src/parser/function_registry.rs
@@ -1593,6 +1593,14 @@ pub fn lookup_builtin_meta_qualified(full_name: &str) -> Option<crate::ast::Buil
     })
 }
 
+/// Resolve built-in function metadata from a [`ObjectName`], handling both
+/// plain (`abs`) and dotted package names (`dbe_output.put_line`).
+pub fn resolve_builtin_meta(name: &crate::ast::ObjectName) -> Option<crate::ast::BuiltinFuncMeta> {
+    let full = name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
+    let last = full.split('.').next_back().unwrap_or(&full).to_string();
+    lookup_builtin_meta_qualified(&full).or_else(|| lookup_builtin_meta(&last))
+}
+
 /// Validate a function call and return a list of warnings (if any).
 pub fn validate_function_call(
     name: &str,
@@ -3133,5 +3141,32 @@ mod tests {
         let reg = FunctionRegistry::new().with_extensions_from_json(json).unwrap();
         let meta = reg.lookup("dbe_test_default").unwrap();
         assert_eq!(meta.distribution, Distribution::BOTH);
+    }
+
+    #[test]
+    fn test_resolve_builtin_meta_plain_function() {
+        let name: crate::ast::ObjectName = vec!["abs".into()];
+        let meta = super::resolve_builtin_meta(&name).unwrap();
+        assert_eq!(meta.domain, "Math");
+    }
+
+    #[test]
+    fn test_resolve_builtin_meta_dotted_package_function() {
+        let name: crate::ast::ObjectName = vec!["dbe_output".into(), "put_line".into()];
+        let meta = super::resolve_builtin_meta(&name).unwrap();
+        assert_eq!(meta.domain, "DbeOutput");
+    }
+
+    #[test]
+    fn test_resolve_builtin_meta_unknown_returns_none() {
+        let name: crate::ast::ObjectName = vec!["definitely_not_a_real_func_xyz".into()];
+        assert!(super::resolve_builtin_meta(&name).is_none());
+    }
+
+    #[test]
+    fn test_resolve_builtin_meta_schema_qualified_fallback() {
+        let name: crate::ast::ObjectName = vec!["myschema".into(), "abs".into()];
+        let meta = super::resolve_builtin_meta(&name).unwrap();
+        assert_eq!(meta.domain, "Math");
     }
 }

--- a/src/parser/plpgsql.rs
+++ b/src/parser/plpgsql.rs
@@ -1267,8 +1267,9 @@ impl Parser {
 
         arguments.retain(|a| !matches!(a, Expr::Default));
 
+        let builtin = crate::parser::function_registry::resolve_builtin_meta(&name);
         Some(PlStatement::ProcedureCall(Spanned::new(
-            PlProcedureCall { name, arguments },
+            PlProcedureCall { name, arguments, builtin },
             Some(SourceSpan { start, end: self.prev_location() }),
         )))
     }
@@ -1302,8 +1303,10 @@ impl Parser {
 
         arguments.retain(|a| !matches!(a, Expr::Default));
 
+        let name: crate::ast::ObjectName = vec![name_str.into()];
+        let builtin = crate::parser::function_registry::resolve_builtin_meta(&name);
         Some(PlStatement::ProcedureCall(Spanned::new(
-            PlProcedureCall { name: vec![name_str.into()], arguments },
+            PlProcedureCall { name, arguments, builtin },
             Some(SourceSpan { start, end: self.prev_location() }),
         )))
     }
@@ -2154,8 +2157,9 @@ impl Parser {
 
         self.try_consume_semicolon();
 
+        let builtin = crate::parser::function_registry::resolve_builtin_meta(&name);
         Ok(PlStatement::ProcedureCall(Spanned::new(
-            PlProcedureCall { name, arguments },
+            PlProcedureCall { name, arguments, builtin },
             Some(SourceSpan { start, end: self.prev_location() }),
         )))
     }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -14320,3 +14320,32 @@ fn test_subscript_single_index_still_works() {
     let output = formatter.format_statement(&stmts[0]);
     assert!(output.contains("[1]"), "formatted SQL should contain [1]: {}", output);
 }
+
+#[test]
+fn test_pl_procedure_call_populates_builtin_for_dbe_output() {
+    let block = parse_do_block("DO $$ BEGIN dbe_output.put_line('hello'); END $$");
+    let proc_call = block
+        .body
+        .iter()
+        .find_map(|s| match s {
+            PlStatement::ProcedureCall(spanned) => Some(&spanned.node),
+            _ => None,
+        })
+        .expect("should have a ProcedureCall");
+    let builtin = proc_call.builtin.as_ref().expect("builtin should be populated for dbe_output.put_line");
+    assert_eq!(builtin.domain, "DbeOutput");
+}
+
+#[test]
+fn test_pl_procedure_call_builtin_none_for_unknown_procedure() {
+    let block = parse_do_block("DO $$ BEGIN my_unknown_proc(); END $$");
+    let proc_call = block
+        .body
+        .iter()
+        .find_map(|s| match s {
+            PlStatement::ProcedureCall(spanned) => Some(&spanned.node),
+            _ => None,
+        })
+        .expect("should have a ProcedureCall");
+    assert!(proc_call.builtin.is_none(), "unknown procedure should have builtin == None");
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -14349,3 +14349,37 @@ fn test_pl_procedure_call_builtin_none_for_unknown_procedure() {
         .expect("should have a ProcedureCall");
     assert!(proc_call.builtin.is_none(), "unknown procedure should have builtin == None");
 }
+
+#[test]
+fn test_call_statement_populates_builtin_for_known_function() {
+    let stmt = parse_one("CALL abs(-1)");
+    match stmt {
+        Statement::Call(call) => {
+            let builtin = call.node.builtin.as_ref().expect("builtin should be populated for CALL abs(...)");
+            assert_eq!(builtin.domain, "Math");
+        }
+        other => panic!("expected Statement::Call, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_call_statement_builtin_none_for_unknown_procedure() {
+    let stmt = parse_one("CALL my_unknown_proc(42)");
+    match stmt {
+        Statement::Call(call) => {
+            assert!(call.node.builtin.is_none(), "unknown procedure CALL should have builtin == None");
+        }
+        other => panic!("expected Statement::Call, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_call_statement_empty_args_does_not_panic() {
+    let stmt = parse_one("CALL pg_sleep()");
+    match stmt {
+        Statement::Call(call) => {
+            let _ = &call.node.builtin;
+        }
+        other => panic!("expected Statement::Call, got {:?}", other),
+    }
+}

--- a/src/parser/utility/copy_explain.rs
+++ b/src/parser/utility/copy_explain.rs
@@ -507,11 +507,12 @@ impl Parser {
 
     pub(crate) fn parse_call(&mut self) -> Result<CallFuncStatement, ParserError> {
         let func_name = self.parse_object_name()?;
+        let builtin = crate::parser::function_registry::resolve_builtin_meta(&func_name);
         self.expect_token(&Token::LParen)?;
 
         if self.match_token(&Token::RParen) {
             self.advance();
-            return Ok(CallFuncStatement { func_name, args: vec![] });
+            return Ok(CallFuncStatement { func_name, args: vec![], builtin });
         }
 
         let mut args = Vec::new();
@@ -551,7 +552,7 @@ impl Parser {
                 break;
             }
         }
-        Ok(CallFuncStatement { func_name, args })
+        Ok(CallFuncStatement { func_name, args, builtin })
     }
 
     fn is_call_named_arg(&self) -> bool {


### PR DESCRIPTION
## Summary

将表达式路径上 `Expr::FunctionCall.builtin` 的元数据填充机制，对称扩展到语句路径的 `PlProcedureCall` 和 `CallFuncStatement`，让下游 visitor 入口即可区分内置包函数调用与用户定义过程调用。

Closes #253

## Changes

### 方案 B：抽取公共 helper + 5 个构造点复用

| Commit | Description |
|--------|-------------|
| `d9b261c` | 新增 `function_registry::resolve_builtin_meta(&ObjectName)` helper + 4 单元测试 |
| `0bd1155` | `PlProcedureCall` 加 `builtin` 字段，3 个 parser 构造点填充，2 个测试构造点更新，2 个集成测试 |
| `e720d66` | `CallFuncStatement` 加 `builtin` 字段，2 个 parser 构造点填充，3 个集成测试 |
| `19b81a2` | 重构 `expr.rs:validate_func` 使用新 helper（纯 DRY，行为不变） |
| `6640c56` | 修复 visitor_tests 缩进 |

### 变更范围

- **9 files changed, +116/-8**
- 2 个 AST struct 新增 `builtin: Option<BuiltinFuncMeta>` 字段（带 `#[serde(default, skip_serializing_if = "Option::is_none")]`）
- 1 个 public helper 函数（`resolve_builtin_meta`）
- 5 个生产构造点调用 helper 填充元数据
- 2 个测试构造点使用 `None`
- 9 个新增测试（4 helper + 2 PlProcedureCall + 3 CallFuncStatement）

### JSON 向后兼容

新字段带 `#[serde(default)]`，旧 JSON 反序列化不受影响；`skip_serializing_if = "Option::is_none"` 确保序列化输出无 `null` 噪音。

## Verification

```
✅ cargo fmt --all -- --check          (EXIT 0)
✅ cargo clippy --all-features -D warnings  (EXIT 0)
✅ cargo test --all-features            (1990 passed, 0 failed)
```

### Smoke test

```bash
$ echo "DO \$\$ BEGIN dbe_output.put_line('hello'); END \$\$" | ogsql parse -j | grep builtin
"builtin": { "category": "Scalar", "domain": "DbeOutput" }

$ echo "CALL abs(-1)" | ogsql parse -j | grep builtin
"builtin": { "category": "Scalar", "domain": "Math" }
```

## Downstream Impact

codeweb 可移除 `noise_rule` 中事后 `lookup_builtin_meta` 补查逻辑，改为在 `visit_procedure_call` / `visit_call` 入口直接读 `builtin` 字段——与表达式路径完全一致。