### PR TITLE
fix: resolve_builtin_meta 末段回退将用户过程误判为内置函数 (#258)

### DIFF
--- a/src/parser/function_registry.rs
+++ b/src/parser/function_registry.rs
@@ -2,6 +2,8 @@
 ///
 /// Provides metadata lookup (`lookup_function`) and validation (`validate_function_call`)
 /// for built-in functions. Core layer is compile-time constant; extension layer TBD.
+use std::sync::OnceLock;
+
 use crate::parser::ParserError;
 use crate::token::SourceLocation;
 
@@ -1514,7 +1516,30 @@ pub fn lookup_builtin_meta(name: &str) -> Option<crate::ast::BuiltinFuncMeta> {
     })
 }
 
-/// Two-phase lookup: exact full-qualified name, then fallback to last segment.
+/// System schemas where built-in functions actually reside (always trusted
+/// for last-segment fallback). Derived from openGauss system catalog layout.
+const SYSTEM_SCHEMAS: &[&str] = &["pg_catalog", "sys"];
+
+static SYSTEM_PREFIXES: OnceLock<Vec<&'static str>> = OnceLock::new();
+
+fn system_prefixes() -> &'static [&'static str] {
+    SYSTEM_PREFIXES.get_or_init(|| {
+        let mut v: Vec<&'static str> =
+            FUNCTIONS.iter().filter_map(|m| m.name.split_once('.').map(|(p, _)| p)).collect();
+        v.extend_from_slice(SYSTEM_SCHEMAS);
+        v.sort_unstable();
+        v.dedup();
+        v
+    })
+}
+
+fn is_known_system_prefix(prefix: &str) -> bool {
+    system_prefixes().binary_search(&prefix).is_ok()
+}
+
+/// Two-phase lookup: exact full-qualified name, then fallback to last segment
+/// only if the first segment is a known system package/schema (e.g. `pg_catalog`,
+/// `dbe_output`, `dbms_lob`). User-defined schemas never trigger the fallback.
 pub fn lookup_function_qualified(full_name: &str) -> Option<&'static FuncMeta> {
     let lower = full_name.to_ascii_lowercase();
     let idx = FUNCTIONS.partition_point(|m| m.name < lower.as_str());
@@ -1523,6 +1548,10 @@ pub fn lookup_function_qualified(full_name: &str) -> Option<&'static FuncMeta> {
     }
     let last_seg = lower.split('.').next_back().unwrap_or(&lower);
     if last_seg.len() == lower.len() {
+        return None;
+    }
+    let first_seg = lower.split('.').next().unwrap_or(&lower);
+    if !is_known_system_prefix(first_seg) {
         return None;
     }
     let idx2 = FUNCTIONS.partition_point(|m| m.name < last_seg);
@@ -1597,8 +1626,7 @@ pub fn lookup_builtin_meta_qualified(full_name: &str) -> Option<crate::ast::Buil
 /// plain (`abs`) and dotted package names (`dbe_output.put_line`).
 pub fn resolve_builtin_meta(name: &crate::ast::ObjectName) -> Option<crate::ast::BuiltinFuncMeta> {
     let full = name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
-    let last = full.split('.').next_back().unwrap_or(&full).to_string();
-    lookup_builtin_meta_qualified(&full).or_else(|| lookup_builtin_meta(&last))
+    lookup_builtin_meta_qualified(&full)
 }
 
 /// Validate a function call and return a list of warnings (if any).
@@ -2489,7 +2517,7 @@ mod tests {
 
     #[test]
     fn test_qualified_lookup_fallback_to_last_segment() {
-        let meta = super::lookup_function_qualified("some_schema.upper");
+        let meta = super::lookup_function_qualified("pg_catalog.upper");
         assert!(meta.is_some());
         let m = meta.unwrap();
         assert_eq!(m.domain, FuncDomain::String);
@@ -3165,8 +3193,63 @@ mod tests {
 
     #[test]
     fn test_resolve_builtin_meta_schema_qualified_fallback() {
-        let name: crate::ast::ObjectName = vec!["myschema".into(), "abs".into()];
+        let name: crate::ast::ObjectName = vec!["pg_catalog".into(), "abs".into()];
         let meta = super::resolve_builtin_meta(&name).unwrap();
         assert_eq!(meta.domain, "Math");
+    }
+
+    // ── Issue #258: user packages must not be misidentified as builtin ──
+
+    #[test]
+    fn test_issue_258_pack_log_log_not_builtin() {
+        assert!(super::lookup_function_qualified("pack_log.log").is_none());
+        let name: crate::ast::ObjectName = vec!["pack_log".into(), "log".into()];
+        assert!(super::resolve_builtin_meta(&name).is_none());
+    }
+
+    #[test]
+    fn test_issue_258_bigfund_pack_log_count_not_builtin() {
+        assert!(super::lookup_function_qualified("bigfund.pack_log.count").is_none());
+        let name: crate::ast::ObjectName = vec!["bigfund".into(), "pack_log".into(), "count".into()];
+        assert!(super::resolve_builtin_meta(&name).is_none());
+    }
+
+    #[test]
+    fn test_issue_258_pckg_ctp_lg_public_log_not_builtin() {
+        assert!(super::lookup_function_qualified("pckg_ctp_lg_public.log").is_none());
+    }
+
+    #[test]
+    fn test_issue_258_my_utils_substr_not_builtin() {
+        assert!(super::lookup_function_qualified("my_utils.substr").is_none());
+        let name: crate::ast::ObjectName = vec!["my_utils".into(), "substr".into()];
+        assert!(super::resolve_builtin_meta(&name).is_none());
+    }
+
+    #[test]
+    fn test_issue_258_user_schema_upper_not_builtin() {
+        assert!(super::lookup_function_qualified("some_schema.upper").is_none());
+        assert!(super::lookup_function_qualified("myschema.abs").is_none());
+    }
+
+    #[test]
+    fn test_issue_258_system_prefix_still_resolves() {
+        let meta = super::lookup_function_qualified("pg_catalog.upper");
+        assert!(meta.is_some());
+        assert_eq!(meta.unwrap().domain, FuncDomain::String);
+
+        let meta = super::lookup_function_qualified("sys.abs");
+        assert!(meta.is_some());
+        assert_eq!(meta.unwrap().domain, FuncDomain::Math);
+    }
+
+    #[test]
+    fn test_issue_258_oracle_compat_package_still_resolves() {
+        let meta = super::lookup_function_qualified("dbe_output.put_line");
+        assert!(meta.is_some());
+        assert_eq!(meta.unwrap().domain, FuncDomain::DbeOutput);
+
+        let meta = super::lookup_function_qualified("dbms_output.put_line");
+        assert!(meta.is_some());
     }
 }


### PR DESCRIPTION
## 问题

带包名 / Schema 前缀的用户自定义过程/函数，只要其**最后一段名称**与某个已注册内置函数重名，就会被 `resolve_builtin_meta` 误判为内置函数，导致 builtin 字段被错误置为 `Some(...)`。

| 调用 | 修复前 | 修复后 |
|---|---|---|
| `pack_log.log(1)` | `Some(Scalar/Math)` | `None` |
| `bigfund.pack_log.count(*)` | `Some(Aggregate)` | `None` |
| `pckg_ctp_lg_public.log(1)` | `Some(...)` | `None` |
| `my_utils.substr(s)` | `Some(...)` | `None` |
| `dbms_output.put_line('x')` | `Some(...)` | `Some(...)` ✅ 保持 |

## 根因

`lookup_function_qualified` 的 Phase 2「末段回退」无条件剥掉 schema 前缀：
`pack_log.log` → `log` → 命中内置 LOG。Oracle 兼容包（`dbe_output.put_line` 等）已有全限定名注册，本不需 Phase 2 回退。

## 修复

新增**系统包前缀白名单**，从已注册点号函数名自动推导 + 显式添加 `pg_catalog`/`sys`：

```rust
fn is_known_system_prefix(prefix: &str) -> bool {
    system_prefixes().binary_search(&prefix).is_ok()
}
```

Phase 2 仅在第一段在白名单内才触发末段回退，用户前缀直接返回 `None`。

## 验证

- 新增 7 项回归测试覆盖所有受害场景
- 全部 1979 个测试通过
- Clippy `-D warnings` 零警告
- cargo fmt 格式检查通过