### PR TITLE
feat(ast): 为 SpecialFunction 附加 builtin 元数据，逗号语法 substr 归入 FunctionCall (#255 #256)

### DIFF
--- a/docs/ast-json-reference.md
+++ b/docs/ast-json-reference.md
@@ -141,7 +141,7 @@ Full list of all variants: `Select`, `Insert`, `InsertAll`, `InsertFirst`, `Upda
 | `RowConstructor` | `(1, 'a', TRUE)` | `{ "RowConstructor": [...] }` |
 | `Prior` | `PRIOR x` (hierarchical query) | `{ "Prior": {...} }` |
 | `Default` | `DEFAULT` | `"Default"` |
-| `SpecialFunction` | `EXTRACT(YEAR FROM d)`, `SUBSTRING(s FROM 1 FOR 3)`, `SUBSTR('hello', 1, 3)` | `{ "SpecialFunction": { "name": "extract", "args": [...] } }` |
+| `SpecialFunction` | `EXTRACT(YEAR FROM d)`, `SUBSTRING(s FROM 1 FOR 3)` | `{ "SpecialFunction": { "name": "extract", "args": [...] } }` |
 | `CurrentOf` | `WHERE CURRENT OF cursor` | `{ "CurrentOf": { "cursor_name": "c1" } }` |
 | `XmlElement` | `XMLELEMENT(...)` | `{ "XmlElement": { "name": ..., "content": [...] } }` |
 | `XmlConcat` | `XMLCONCAT(...)` | `{ "XmlConcat": [...] }` |
@@ -156,9 +156,10 @@ Full list of all variants: `Select`, `Insert`, `InsertAll`, `InsertFirst`, `Upda
 ## FunctionCall
 
 The most complex and important expression node. Covers all user-defined functions and most
-built-in functions. For functions with keyword-separated syntax (e.g. `EXTRACT`, `SUBSTRING`,
-`SUBSTR`), see [SpecialFunction](#specialfunction) — JSON consumers must handle **both**
-node types when looking for "all function calls".
+built-in functions, including comma-syntax `SUBSTR(s, p, l)` / `SUBSTRING(s, p, l)`. Only
+keyword-separated syntax (e.g. `EXTRACT`, `SUBSTRING(s FROM ...)`) uses
+[SpecialFunction](#specialfunction) — JSON consumers must handle **both** node types when
+looking for "all function calls".
 
 ```json
 {
@@ -225,16 +226,16 @@ SQL functions that use keyword-separated syntax instead of commas, or have multi
 forms that must be unified into a single AST type. When walking the AST for "all function
 calls", you **must** handle both `FunctionCall` and `SpecialFunction`.
 
-**Why `substr` is SpecialFunction:** `substr` is an alias of `substring`, which supports
-both keyword syntax (`SUBSTRING(str FROM 1 FOR 3)`) and comma syntax (`SUBSTR(str, 1, 3)`).
-To avoid splitting one semantic function across two different AST node types, `substr` is
-always parsed as `SpecialFunction`, even when written with pure comma-separated arguments.
+**Comma vs keyword syntax for SUBSTRING/SUBSTR:** `SUBSTR(s, p, l)` and `SUBSTRING(s, p, l)`
+with comma-separated arguments produce `FunctionCall` (carrying `builtin` metadata). Only the
+keyword form `SUBSTRING(s FROM p [FOR l])` produces `SpecialFunction`. This mirrors how `TRIM`
+and `CONVERT` already split on syntax. See issues #255 / #256 for rationale.
 
 #### Complete List
 
 | Function | `name` value | SQL Syntax | Notes |
 |----------|-------------|------------|-------|
-| `SUBSTRING` / `SUBSTR` | `"substring"` or `"substr"` | `SUBSTRING(str FROM pos [FOR len])` or `SUBSTR(str, pos [, len])` | Both keyword and comma forms → SpecialFunction |
+| `SUBSTRING` / `SUBSTR` | `"substring"` or `"substr"` | `SUBSTRING(str FROM pos [FOR len])` (keyword form) | Keyword form → SpecialFunction; comma form `SUBSTR(str, pos [, len])` → `FunctionCall` |
 | `OVERLAY` | `"overlay"` | `OVERLAY(str PLACING repl FROM pos [FOR len])` | |
 | `POSITION` | `"position"` | `POSITION(substr IN str)` | |
 | `EXTRACT` | `"extract"` | `EXTRACT(field FROM expr)` | First arg is the field name as `ColumnRef` |
@@ -246,7 +247,8 @@ always parsed as `SpecialFunction`, even when written with pure comma-separated 
 | `LOCALTIME` | `"localtime"` | `LOCALTIME` or `LOCALTIME(precision)` | Without `()` → `ColumnRef`, not SpecialFunction |
 | `LOCALTIMESTAMP` | `"localtimestamp"` | `LOCALTIMESTAMP` or `LOCALTIMESTAMP(precision)` | Without `()` → `ColumnRef`, not SpecialFunction |
 
-`SpecialFunction` nodes do **not** have `_meta` annotation — they are recognized by the `name` field.
+`SpecialFunction` nodes carry an optional `builtin` field (function-registry metadata,
+serialized only when present). They do **not** carry `over`, `filter`, or `within_group`.
 
 #### Consumer Guidance
 
@@ -379,9 +381,9 @@ Variants: `Union`, `Intersect`, `Except`. Each has `all` (boolean) and `right` (
 ### Identify all function calls
 
 Walk the JSON tree recursively. Any object with a `FunctionCall` **or** `SpecialFunction` key
-contains a function call node. You must handle both — `SpecialFunction` covers functions like
-`SUBSTRING`, `SUBSTR`, `EXTRACT`, `OVERLAY`, `POSITION`, `TRIM` (with `FROM`), `CONVERT` (with
-`USING`), and `INTERVAL`.
+contains a function call node. You must handle both — `SpecialFunction` covers keyword-syntax
+forms like `SUBSTRING(s FROM ...)`, `EXTRACT`, `OVERLAY`, `POSITION`, `TRIM` (with `FROM`),
+`CONVERT` (with `USING`), and `INTERVAL`. Comma-syntax `SUBSTR(s, p, l)` is `FunctionCall`.
 
 - `FunctionCall`: `name` is an array (last element is the function name)
 - `SpecialFunction`: `name` is a string (never schema-qualified)

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1329,15 +1329,15 @@ pub enum Expr {
     /// dedicated parsing logic and a simplified AST representation that only captures
     /// positional arguments (the keywords are implied by position).
     ///
-    /// Additionally, `substr` is treated as an alias of `substring` and always produces
-    /// `SpecialFunction`, even when written with comma syntax (`substr('hello', 1, 3)`).
-    /// This avoids having the same semantic function produce two different AST node types.
+    /// `substr` and `substring` with comma syntax (`substr('hello', 1, 3)`) produce
+    /// [`FunctionCall`] instead of `SpecialFunction`. Keyword syntax
+    /// (`SUBSTRING(str FROM 1 FOR 3)`) produces `SpecialFunction`.
     ///
     /// # Complete list of functions that produce SpecialFunction
     ///
     /// | Function | `name` value | Syntax forms | Notes |
     /// |----------|-------------|--------------|-------|
-    /// | `SUBSTRING` / `SUBSTR` | `"substring"` or `"substr"` | `FROM`/`FOR` keywords **or** commas | `substr` is always SpecialFunction |
+    /// | `SUBSTRING` / `SUBSTR` | `"substring"` or `"substr"` | `FROM`/`FOR` keywords | Comma syntax → `FunctionCall`; keyword syntax → `SpecialFunction` |
     /// | `OVERLAY` | `"overlay"` | `PLACING`/`FROM`/`FOR` keywords | |
     /// | `POSITION` | `"position"` | `IN` keyword | |
     /// | `EXTRACT` | `"extract"` | `field FROM expr` | |
@@ -1357,17 +1357,18 @@ pub enum Expr {
     /// ```rust,ignore
     /// match expr {
     ///     Expr::FunctionCall { name, args, .. } => { /* regular function */ }
-    ///     Expr::SpecialFunction { name, args } => { /* special function */ }
+    ///     Expr::SpecialFunction { name, args, .. } => { /* special function */ }
     ///     _ => {}
     /// }
     /// ```
     ///
-    /// `SpecialFunction` does **not** carry `builtin` metadata, `over`, `filter`,
-    /// or `within_group` clauses. If you need to check whether a function is built-in,
-    /// use the `function_registry` module to look up the name.
+    /// `SpecialFunction` carries `builtin` metadata, populated from `function_registry`.
+    /// It does **not** carry `over`, `filter`, or `within_group` clauses.
     SpecialFunction {
         name: String,
         args: Vec<Expr>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        builtin: Option<BuiltinFuncMeta>,
     },
     /// WHERE CURRENT OF cursor_name — for positioned UPDATE/DELETE
     CurrentOf {

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1337,7 +1337,7 @@ impl SqlFormatter {
                 }
                 result
             }
-            Expr::SpecialFunction { name, args } => {
+            Expr::SpecialFunction { name, args, .. } => {
                 let lower = name.to_lowercase();
                 match lower.as_str() {
                     "overlay" => {

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -1162,6 +1162,15 @@ fn r006_greatest_on_column_not_triggered() {
     assert!(!has_rule(&w, "R006"), "GREATEST is a safe function, should not trigger R006");
 }
 
+#[test]
+fn r006_substr_on_column_now_detected() {
+    // Comma-syntax substr became FunctionCall (#256), so R006 now detects it
+    // (previously invisible because substr produced SpecialFunction).
+    let stmts = parse("SELECT * FROM t WHERE substr(name, 1, 5) = 'abc'");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R006"), "substr(col, ...) should trigger R006 after AST change");
+}
+
 // ── R008: Downgraded to Caution level ──
 
 #[test]

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1034,12 +1034,14 @@ impl Parser {
                             ) {
                                 let unit_name = unit_kw.as_str().to_string();
                                 self.advance();
+                                let builtin = crate::parser::function_registry::lookup_builtin_meta("interval");
                                 return Ok(Expr::SpecialFunction {
                                     name: "interval".to_string(),
                                     args: vec![
                                         Expr::Literal(Literal::String(s)),
                                         Expr::ColumnRef(vec![unit_name.into()]),
                                     ],
+                                    builtin,
                                 });
                             }
                         }
@@ -1072,9 +1074,11 @@ impl Parser {
                             ) {
                                 let unit_name = unit_kw.as_str().to_string();
                                 self.advance();
+                                let builtin = crate::parser::function_registry::lookup_builtin_meta("interval");
                                 return Ok(Expr::SpecialFunction {
                                     name: "interval".to_string(),
                                     args: vec![expr, Expr::ColumnRef(vec![unit_name.into()])],
+                                    builtin,
                                 });
                             }
                         }
@@ -1111,11 +1115,13 @@ impl Parser {
                         self.advance();
                         if self.match_token(&Token::RParen) {
                             self.advance();
-                            return Ok(Expr::SpecialFunction { name, args: vec![] });
+                            let builtin = crate::parser::function_registry::lookup_builtin_meta(&name);
+                            return Ok(Expr::SpecialFunction { name, args: vec![], builtin });
                         }
                         let precision = self.parse_expr()?;
                         self.expect_token(&Token::RParen)?;
-                        return Ok(Expr::SpecialFunction { name, args: vec![precision] });
+                        let builtin = crate::parser::function_registry::lookup_builtin_meta(&name);
+                        return Ok(Expr::SpecialFunction { name, args: vec![precision], builtin });
                     }
                     return Ok(Expr::ColumnRef(vec![name.into()]));
                 }
@@ -1408,9 +1414,8 @@ impl Parser {
         if lower_name == "position" {
             return self.parse_position_function(name);
         }
-        // Both `substring` and `substr` are handled by the same parser.
-        // Even `substr(a, 1, 3)` with pure comma syntax becomes SpecialFunction
-        // to avoid splitting one semantic function across two AST node types.
+        // `substring`/`substr` keyword syntax (FROM/FOR) → SpecialFunction;
+        // comma syntax → FunctionCall. See parse_substring_function and #256.
         if lower_name == "substring" || lower_name == "substr" {
             return self.parse_substring_function(name);
         }
@@ -1624,7 +1629,10 @@ impl Parser {
             self.advance();
             let charset = self.parse_expr()?;
             self.expect_token(&Token::RParen)?;
-            return Ok(Expr::SpecialFunction { name: name.join("."), args: vec![first, charset] });
+            let builtin = crate::parser::function_registry::lookup_builtin_meta(
+                &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+            );
+            return Ok(Expr::SpecialFunction { name: name.join("."), args: vec![first, charset], builtin });
         }
         let mut args = vec![first];
         while self.match_token(&Token::Comma) {
@@ -1724,7 +1732,10 @@ impl Parser {
         if let Some(a) = arg4 {
             args.push(a);
         }
-        Ok(Expr::SpecialFunction { name: name.join("."), args })
+        let builtin = crate::parser::function_registry::lookup_builtin_meta(
+            &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+        );
+        Ok(Expr::SpecialFunction { name: name.join("."), args, builtin })
     }
 
     fn parse_position_function(&mut self, name: ObjectName) -> Result<Expr, ParserError> {
@@ -1746,29 +1757,65 @@ impl Parser {
             arg2 = Expr::TypeCast { expr: Box::new(arg2), type_name, default: None, format: None };
         }
         self.expect_token(&Token::RParen)?;
-        Ok(Expr::SpecialFunction { name: name.join("."), args: vec![arg1, arg2] })
+        let builtin = crate::parser::function_registry::lookup_builtin_meta(
+            &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+        );
+        Ok(Expr::SpecialFunction { name: name.join("."), args: vec![arg1, arg2], builtin })
     }
 
     fn parse_substring_function(&mut self, name: ObjectName) -> Result<Expr, ParserError> {
         let arg1 = self.parse_expr()?;
-        let mut args = vec![arg1];
-        if self.try_consume_keyword(Keyword::FROM) {
-            args.push(self.parse_expr()?);
+
+        // Keyword-separated syntax (FROM / FOR) → SpecialFunction.
+        if self.match_keyword(Keyword::FROM) {
+            self.advance();
+            let mut args = vec![arg1, self.parse_expr()?];
             if self.try_consume_keyword(Keyword::FOR) {
                 args.push(self.parse_expr()?);
             }
-        } else if self.try_consume_keyword(Keyword::FOR) {
-            args.push(self.parse_expr()?);
-        } else if self.match_token(&Token::Comma) {
+            self.expect_token(&Token::RParen)?;
+            let builtin = crate::parser::function_registry::lookup_builtin_meta(
+                &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+            );
+            return Ok(Expr::SpecialFunction { name: name.join("."), args, builtin });
+        }
+        if self.match_keyword(Keyword::FOR) {
+            self.advance();
+            let args = vec![arg1, self.parse_expr()?];
+            self.expect_token(&Token::RParen)?;
+            let builtin = crate::parser::function_registry::lookup_builtin_meta(
+                &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+            );
+            return Ok(Expr::SpecialFunction { name: name.join("."), args, builtin });
+        }
+
+        // Comma syntax (or bare single-arg form) → regular FunctionCall.
+        // Mirrors parse_convert_function's comma path so that comma-syntax substr/substring
+        // obtains builtin metadata, validate_func arg checking, and FILTER/OVER/WITHIN GROUP
+        // support — consistent with how TRIM and CONVERT already split on syntax.
+        let mut args = vec![arg1];
+        while self.match_token(&Token::Comma) {
             self.advance();
             args.push(self.parse_expr()?);
-            if self.match_token(&Token::Comma) {
-                self.advance();
-                args.push(self.parse_expr()?);
-            }
         }
         self.expect_token(&Token::RParen)?;
-        Ok(Expr::SpecialFunction { name: name.join("."), args })
+        let filter = self.try_parse_filter()?;
+        let within_group = self.try_parse_within_group()?;
+        let over = self.try_parse_over_clause()?;
+        let builtin = self.validate_func(&name, args.len(), false, over.is_some(), false);
+        Ok(Expr::FunctionCall {
+            name,
+            args,
+            distinct: false,
+            over,
+            filter,
+            within_group,
+            separator: None,
+            default: None,
+            conversion_format: None,
+            agg_from: None,
+            builtin,
+        })
     }
 
     fn parse_extract_function(&mut self, name: ObjectName) -> Result<Expr, ParserError> {
@@ -1776,7 +1823,14 @@ impl Parser {
         self.expect_keyword(Keyword::FROM)?;
         let expr = self.parse_expr()?;
         self.expect_token(&Token::RParen)?;
-        Ok(Expr::SpecialFunction { name: name.join("."), args: vec![Expr::ColumnRef(vec![field.into()]), expr] })
+        let builtin = crate::parser::function_registry::lookup_builtin_meta(
+            &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+        );
+        Ok(Expr::SpecialFunction {
+            name: name.join("."),
+            args: vec![Expr::ColumnRef(vec![field.into()]), expr],
+            builtin,
+        })
     }
 
     fn parse_trim_function(&mut self, name: ObjectName) -> Result<Expr, ParserError> {
@@ -1795,9 +1849,13 @@ impl Parser {
                 self.advance();
                 let source = self.parse_expr()?;
                 self.expect_token(&Token::RParen)?;
+                let builtin = crate::parser::function_registry::lookup_builtin_meta(
+                    &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+                );
                 Ok(Expr::SpecialFunction {
                     name: name.join("."),
                     args: vec![Expr::ColumnRef(vec![dir.into()]), source],
+                    builtin,
                 })
             } else {
                 // TRIM(direction chars FROM expr)
@@ -1805,9 +1863,13 @@ impl Parser {
                 self.expect_keyword(Keyword::FROM)?;
                 let source = self.parse_expr()?;
                 self.expect_token(&Token::RParen)?;
+                let builtin = crate::parser::function_registry::lookup_builtin_meta(
+                    &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+                );
                 Ok(Expr::SpecialFunction {
                     name: name.join("."),
                     args: vec![Expr::ColumnRef(vec![dir.into()]), chars, source],
+                    builtin,
                 })
             }
         } else {
@@ -1818,7 +1880,10 @@ impl Parser {
                 self.advance();
                 let source = self.parse_expr()?;
                 self.expect_token(&Token::RParen)?;
-                Ok(Expr::SpecialFunction { name: name.join("."), args: vec![first, source] })
+                let builtin = crate::parser::function_registry::lookup_builtin_meta(
+                    &name.last().map(|s| s.to_lowercase()).unwrap_or_default(),
+                );
+                Ok(Expr::SpecialFunction { name: name.join("."), args: vec![first, source], builtin })
             } else {
                 // Regular function call: TRIM(expr [, ...])
                 let mut args = vec![first];

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -9438,7 +9438,7 @@ fn test_trim_both_from_ast() {
     match stmt {
         Statement::Select(s) => match &s.targets[0] {
             SelectTarget::Expr(expr, _) => match expr {
-                Expr::SpecialFunction { name, args } => {
+                Expr::SpecialFunction { name, args, .. } => {
                     assert_eq!(name, "trim");
                     assert_eq!(args.len(), 3, "trim(BOTH 'x' FROM 'xTomxx') should have 3 args: [BOTH, 'x', 'xTomxx']");
                 }
@@ -9456,7 +9456,7 @@ fn test_trim_leading_with_chars_ast() {
     match stmt {
         Statement::Select(s) => match &s.targets[0] {
             SelectTarget::Expr(expr, _) => match expr {
-                Expr::SpecialFunction { name, args } => {
+                Expr::SpecialFunction { name, args, .. } => {
                     assert_eq!(name, "trim");
                     assert_eq!(args.len(), 3);
                 }
@@ -9710,7 +9710,7 @@ fn test_convert_using_ast() {
     match stmt {
         Statement::Select(s) => match &s.targets[0] {
             SelectTarget::Expr(expr, _) => match expr {
-                Expr::SpecialFunction { name, args } => {
+                Expr::SpecialFunction { name, args, .. } => {
                     assert_eq!(name, "convert");
                     assert_eq!(args.len(), 2);
                 }
@@ -9727,6 +9727,50 @@ fn test_convert_normal() {
     let stmt = parse_one("SELECT convert('text', 'UTF8', 'GBK')");
     match stmt {
         Statement::Select(s) => assert_eq!(s.targets.len(), 1),
+        _ => panic!("expected Select, got {:?}", stmt),
+    }
+}
+
+// ========== Issue #255/#256: SUBSTR/SUBSTRING builtin metadata + comma→FunctionCall ==========
+
+#[test]
+fn test_substr_comma_syntax_is_function_call_with_builtin() {
+    let stmt = parse_one("SELECT substr('hello', 1, 3) FROM t");
+    match stmt {
+        Statement::Select(s) => match &s.targets[0] {
+            SelectTarget::Expr(expr, _) => match expr {
+                Expr::FunctionCall { name, args, builtin, .. } => {
+                    assert_eq!(name.last().map(|i| i.value.as_str()), Some("substr"));
+                    assert_eq!(args.len(), 3);
+                    let meta = builtin.as_ref().expect("comma-syntax substr must carry builtin metadata");
+                    assert_eq!(meta.category, "Scalar");
+                    assert_eq!(meta.domain, "String");
+                }
+                other => panic!("comma-syntax substr must be FunctionCall, got {:?}", other),
+            },
+            _ => panic!("expected Expr target"),
+        },
+        _ => panic!("expected Select, got {:?}", stmt),
+    }
+}
+
+#[test]
+fn test_substring_keyword_syntax_is_special_function_with_builtin() {
+    let stmt = parse_one("SELECT substring('hello' FROM 1 FOR 3) FROM t");
+    match stmt {
+        Statement::Select(s) => match &s.targets[0] {
+            SelectTarget::Expr(expr, _) => match expr {
+                Expr::SpecialFunction { name, args, builtin } => {
+                    assert_eq!(name, "substring");
+                    assert_eq!(args.len(), 3);
+                    let meta = builtin.as_ref().expect("keyword-syntax substring must carry builtin metadata");
+                    assert_eq!(meta.category, "Scalar");
+                    assert_eq!(meta.domain, "String");
+                }
+                other => panic!("keyword-syntax substring must be SpecialFunction, got {:?}", other),
+            },
+            _ => panic!("expected Expr target"),
+        },
         _ => panic!("expected Select, got {:?}", stmt),
     }
 }


### PR DESCRIPTION
## 概要

继 #253（语句路径 builtin 元数据）之后，补齐表达式路径的最后一类节点 `Expr::SpecialFunction`。实现 #255 + 采纳 #256 选项 **A+B**。

## 改动

### B — `Expr::SpecialFunction` 携带 `builtin` 元数据
- 新增 `builtin: Option<BuiltinFuncMeta>` 字段（`#[serde(default, skip_serializing_if = "Option::is_none")]`，JSON 向后兼容）
- 全部 12 个构造点填充 function_registry 元数据：INTERVAL×2 / CURRENT_TIME×2 / CONVERT-USING / OVERLAY / POSITION / SUBSTRING-keyword / EXTRACT / TRIM×3
- 4 处破坏性 destructure 编译修复（formatter + tests×3）

### A — 逗号语法 `SUBSTR(s,p,l)` 回归 `FunctionCall`
- `parse_substring_function` 重写：`FROM`/`FOR` 关键字 → `SpecialFunction`（带 builtin）；逗号 → `FunctionCall`（含 `validate_func` 参数校验 + FILTER/OVER/WITHIN GROUP）
- 镜像既有 `parse_convert_function` / `parse_trim_function` 的关键字 vs 逗号分流先例
- **R006 现可检测 `WHERE substr(col,…)`**——此前因 SpecialFunction 不可见而静默遗漏（这正是 R006 的设计目的）

## 行为变更（请知悉，均为修正性）

| 变更 | 说明 |
|---|---|
| `SUBSTRING(x)` 单参数现在报 "requires ≥2 args" 警告 | 单参数 SUBSTRING 本就是非法 SQL；validate_func 现按 registry 的 min_args=2 校验 |
| `SUBSTR(a,b,c,d,…)` 4+ 参数现在解析+警告（而非第 4 个逗号硬报错） | 与 convert/trim/所有其他函数一致（validate_func 警告参数数，而非解析器中途硬失败） |
| 格式化器：`SUBSTR('hello', 1, 3)` 往返现在保留逗号形式（此前被改写成 `SUBSTRING(... FROM ... FOR ...)`） | 更忠实于输入；本项目无 golden-file 断言旧的重写输出（1993 测试全绿） |

## 验证（CI 合约）

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅（1993 passed, 0 failed）

## 新增测试
- `test_substr_comma_syntax_is_function_call_with_builtin` — 逗号→FunctionCall + builtin
- `test_substring_keyword_syntax_is_special_function_with_builtin` — 关键字→SpecialFunction + builtin
- `r006_substr_on_column_now_detected` — 锁定 R006 新行为

## 设计决策
采纳 #256 选项 A（逗号语法不再分流到 SpecialFunction）+ B（给 SpecialFunction 加 builtin 字段）。理由：项目已有 TRIM/CONVERT 按语法分流的先例；逗号语法 SUBSTR 结构上与普通函数调用无异，强行分流是“为避免分裂而自我施加的分裂”。A+B 合起来让 builtin 元数据在所有 AST 节点类型上完整，下游（codeweb）不再需要为 SpecialFunction 单独补查。

Closes #255, #256