### PR TITLE
fix: prevent slash from being treated as statement terminator in expressions

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -456,6 +456,8 @@ impl Parser {
                 Token::Slash if depth <= 0 && begin_depth <= 0 => {
                     if is_package && !seen_outer_end {
                         // Slash inside package — not a terminator
+                    } else if Self::looks_like_division_operator(&self.tokens, i) {
+                        // Slash between expression tokens — division operator, not terminator
                     } else {
                         return i;
                     }
@@ -470,6 +472,67 @@ impl Parser {
         }
         self.tokens.len().saturating_sub(1)
     }
+
+/// Heuristic: is the Slash at position `i` a division operator (not a statement terminator)?
+///
+/// A Slash is likely a division operator when the token before it can end an expression
+/// (e.g. identifier, number, `)`) and the token after it can start an expression
+/// (e.g. identifier, number, `(`, unary `+`/`-`).
+fn looks_like_division_operator(tokens: &[TokenWithSpan], i: usize) -> bool {
+    if i == 0 || i + 1 >= tokens.len() {
+        return false;
+    }
+    Self::is_expr_end_token(&tokens[i - 1].token) && Self::is_expr_start_token(&tokens[i + 1].token)
+}
+
+fn is_expr_end_token(tok: &Token) -> bool {
+    matches!(
+        tok,
+        Token::Ident(_)
+            | Token::QuotedIdent(_)
+            | Token::Integer(_)
+            | Token::Float(_)
+            | Token::StringLiteral(_)
+            | Token::BitString(_)
+            | Token::HexString(_)
+            | Token::DollarString { .. }
+            | Token::NationalString(_)
+            | Token::EscapeString(_)
+            | Token::RParen
+            | Token::RBracket
+            | Token::Param(_)
+            | Token::JdbcParam
+            | Token::SetIdent(_)
+    )
+}
+
+fn is_expr_start_token(tok: &Token) -> bool {
+    matches!(
+        tok,
+        Token::Ident(_)
+            | Token::QuotedIdent(_)
+            | Token::Integer(_)
+            | Token::Float(_)
+            | Token::StringLiteral(_)
+            | Token::BitString(_)
+            | Token::HexString(_)
+            | Token::DollarString { .. }
+            | Token::NationalString(_)
+            | Token::EscapeString(_)
+            | Token::LParen
+            | Token::Plus
+            | Token::Minus
+            | Token::Param(_)
+            | Token::JdbcParam
+            | Token::SetIdent(_)
+            | Token::Keyword(Keyword::TRUE_P)
+            | Token::Keyword(Keyword::FALSE_P)
+            | Token::Keyword(Keyword::NULL_P)
+            | Token::Keyword(Keyword::CASE)
+            | Token::Keyword(Keyword::EXISTS)
+            | Token::Keyword(Keyword::NOT)
+    )
+}
 
     fn is_separator_line(&self) -> bool {
         let mut count = 0;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,164 @@
+//! Shared helpers for regression test files.
+//!
+//! Each `tests/regression_{module}.rs` imports this module:
+//! ```rust
+//! mod common;
+//! use common::{load_issue, RegressFixture};
+//! ```
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Parsed regression fixture.
+pub struct RegressFixture {
+    pub id: String,
+    pub description: String,
+    pub expect: String,
+    pub content: String,
+    pub file_type: FileType,
+}
+
+pub enum FileType {
+    Sql,
+    Xml,
+    Java,
+}
+
+/// Load all fixture files matching `{typ}_{id}_{module}.*` from `tests/regress/`.
+pub fn load_all(typ: &str, id: &str, module: &str) -> Vec<RegressFixture> {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("regress");
+    let prefix = format!("{}_{}_{}", typ, id, module);
+
+    let mut results = Vec::new();
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return results,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let fname = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        if fname != prefix {
+            continue;
+        }
+
+        let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+        let file_type = match ext {
+            "sql" => FileType::Sql,
+            "xml" => FileType::Xml,
+            "java" => FileType::Java,
+            _ => continue,
+        };
+
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let (meta, content) = parse_metadata(&raw, &file_type);
+        results.push(RegressFixture {
+            id: meta.get("Issue").cloned().unwrap_or_else(|| id.to_string()),
+            description: meta.get("Description").cloned().unwrap_or_default(),
+            expect: meta.get("Expect").cloned().unwrap_or_default(),
+            content,
+            file_type,
+        });
+    }
+
+    results
+}
+
+/// Load fixtures for an issue.
+pub fn load_issue(id: u32, module: &str) -> Vec<RegressFixture> {
+    load_all("issue", &id.to_string(), module)
+}
+
+/// Load fixtures for a named feature or bug (when no issue number exists yet).
+pub fn load_named(name: &str, module: &str) -> Vec<RegressFixture> {
+    load_all("feat", name, module)
+}
+
+/// Parse metadata comments from the beginning of file content.
+///
+/// Metadata lines are consecutive comment lines at the file start,
+/// matching `Key: Value` format. First non-comment, non-empty line
+/// ends the metadata block and everything after is `content`.
+fn parse_metadata(raw: &str, file_type: &FileType) -> (std::collections::HashMap<String, String>, String) {
+    let comment_prefix = match file_type {
+        FileType::Sql => "-- ",
+        FileType::Java => "// ",
+        FileType::Xml => "<!-- ",
+    };
+    let xml_suffix = match file_type {
+        FileType::Xml => Some(" -->"),
+        _ => None,
+    };
+
+    let mut meta = std::collections::HashMap::new();
+    let mut lines = raw.lines();
+    let mut content_start = 0usize;
+
+    for line in lines.by_ref() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            content_start += line.len() + 1; // +1 for newline
+            continue;
+        }
+
+        let stripped = if trimmed.starts_with(comment_prefix) {
+            let mut s = &trimmed[comment_prefix.len()..];
+            if let Some(suffix) = xml_suffix {
+                if s.ends_with(suffix) {
+                    s = &s[..s.len() - suffix.len()];
+                }
+            }
+            s.trim()
+        } else {
+            // Not a comment → metadata block ends
+            break;
+        };
+
+        if let Some((key, value)) = stripped.split_once(':') {
+            meta.insert(key.trim().to_string(), value.trim().to_string());
+        }
+        content_start += line.len() + 1;
+    }
+
+    let content = if content_start < raw.len() {
+        raw[content_start..].to_string()
+    } else {
+        String::new()
+    };
+
+    (meta, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sql_metadata() {
+        let raw = "-- Issue: #246\n-- Description: test\n-- Expect: ok\n\nSELECT 1;\n";
+        let (meta, content) = parse_metadata(raw, &FileType::Sql);
+        assert_eq!(meta.get("Issue").unwrap(), "#246");
+        assert_eq!(meta.get("Description").unwrap(), "test");
+        assert_eq!(content.trim(), "SELECT 1;");
+    }
+
+    #[test]
+    fn test_parse_xml_metadata() {
+        let raw = "<!-- Issue: #300 -->\n<!-- Description: test -->\n\n<root/>\n";
+        let (meta, content) = parse_metadata(raw, &FileType::Xml);
+        assert_eq!(meta.get("Issue").unwrap(), "#300");
+        assert_eq!(content.trim(), "<root/>");
+    }
+
+    #[test]
+    fn test_parse_java_metadata() {
+        let raw = "// Issue: #301\n// Description: test\n\npublic class T {}\n";
+        let (meta, content) = parse_metadata(raw, &FileType::Java);
+        assert_eq!(meta.get("Issue").unwrap(), "#301");
+        assert!(content.contains("public class T"));
+    }
+}

--- a/tests/regress/feat_slash_division_complex_parser.sql
+++ b/tests/regress/feat_slash_division_complex_parser.sql
@@ -1,0 +1,23 @@
+-- Issue: slash-division-operator
+-- Description: / is treated as terminator in complex expression contexts
+-- Expect: all statements parse without error
+
+SELECT * FROM tab WHERE a / 1000 > 1;
+
+SELECT * FROM (SELECT a / 1000 AS r FROM tab) sub WHERE sub.r > 1;
+
+WITH cte AS (SELECT a / 1000 AS r FROM tab) SELECT * FROM cte;
+
+SELECT a / 1000, COUNT(*) FROM tab GROUP BY a / 1000 HAVING COUNT(*) / 1000 > 1;
+
+SELECT * FROM tab ORDER BY a / 1000;
+
+SELECT CASE WHEN a / 1000 > 1 THEN 'big' ELSE 'small' END FROM tab;
+
+SELECT COUNT(*) / 100 FROM tab;
+
+SELECT CAST(a AS FLOAT) / 1000 FROM tab;
+
+SELECT a / b / c FROM tab;
+
+SELECT (a + b) * (c / 1000) FROM tab;

--- a/tests/regress/feat_slash_division_ddl_parser.sql
+++ b/tests/regress/feat_slash_division_ddl_parser.sql
@@ -1,0 +1,9 @@
+-- Issue: slash-division-operator
+-- Description: / is treated as terminator in DDL statements (CREATE VIEW, CREATE TABLE AS, etc.)
+-- Expect: all DDL parse without error
+
+CREATE VIEW v AS SELECT a / 1000 FROM tab;
+
+CREATE MATERIALIZED VIEW mv AS SELECT a / 1000 FROM tab;
+
+CREATE TABLE t2 AS SELECT a / 1000 FROM tab;

--- a/tests/regress/feat_slash_division_plpgsql_parser.sql
+++ b/tests/regress/feat_slash_division_plpgsql_parser.sql
@@ -1,0 +1,31 @@
+-- Issue: slash-division-operator
+-- Description: / is treated as terminator in PL/pgSQL blocks
+-- Expect: all PL/pgSQL parse without error
+
+DO $$ DECLARE x INT := 10 / 2; BEGIN RAISE NOTICE '%', x; END $$;
+
+CREATE FUNCTION f_div() RETURNS INT AS $$
+DECLARE
+    result INT;
+BEGIN
+    result := 100 / 3;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE PROCEDURE p_div() AS $$
+DECLARE
+    x INT := a / 1000;
+BEGIN
+    UPDATE tab SET col = col / 2 WHERE id = x;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT a / 1000 AS ratio FROM tab LOOP
+        RAISE NOTICE '%', r.ratio;
+    END LOOP;
+END $$;

--- a/tests/regress/feat_slash_division_select_parser.sql
+++ b/tests/regress/feat_slash_division_select_parser.sql
@@ -1,0 +1,21 @@
+-- Issue: slash-division-operator
+-- Description: / is treated as statement terminator in SELECT list, DDL, subqueries, and PL/pgSQL
+-- Expect: all statements parse without error (no "unexpected token" errors)
+
+SELECT a / 1000 FROM tab;
+
+SELECT a / 1000, b / 200 FROM tab;
+
+SELECT 1 / 2 FROM tab;
+
+SELECT 1.5 / 2.0 FROM tab;
+
+SELECT a / -1000 FROM tab;
+
+SELECT a / (1000 + 1) FROM tab;
+
+SELECT c2 / c1 c FROM tab;
+
+SELECT c2 / c1 AS c FROM tab;
+
+SELECT a / b c FROM tab;

--- a/tests/regression_parser.rs
+++ b/tests/regression_parser.rs
@@ -1,0 +1,73 @@
+mod common;
+use common::load_named;
+use ogsql_parser::Parser;
+
+fn assert_parse_all(sql: &str, label: &str) {
+    let (infos, errors) = Parser::parse_sql(sql);
+    let empty_count = infos.iter().filter(|s| matches!(s.statement, ogsql_parser::Statement::Empty)).count();
+    assert!(
+        errors.is_empty() && empty_count == 0,
+        "回归守护: [{label}] 解析失败\n  errors: {errors:?}\n  empty statements: {empty_count}\n  SQL: {sql}"
+    );
+}
+
+#[test]
+fn slash_division_in_select() {
+    let fixtures = load_named("slash_division_select", "parser");
+    assert!(!fixtures.is_empty(), "回归守护: fixture 文件缺失");
+    for f in &fixtures {
+        for (i, stmt) in f.content.split(';').enumerate() {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            let sql = format!("{};", stmt);
+            assert_parse_all(&sql, &format!("{}/stmt{}", f.id, i));
+        }
+    }
+}
+
+#[test]
+fn slash_division_in_ddl() {
+    let fixtures = load_named("slash_division_ddl", "parser");
+    assert!(!fixtures.is_empty(), "回归守护: fixture 文件缺失");
+    for f in &fixtures {
+        for (i, stmt) in f.content.split(';').enumerate() {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            let sql = format!("{};", stmt);
+            assert_parse_all(&sql, &format!("{}/stmt{}", f.id, i));
+        }
+    }
+}
+
+#[test]
+fn slash_division_in_complex() {
+    let fixtures = load_named("slash_division_complex", "parser");
+    assert!(!fixtures.is_empty(), "回归守护: fixture 文件缺失");
+    for f in &fixtures {
+        for (i, stmt) in f.content.split(';').enumerate() {
+            let stmt = stmt.trim();
+            if stmt.is_empty() {
+                continue;
+            }
+            let sql = format!("{};", stmt);
+            assert_parse_all(&sql, &format!("{}/stmt{}", f.id, i));
+        }
+    }
+}
+
+#[test]
+fn slash_division_in_plpgsql() {
+    let fixtures = load_named("slash_division_plpgsql", "parser");
+    assert!(!fixtures.is_empty(), "回归守护: fixture 文件缺失");
+    for f in &fixtures {
+        // PL/pgSQL blocks use $$ quoting — split by empty lines between blocks
+        let blocks: Vec<&str> = f.content.split("\n\n").filter(|b| !b.trim().is_empty()).collect();
+        for (i, block) in blocks.iter().enumerate() {
+            assert_parse_all(block, &format!("{}/plblock{}", f.id, i));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The `/` token in `find_statement_end_pos()` was unconditionally treated as a PL/SQL statement terminator (like `END; /`), causing valid division expressions to fail parsing.

## Root Cause

In `src/parser/mod.rs`, `find_statement_end_pos()` line 456 treats `Token::Slash` at depth 0 as a statement terminator without checking whether it's actually a division operator.

## Fix

Add `looks_like_division_operator()` heuristic: when encountering a `Slash` token outside parens/PL blocks, check if the token before it can end an expression (ident, number, `)`, etc.) AND the token after it can start an expression (ident, number, `(`, unary `+`/`-`, etc.). If both sides look like operands, skip the terminator treatment — it's a division operator.

## Test Cases (26 scenarios)

- **SELECT**: basic division, aliased (c2/c1 c), AS alias, expressions, unary minus
- **DDL**: CREATE VIEW, MATERIALIZED VIEW, TABLE AS with division
- **Complex**: WHERE, subquery, CTE, GROUP BY/HAVING, ORDER BY, CASE, CAST, chained, mixed operators
- **PL/pgSQL**: anonymous blocks, FUNCTION, PROCEDURE, FOR loop

```
cargo test --all-features: 1899 passed, 0 failed
```

## Changes

| File | Description |
|------|-------------|
| `src/parser/mod.rs` | Fix: add division operator heuristic to `find_statement_end_pos()` |
| `tests/common/mod.rs` | New: regression test fixture infrastructure |
| `tests/regression_parser.rs` | New: parser regression test entry |
| `tests/regress/*.sql` | New: 4 fixture files covering 26 scenarios |