### PR TITLE
fix(analyzer): match package spec/body by last name component; warn on schema mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ogsql-parser"
-version = "0.8.14"
+version = "0.8.15"
 edition = "2021"
 rust-version = "1.70"
 description = "A SQL parser for openGauss/GaussDB written in Rust"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1082,6 +1082,8 @@ pub enum PackageConsistencyErrorKind {
     DefaultMismatch { param_name: String, spec_default: Option<String>, body_default: Option<String> },
     /// A parameter has a different data type in spec vs body
     TypeMismatch { param_name: String, spec_type: String, body_type: String },
+    /// The schema qualifier differs between package spec and body
+    SchemaMismatch { spec_name: String, body_name: String },
 }
 
 /// Validate that all package specs and bodies in the parsed statements are consistent.
@@ -1095,12 +1097,12 @@ pub fn validate_package_consistency(stmts: &[crate::ast::StatementInfo]) -> Vec<
     for si in stmts {
         match &si.statement {
             Statement::CreatePackage(spec) => {
-                let name = object_name_str(&spec.name);
-                specs.insert(name, spec);
+                let key = last_name_lower(&spec.name);
+                specs.insert(key, spec);
             }
             Statement::CreatePackageBody(body) => {
-                let name = object_name_str(&body.name);
-                bodies.insert(name, body);
+                let key = last_name_lower(&body.name);
+                bodies.insert(key, body);
             }
             _ => {}
         }
@@ -1108,13 +1110,33 @@ pub fn validate_package_consistency(stmts: &[crate::ast::StatementInfo]) -> Vec<
 
     let mut errors = Vec::new();
 
-    for (pkg_name, spec) in &specs {
-        if let Some(body) = bodies.get(pkg_name) {
-            validate_single_package(pkg_name, spec, body, &mut errors);
+    for (pkg_key, spec) in &specs {
+        if let Some(body) = bodies.get(pkg_key) {
+            let spec_full = object_name_str(&spec.name);
+            let body_full = object_name_str(&body.name);
+            if spec_full != body_full {
+                errors.push(PackageConsistencyError {
+                    package_name: pkg_key.to_uppercase(),
+                    subprogram_name: String::new(),
+                    kind: PackageConsistencyErrorKind::SchemaMismatch {
+                        spec_name: spec_full.clone(),
+                        body_name: body_full.clone(),
+                    },
+                    detail: Some(format!(
+                        "package spec defined as \"{}\" but body defined as \"{}\"",
+                        spec_full, body_full
+                    )),
+                });
+            }
+            validate_single_package(pkg_key, spec, body, &mut errors);
         }
     }
 
     errors
+}
+
+pub(crate) fn last_name_lower(name: &crate::ast::ObjectName) -> String {
+    name.last().map(|s| s.to_lowercase()).unwrap_or_default()
 }
 
 fn object_name_str(name: &crate::ast::ObjectName) -> String {

--- a/src/analyzer/validate.rs
+++ b/src/analyzer/validate.rs
@@ -55,7 +55,7 @@ pub fn validate_pl_variables_from_stmts(
                 }
             }
             Statement::CreatePackageBody(body) => {
-                let body_name: String = body.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
+                let body_key = crate::analyzer::last_name_lower(&body.name);
                 let mut pkg_vars: Vec<&str> = body
                     .items
                     .iter()
@@ -66,9 +66,8 @@ pub fn validate_pl_variables_from_stmts(
                     .collect();
                 for other_si in stmts {
                     if let Statement::CreatePackage(spec) = &other_si.statement {
-                        let spec_name: String =
-                            spec.name.iter().map(|s| s.to_lowercase()).collect::<Vec<_>>().join(".");
-                        if spec_name == body_name {
+                        let spec_key = crate::analyzer::last_name_lower(&spec.name);
+                        if spec_key == body_key {
                             for item in &spec.items {
                                 if let crate::ast::PackageItem::Variable(v) = item {
                                     pkg_vars.push(v.name.as_str());
@@ -320,6 +319,65 @@ mod tests {
         let stmts = parse_stmts(sql);
         let report = validate_statements(&stmts, &["known_func".to_string()], true);
         assert!(report.undefined_variable_errors.is_empty(), "known_func in extra_funcs should suppress error");
+    }
+
+    #[test]
+    fn package_schema_mismatch_emits_warning() {
+        let sql = "CREATE OR REPLACE PACKAGE pkg_a AS v_flag NUMBER; PROCEDURE prc_test; END pkg_a;\n\
+                   CREATE OR REPLACE PACKAGE BODY myschema.pkg_a AS \
+                   PROCEDURE prc_test IS BEGIN v_flag := 1; END prc_test; END pkg_a;";
+        let stmts = parse_stmts(sql);
+        let report = validate_statements(&stmts, &[], false);
+        assert!(
+            report
+                .package_errors
+                .iter()
+                .any(|e| matches!(e.kind, crate::PackageConsistencyErrorKind::SchemaMismatch { .. })),
+            "should emit SchemaMismatch when spec and body have different schema qualification"
+        );
+    }
+
+    #[test]
+    fn package_schema_mismatch_still_resolves_variables() {
+        let sql = "CREATE OR REPLACE PACKAGE pkg_b AS v_flag NUMBER; PROCEDURE prc_test; END pkg_b;\n\
+                   CREATE OR REPLACE PACKAGE BODY myschema.pkg_b AS \
+                   PROCEDURE prc_test IS BEGIN v_flag := 1; END prc_test; END pkg_b;";
+        let stmts = parse_stmts(sql);
+        let report = validate_statements(&stmts, &[], false);
+        assert!(
+            report.undefined_variable_errors.is_empty(),
+            "should NOT report undefined variable when spec/body schemas differ but package name matches"
+        );
+    }
+
+    #[test]
+    fn package_schema_mismatch_reversed_still_resolves_variables() {
+        let sql = "CREATE OR REPLACE PACKAGE myschema.pkg_c AS v_flag NUMBER; PROCEDURE prc_test; END pkg_c;\n\
+                   CREATE OR REPLACE PACKAGE BODY pkg_c AS \
+                   PROCEDURE prc_test IS BEGIN v_flag := 1; END prc_test; END pkg_c;";
+        let stmts = parse_stmts(sql);
+        let report = validate_statements(&stmts, &[], false);
+        assert!(
+            report.undefined_variable_errors.is_empty(),
+            "should NOT report undefined variable when spec has schema but body doesn't"
+        );
+    }
+
+    #[test]
+    fn package_same_schema_no_warning() {
+        let sql = "CREATE OR REPLACE PACKAGE myschema.pkg_d AS v_flag NUMBER; PROCEDURE prc_test; END pkg_d;\n\
+                   CREATE OR REPLACE PACKAGE BODY myschema.pkg_d AS \
+                   PROCEDURE prc_test IS BEGIN v_flag := 1; END prc_test; END pkg_d;";
+        let stmts = parse_stmts(sql);
+        let report = validate_statements(&stmts, &[], false);
+        assert!(
+            !report
+                .package_errors
+                .iter()
+                .any(|e| matches!(e.kind, crate::PackageConsistencyErrorKind::SchemaMismatch { .. })),
+            "should NOT emit SchemaMismatch when spec and body have same schema"
+        );
+        assert!(report.undefined_variable_errors.is_empty(), "should NOT report undefined variable");
     }
 
     /// Helper: parse SQL text into Vec<StatementInfo>.

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -13274,6 +13274,102 @@ fn test_package_body_mixed_variables_and_procedures() {
 }
 
 #[test]
+fn test_package_body_procedure_references_package_variable() {
+    let sql = "CREATE OR REPLACE PACKAGE BODY pkg_example AS\n\
+               v_status VARCHAR := 'ACTIVE';\n\
+               v_counter INTEGER := 0;\n\
+               PROCEDURE prc_update(p_new_status VARCHAR) IS\n\
+               BEGIN\n\
+                 v_status := p_new_status;\n\
+                 v_counter := v_counter + 1;\n\
+                 RAISE NOTICE 'status: %, count: %', v_status, v_counter;\n\
+               END prc_update;\n\
+               FUNCTION get_status RETURN VARCHAR IS\n\
+               BEGIN\n\
+                 RETURN v_status;\n\
+               END get_status;\n\
+               END pkg_example;";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreatePackageBody(p) => {
+            // Verify package-level variables exist
+            assert_eq!(p.items.len(), 4, "should have 4 items: 2 vars + 1 proc + 1 func, got {}", p.items.len());
+            assert!(matches!(&p.items[0], PackageItem::Variable(v) if v.name == "v_status"));
+            assert!(matches!(&p.items[1], PackageItem::Variable(v) if v.name == "v_counter"));
+
+            // Verify procedure references v_status and v_counter
+            let proc = match &p.items[2] {
+                PackageItem::Procedure(pr) => pr,
+                other => panic!("expected Procedure, got {:?}", other),
+            };
+            let block = proc.block.as_ref().expect("procedure should have a block");
+            assert_eq!(block.body.len(), 3, "should have 3 statements: 2 assignments + 1 RAISE");
+
+            // Check assignment: v_status := p_new_status
+            match &block.body[0] {
+                PlStatement::Assignment { target, expression: _ } => match target {
+                    Expr::ColumnRef(ident_list) => {
+                        assert_eq!(ident_list.len(), 1);
+                        assert_eq!(ident_list[0].value, "v_status");
+                    }
+                    other => panic!("expected ColumnRef for assignment target, got {:?}", other),
+                },
+                other => panic!("expected Assignment, got {:?}", other),
+            }
+
+            // Check assignment: v_counter := v_counter + 1 (references v_counter in RHS)
+            match &block.body[1] {
+                PlStatement::Assignment { target, expression: _ } => match target {
+                    Expr::ColumnRef(ident_list) => {
+                        assert_eq!(ident_list.len(), 1);
+                        assert_eq!(ident_list[0].value, "v_counter");
+                    }
+                    other => panic!("expected ColumnRef for assignment target, got {:?}", other),
+                },
+                other => panic!("expected Assignment, got {:?}", other),
+            }
+
+            // Check RAISE references v_status and v_counter
+            match &block.body[2] {
+                PlStatement::Raise(raise_stmt) => {
+                    assert_eq!(raise_stmt.params.len(), 2, "RAISE should have 2 params");
+                    match &raise_stmt.params[0] {
+                        Expr::ColumnRef(ident_list) => {
+                            assert_eq!(ident_list[0].value, "v_status");
+                        }
+                        other => panic!("expected ColumnRef for RAISE param, got {:?}", other),
+                    }
+                    match &raise_stmt.params[1] {
+                        Expr::ColumnRef(ident_list) => {
+                            assert_eq!(ident_list[0].value, "v_counter");
+                        }
+                        other => panic!("expected ColumnRef for RAISE param, got {:?}", other),
+                    }
+                }
+                other => panic!("expected Raise, got {:?}", other),
+            }
+
+            // Verify function references v_status
+            let func = match &p.items[3] {
+                PackageItem::Function(f) => f,
+                other => panic!("expected Function, got {:?}", other),
+            };
+            let fblock = func.block.as_ref().expect("function should have a block");
+            match &fblock.body[0] {
+                PlStatement::Return { expression: Some(expr) } => match expr {
+                    Expr::ColumnRef(ident_list) => {
+                        assert_eq!(ident_list[0].value, "v_status");
+                    }
+                    other => panic!("expected ColumnRef for RETURN, got {:?}", other),
+                },
+                other => panic!("expected Return with expression, got {:?}", other),
+            }
+        }
+        other => panic!("expected CreatePackageBody, got {:?}", other),
+    }
+}
+
+#[test]
 fn test_package_body_variable_json_serialization() {
     let sql = "CREATE OR REPLACE PACKAGE BODY pkg_example AS\n\
                v_status VARCHAR := 'ACTIVE';\n\

--- a/tests/regress/feat_package_var_reference_parser.sql
+++ b/tests/regress/feat_package_var_reference_parser.sql
@@ -1,0 +1,117 @@
+-- Issue: package-var-reference
+-- Description: Package-level variables referenced inside procedures and functions
+-- Expect: all parse without error
+
+-- 场景1: 包级变量在过程中赋值和读取
+CREATE OR REPLACE PACKAGE BODY pkg_var_ref AS
+  v_status VARCHAR := 'ACTIVE';
+  v_counter INTEGER := 0;
+  PROCEDURE prc_update_status(p_new_status VARCHAR) IS
+  BEGIN
+    v_status := p_new_status;
+    v_counter := v_counter + 1;
+    RAISE NOTICE 'status: %, count: %', v_status, v_counter;
+  END prc_update_status;
+  FUNCTION get_status RETURN VARCHAR IS
+  BEGIN
+    RETURN v_status;
+  END get_status;
+END pkg_var_ref;
+
+-- 场景2: 包级变量在条件判断中引用
+CREATE OR REPLACE PACKAGE BODY pkg_cond_ref AS
+  v_threshold INTEGER := 100;
+  PROCEDURE prc_check(p_value INTEGER) IS
+  BEGIN
+    IF p_value > v_threshold THEN
+      RAISE NOTICE 'value % exceeds threshold %', p_value, v_threshold;
+    ELSE
+      RAISE NOTICE 'value % within limit', p_value;
+    END IF;
+  END prc_check;
+END pkg_cond_ref;
+
+-- 场景3: 包级变量在 FOR/WHILE 循环中使用
+CREATE OR REPLACE PACKAGE BODY pkg_loop_ref AS
+  v_total INTEGER := 0;
+  v_limit INTEGER := 10;
+  PROCEDURE prc_accumulate IS
+    i INTEGER;
+  BEGIN
+    v_total := 0;
+    FOR i IN 1 .. v_limit LOOP
+      v_total := v_total + i;
+    END LOOP;
+  END prc_accumulate;
+END pkg_loop_ref;
+
+-- 场景4: 包级变量在 SELECT INTO 中作为目标
+CREATE OR REPLACE PACKAGE BODY pkg_select_ref AS
+  v_current_user VARCHAR := '';
+  PROCEDURE prc_fetch_user IS
+  BEGIN
+    SELECT current_user INTO v_current_user;
+    RAISE NOTICE 'current user: %', v_current_user;
+  END prc_fetch_user;
+END pkg_select_ref;
+
+-- 场景5: 包级变量在 EXECUTE IMMEDIATE 中引用
+CREATE OR REPLACE PACKAGE BODY pkg_dynamic_ref AS
+  v_table_name VARCHAR := 'employees';
+  v_sql VARCHAR(1000);
+  PROCEDURE prc_dynamic_delete IS
+  BEGIN
+    v_sql := 'DELETE FROM ' || v_table_name || ' WHERE status = ''INACTIVE''';
+    EXECUTE IMMEDIATE v_sql;
+  END prc_dynamic_delete;
+END pkg_dynamic_ref;
+
+-- 场景6: 包级变量作为 EXCEPTION 处理中的参数
+CREATE OR REPLACE PACKAGE BODY pkg_exception_ref AS
+  v_retry_count INTEGER := 0;
+  v_max_retries INTEGER := 3;
+  PROCEDURE prc_with_retry IS
+  BEGIN
+    v_retry_count := 0;
+    LOOP
+      BEGIN
+        NULL;
+      EXCEPTION
+        WHEN OTHERS THEN
+          v_retry_count := v_retry_count + 1;
+          IF v_retry_count >= v_max_retries THEN
+            RAISE;
+          END IF;
+      END;
+      EXIT;
+    END LOOP;
+  END prc_with_retry;
+END pkg_exception_ref;
+
+-- 场景7: spec 无 schema，body 带 schema — 仍应关联变量
+CREATE OR REPLACE PACKAGE pkg_schema_test AS
+  v_flag NUMBER;
+  PROCEDURE prc_test;
+END pkg_schema_test;
+
+CREATE OR REPLACE PACKAGE BODY myschema.pkg_schema_test AS
+  PROCEDURE prc_test IS
+  BEGIN
+    v_flag := 1;
+    RAISE NOTICE '%', v_flag;
+  END prc_test;
+END pkg_schema_test;
+
+-- 场景8: spec 带 schema，body 无 schema — 仍应关联变量
+CREATE OR REPLACE PACKAGE myschema.pkg_schema_rev AS
+  v_flag NUMBER;
+  PROCEDURE prc_test;
+END pkg_schema_rev;
+
+CREATE OR REPLACE PACKAGE BODY pkg_schema_rev AS
+  PROCEDURE prc_test IS
+  BEGIN
+    v_flag := 1;
+    RAISE NOTICE '%', v_flag;
+  END prc_test;
+END pkg_schema_rev;

--- a/tests/regression_parser.rs
+++ b/tests/regression_parser.rs
@@ -60,6 +60,18 @@ fn slash_division_in_complex() {
 }
 
 #[test]
+fn package_var_reference_in_body() {
+    let fixtures = load_named("package_var_reference", "parser");
+    assert!(!fixtures.is_empty(), "回归守护: fixture 文件缺失");
+    for f in &fixtures {
+        let blocks: Vec<&str> = f.content.split("\n\n").filter(|b| !b.trim().is_empty()).collect();
+        for (i, block) in blocks.iter().enumerate() {
+            assert_parse_all(block, &format!("{}/block{}", f.id, i));
+        }
+    }
+}
+
+#[test]
 fn slash_division_in_plpgsql() {
     let fixtures = load_named("slash_division_plpgsql", "parser");
     assert!(!fixtures.is_empty(), "回归守护: fixture 文件缺失");


### PR DESCRIPTION
## Summary

Fix two validators to match PACKAGE spec and body by the last name component instead of the fully-qualified name. When schema qualifiers differ but the package name matches, variables are still correctly resolved and a `SchemaMismatch` warning is emitted.

## Changes

- **`src/analyzer/mod.rs`**: Add `SchemaMismatch` variant to `PackageConsistencyErrorKind`; change `validate_package_consistency` to match by `last_name_lower`; emit warning when schema qualifiers differ
- **`src/analyzer/validate.rs`**: Change `validate_pl_variables_from_stmts` to match by `last_name_lower` for variable association
- **`src/parser/tests.rs`**: Add AST-level unit test verifying package variable references in procedure assignments, RAISE, and RETURN
- **`tests/regression_parser.rs`**: Add regression test loading the new fixture
- **`tests/regress/feat_package_var_reference_parser.sql`**: New fixture with 8 scenarios covering normal variable references and schema mismatch both directions
- **`Cargo.toml`**: Bump version to 0.8.15

## Before/After

| Scenario | Before | After |
|---|---|---|
| spec=`pkg`, body=`myschema.pkg` | ❌ `undefined variable` | ✅ `VALID` + ⚠️ warning |
| spec=`myschema.pkg`, body=`pkg` | ❌ `undefined variable` | ✅ `VALID` + ⚠️ warning |
| spec=`myschema.pkg`, body=`myschema.pkg` | ✅ `VALID` | ✅ `VALID` (no warning) |

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-features -- -D warnings` ✅
- All 18 relevant tests pass ✅