### PR TITLE
fix: parse inline CONSTRAINT name, ON DELETE/UPDATE FK order, trigger NEW/OLD builtins (#263, #264, #265)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1442,6 +1442,20 @@ const PL_BUILTIN_VALUES: &[&str] = &[
     "BOTH",
     "LEADING",
     "TRAILING",
+    // PL/pgSQL trigger context built-in variables (NEW, OLD, TG_*).
+    // Valid in trigger functions (RETURNS trigger) and treated as
+    // implicitly declared built-in values for PL variable validation.
+    "NEW",
+    "OLD",
+    "TG_ARGV",
+    "TG_LEVEL",
+    "TG_NAME",
+    "TG_NARGS",
+    "TG_OP",
+    "TG_RELID",
+    "TG_TABLE_NAME",
+    "TG_TABLE_SCHEMA",
+    "TG_WHEN",
 ];
 
 fn is_pl_builtin(name: &str) -> bool {

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -1366,3 +1366,139 @@ fn test_strict_mode_allows_param_as_subscript() {
     let func_errors: Vec<_> = strict.iter().filter(|e| e.kind == super::UndefinedRefKind::Function).collect();
     assert!(func_errors.is_empty(), "parameter used as subscript should not be flagged: {:?}", func_errors);
 }
+
+// ══ Regression tests: Issue #265 — NEW/OLD trigger variables flagged undefined ══
+
+fn parse_func_validate(sql: &str) -> (crate::ast::plpgsql::PlBlock, Vec<crate::ast::RoutineParam>) {
+    let tokens = crate::Tokenizer::new(sql).tokenize().unwrap();
+    let stmts = Parser::new(tokens).parse();
+    match &stmts[0] {
+        crate::ast::Statement::CreateFunction(func) => {
+            let block = func.block.as_ref().expect("block should parse").clone();
+            (block, func.parameters.clone())
+        }
+        _ => panic!("expected CreateFunction, got {:?}", stmts[0]),
+    }
+}
+
+#[test]
+fn test_trigger_new_variable_not_undefined() {
+    // 正例: RETURNS trigger 函数中 NEW 不应被标记为未定义
+    let (block, params) = parse_func_validate(
+        "CREATE FUNCTION public.last_updated() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN NEW.last_update = CURRENT_TIMESTAMP; RETURN NEW; END; $$",
+    );
+    let warnings = super::validate_pl_variables(&block, &params);
+    let vars: Vec<_> = warnings.iter().filter(|e| e.kind == super::UndefinedRefKind::Variable).collect();
+    assert!(vars.is_empty(), "NEW should not be flagged as undefined in trigger function, got: {:?}", warnings);
+}
+
+#[test]
+fn test_trigger_old_variable_not_undefined() {
+    // 正例: RETURNS trigger 函数中 OLD 不应被标记为未定义
+    let (block, params) = parse_func_validate(
+        "CREATE FUNCTION public.check_old() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN IF OLD.status = 'deleted' THEN RETURN NULL; END IF; RETURN NEW; END; $$",
+    );
+    let warnings = super::validate_pl_variables(&block, &params);
+    assert!(!has_undefined(&warnings, "OLD"), "OLD should not be flagged as undefined in trigger function");
+    assert!(!has_undefined(&warnings, "NEW"), "NEW should not be flagged as undefined in trigger function");
+}
+
+#[test]
+fn test_trigger_new_in_do_block_not_undefined() {
+    // 正例: DO block 中单部分 NEW 引用不应标记为未定义
+    let block = parse_do_validate("DO $$ DECLARE r RECORD; BEGIN r := NEW; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(
+        !has_undefined(&warnings, "NEW"),
+        "NEW should not be flagged as undefined even in non-trigger PL blocks, got: {:?}",
+        warnings
+    );
+}
+
+#[test]
+fn test_trigger_old_in_do_block_not_undefined() {
+    // 正例: DO block 中单部分 OLD 引用不应标记为未定义
+    let block = parse_do_validate("DO $$ DECLARE r RECORD; BEGIN r := OLD; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(
+        !has_undefined(&warnings, "OLD"),
+        "OLD should not be flagged as undefined even in non-trigger PL blocks, got: {:?}",
+        warnings
+    );
+}
+
+#[test]
+fn test_trigger_tg_op_not_undefined() {
+    // 正例: TG_OP 不应被标记为未定义
+    let block = parse_do_validate("DO $$ BEGIN IF TG_OP = 'INSERT' THEN NULL; END IF; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(!has_undefined(&warnings, "TG_OP"), "TG_OP should not be flagged as undefined");
+}
+
+#[test]
+fn test_trigger_tg_name_not_undefined() {
+    // 正例: TG_NAME 不应被标记为未定义
+    let block = parse_do_validate("DO $$ BEGIN RAISE NOTICE 'trigger: %', TG_NAME; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(!has_undefined(&warnings, "TG_NAME"), "TG_NAME should not be flagged as undefined");
+}
+
+#[test]
+fn test_trigger_tg_when_not_undefined() {
+    // 正例: TG_WHEN, TG_LEVEL, TG_RELID, TG_TABLE_NAME, TG_TABLE_SCHEMA, TG_ARGV, TG_NARGS
+    let block = parse_do_validate("DO $$ BEGIN IF TG_WHEN = 'BEFORE' AND TG_LEVEL = 'ROW' THEN NULL; END IF; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(!has_undefined(&warnings, "TG_WHEN"));
+    assert!(!has_undefined(&warnings, "TG_LEVEL"));
+}
+
+#[test]
+fn test_trigger_tg_all_builtins_not_undefined() {
+    // 正例: 所有 TG_ 变量综合测试
+    let block = parse_do_validate(
+        "DO $$ BEGIN
+        IF TG_OP = 'UPDATE' THEN
+            IF TG_WHEN = 'BEFORE' THEN
+                RAISE NOTICE 'trigger % on %', TG_NAME, TG_TABLE_NAME;
+            END IF;
+        END IF;
+        IF TG_NARGS > 0 THEN NULL; END IF;
+    END $$",
+    );
+    let warnings = super::validate_pl_variables(&block, &[]);
+    let vars: Vec<_> = warnings.iter().filter(|e| e.kind == super::UndefinedRefKind::Variable).collect();
+    assert!(
+        vars.is_empty(),
+        "TG_NAME, TG_OP, TG_WHEN, TG_TABLE_NAME, TG_NARGS should not be flagged, got: {:?}",
+        warnings.iter().map(|e| &e.variable_name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_pl_variable_new_field_access_not_undefined() {
+    // 正例: NEW.column_name 的 field access — NEW should 被识别
+    let block = parse_do_validate("DO $$ BEGIN NEW.last_update := CURRENT_TIMESTAMP; RETURN NEW; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(!has_undefined(&warnings, "NEW"), "NEW should not be flagged in field access, got: {:?}", warnings);
+}
+
+// ══ Regression: Issue #265 反例 — 确保真正的未定义变量仍被正确标记 ══
+
+#[test]
+fn test_truly_undefined_variable_still_detected() {
+    // 反例: 真正的未定义变量仍应被标记
+    let block = parse_do_validate("DO $$ BEGIN v_unknown := 1; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(has_undefined(&warnings, "v_unknown"), "truly undefined variable should still be flagged");
+}
+
+#[test]
+fn test_found_not_found_still_work_as_builtins() {
+    // 反例: FOUND 和 NOT_FOUND 原本就在 PL_BUILTIN_VALUES 中，不应受影响
+    let block = parse_do_validate("DO $$ BEGIN IF FOUND THEN NULL; END IF; IF NOT_FOUND THEN NULL; END IF; END $$");
+    let warnings = super::validate_pl_variables(&block, &[]);
+    assert!(!has_undefined(&warnings, "FOUND"));
+    assert!(!has_undefined(&warnings, "NOT_FOUND"));
+}

--- a/src/parser/ddl/table.rs
+++ b/src/parser/ddl/table.rs
@@ -1366,6 +1366,30 @@ impl Parser {
     }
 
     fn try_parse_column_constraint(&mut self) -> Result<Option<ColumnConstraint>, ParserError> {
+        // Handle inline CONSTRAINT [name] prefix for column-level constraints.
+        // ColumnConstraint AST type does not store constraint names, so we
+        // consume the name but discard it — same as how parse_table_constraint
+        // optionally consumes CONSTRAINT name before the constraint body.
+        if self.match_keyword(Keyword::CONSTRAINT) {
+            self.advance();
+            // If the next token is a constraint keyword (NOT, NULL, DEFAULT,
+            // UNIQUE, PRIMARY, CHECK, REFERENCES), then no name was given —
+            // CONSTRAINT is just an optional keyword prefix.
+            let has_name = !matches!(
+                self.peek_keyword(),
+                Some(Keyword::NOT)
+                    | Some(Keyword::NULL_P)
+                    | Some(Keyword::DEFAULT)
+                    | Some(Keyword::UNIQUE)
+                    | Some(Keyword::PRIMARY)
+                    | Some(Keyword::CHECK)
+                    | Some(Keyword::REFERENCES)
+            );
+            if has_name {
+                let _name = self.parse_identifier()?;
+            }
+        }
+
         let result = match self.peek_keyword() {
             Some(Keyword::NOT) => {
                 self.advance();
@@ -1422,8 +1446,7 @@ impl Parser {
                 } else {
                     Vec::new()
                 };
-                let on_delete = self.parse_referential_action(Keyword::DELETE_P)?;
-                let on_update = self.parse_referential_action(Keyword::UPDATE)?;
+                let (on_delete, on_update) = self.parse_referential_actions()?;
                 Some(ColumnConstraint::References { ref_table, ref_columns, on_delete, on_update })
             }
             _ => None,
@@ -1588,8 +1611,7 @@ impl Parser {
                 self.expect_keyword(Keyword::REFERENCES)?;
                 let ref_table = self.parse_object_name()?;
                 let ref_columns = self.parse_column_list()?;
-                let on_delete = self.parse_referential_action(Keyword::DELETE_P)?;
-                let on_update = self.parse_referential_action(Keyword::UPDATE)?;
+                let (on_delete, on_update) = self.parse_referential_actions()?;
                 Ok(TableConstraint::ForeignKey { columns, ref_table, ref_columns, on_delete, on_update })
             }
             _ => Err(ParserError::UnexpectedToken {
@@ -1617,45 +1639,60 @@ impl Parser {
         Ok(columns)
     }
 
-    fn parse_referential_action(&mut self, keyword: Keyword) -> Result<Option<ReferentialAction>, ParserError> {
-        if self.match_keyword(Keyword::ON) {
-            let pos = self.pos;
+    /// Parse ON DELETE / ON UPDATE referential action clauses in any order.
+    /// PostgreSQL grammar permits ON DELETE and ON UPDATE to appear in either
+    /// order: `REFERENCES ... ON UPDATE CASCADE ON DELETE RESTRICT` and
+    /// `REFERENCES ... ON DELETE RESTRICT ON UPDATE CASCADE` are both valid.
+    fn parse_referential_actions(
+        &mut self,
+    ) -> Result<(Option<ReferentialAction>, Option<ReferentialAction>), ParserError> {
+        let mut on_delete = None;
+        let mut on_update = None;
+        while self.match_keyword(Keyword::ON) {
             self.advance();
-            if self.match_keyword(keyword) {
+            if self.match_keyword(Keyword::DELETE_P) {
                 self.advance();
-                let action = if self.match_keyword(Keyword::CASCADE) {
-                    self.advance();
-                    ReferentialAction::Cascade
-                } else if self.match_keyword(Keyword::RESTRICT) {
-                    self.advance();
-                    ReferentialAction::Restrict
-                } else if self.match_keyword(Keyword::SET) {
-                    self.advance();
-                    if self.match_keyword(Keyword::NULL_P) {
-                        self.advance();
-                        ReferentialAction::SetNull
-                    } else {
-                        self.expect_keyword(Keyword::DEFAULT)?;
-                        ReferentialAction::SetDefault
-                    }
-                } else if self.match_keyword(Keyword::NO) {
-                    self.advance();
-                    self.expect_keyword(Keyword::ACTION)?;
-                    ReferentialAction::NoAction
-                } else {
-                    return Err(ParserError::UnexpectedToken {
-                        location: self.current_location(),
-                        expected: "CASCADE, RESTRICT, SET NULL, SET DEFAULT, or NO ACTION".to_string(),
-                        got: format!("{:?}", self.peek()),
-                    });
-                };
-                Ok(Some(action))
+                on_delete = Some(self.parse_referential_action_body()?);
+            } else if self.match_keyword(Keyword::UPDATE) {
+                self.advance();
+                on_update = Some(self.parse_referential_action_body()?);
             } else {
-                self.pos = pos;
-                Ok(None)
+                return Err(ParserError::UnexpectedToken {
+                    location: self.current_location(),
+                    expected: "DELETE or UPDATE".to_string(),
+                    got: format!("{:?}", self.peek()),
+                });
             }
+        }
+        Ok((on_delete, on_update))
+    }
+
+    fn parse_referential_action_body(&mut self) -> Result<ReferentialAction, ParserError> {
+        if self.match_keyword(Keyword::CASCADE) {
+            self.advance();
+            Ok(ReferentialAction::Cascade)
+        } else if self.match_keyword(Keyword::RESTRICT) {
+            self.advance();
+            Ok(ReferentialAction::Restrict)
+        } else if self.match_keyword(Keyword::SET) {
+            self.advance();
+            if self.match_keyword(Keyword::NULL_P) {
+                self.advance();
+                Ok(ReferentialAction::SetNull)
+            } else {
+                self.expect_keyword(Keyword::DEFAULT)?;
+                Ok(ReferentialAction::SetDefault)
+            }
+        } else if self.match_keyword(Keyword::NO) {
+            self.advance();
+            self.expect_keyword(Keyword::ACTION)?;
+            Ok(ReferentialAction::NoAction)
         } else {
-            Ok(None)
+            Err(ParserError::UnexpectedToken {
+                location: self.current_location(),
+                expected: "CASCADE, RESTRICT, SET NULL, SET DEFAULT, or NO ACTION".to_string(),
+                got: format!("{:?}", self.peek()),
+            })
         }
     }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -14523,3 +14523,396 @@ fn test_call_statement_empty_args_does_not_panic() {
         other => panic!("expected Statement::Call, got {:?}", other),
     }
 }
+
+// ══ Regression tests: Issue #263 — Inline CONSTRAINT name in column definition ══
+
+#[test]
+fn test_column_def_inline_constraint_name_check() {
+    // 正例: CONSTRAINT name CHECK (...) in column definition
+    let sql = "CREATE TABLE public.film (film_id INTEGER NOT NULL, release_year INTEGER CONSTRAINT film_release_year_check CHECK (release_year IS NULL OR (release_year >= 1901 AND release_year <= 2155)))";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let CreateTableStatement { columns, .. } = &s.node;
+            assert_eq!(columns.len(), 2, "should have 2 columns");
+            // release_year column should have a CHECK constraint (name discarded)
+            let col = &columns[1];
+            assert_eq!(col.name, "release_year");
+            assert!(
+                col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Check(_))),
+                "release_year should have CHECK constraint, got: {:?}",
+                col.constraints
+            );
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_name_unique() {
+    // 正例: CONSTRAINT name UNIQUE in column definition
+    let sql = "CREATE TABLE t (a INT CONSTRAINT uq_a UNIQUE)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Unique)));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_name_primary_key() {
+    // 正例: CONSTRAINT name PRIMARY KEY in column definition
+    let sql = "CREATE TABLE t (a INT CONSTRAINT pk_a PRIMARY KEY)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::PrimaryKey)));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_name_references() {
+    // 正例: CONSTRAINT name REFERENCES table(col) in column definition
+    let sql = "CREATE TABLE t (a INT CONSTRAINT fk_a REFERENCES other(id))";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::References { .. })));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_name_default() {
+    // 正例: CONSTRAINT name DEFAULT in column definition
+    let sql = "CREATE TABLE t (a INT CONSTRAINT df_a DEFAULT 0)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Default(_))));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_name_not_null() {
+    // 正例: CONSTRAINT name NOT NULL in column definition
+    let sql = "CREATE TABLE t (a INT CONSTRAINT nn_a NOT NULL)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::NotNull)));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_name_null() {
+    // 正例: CONSTRAINT name NULL in column definition
+    let sql = "CREATE TABLE t (a INT CONSTRAINT n_a NULL)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Null)));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_multiple_inline_constraint_names() {
+    // 正例: 多个 inline CONSTRAINT name 在同一个列定义中
+    let sql =
+        "CREATE TABLE t (a INT CONSTRAINT nn_a NOT NULL CONSTRAINT df_a DEFAULT 0 CONSTRAINT chk_a CHECK (a > 0))";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert_eq!(col.constraints.len(), 3);
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::NotNull)));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Default(_))));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Check(_))));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_column_def_inline_constraint_mixed_with_unnamed() {
+    // 正例: inline named constraint 与 unnamed constraint 混用
+    let sql = "CREATE TABLE t (a INT NOT NULL CONSTRAINT chk_a CHECK (a > 0))";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert_eq!(col.constraints.len(), 2);
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::NotNull)));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Check(_))));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+// ══ Regression: Issue #263 反例 — 确保现有 unnamed column constraint 不受影响 ══
+
+#[test]
+fn test_column_def_unnamed_constraints_still_work() {
+    // 反例: 不带 CONSTRAINT keyword 的列约束不应该受影响
+    let sql = "CREATE TABLE t (a INT NOT NULL DEFAULT 0 UNIQUE CHECK (a > 0) PRIMARY KEY REFERENCES other(id))";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::NotNull)));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Default(_))));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Unique)));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::Check(_))));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::PrimaryKey)));
+            assert!(col.constraints.iter().any(|c| matches!(c, ColumnConstraint::References { .. })));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_table_level_constraint_name_still_works() {
+    // 反例: 表级 CONSTRAINT name 不应受影响
+    let sql = "CREATE TABLE t (a INT, CONSTRAINT pk_a PRIMARY KEY (a))";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            assert_eq!(s.node.constraints.len(), 1);
+            assert!(matches!(s.node.constraints[0], TableConstraint::PrimaryKey { .. }));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+// ══ Regression tests: Issue #264 — ON DELETE/UPDATE in ALTER TABLE ADD CONSTRAINT FK ══
+
+#[test]
+fn test_alter_table_add_constraint_fk_on_delete_restrict() {
+    // 正例: ON DELETE RESTRICT (单个动作，先 DELETE)
+    let sql = "ALTER TABLE public.address ADD CONSTRAINT fk_city FOREIGN KEY (city_id) REFERENCES public.city(city_id) ON DELETE RESTRICT";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => {
+            let action = a.actions.first().unwrap();
+            match action {
+                AlterTableAction::AddConstraint { name, constraint } => {
+                    assert_eq!(name.as_deref(), Some("fk_city"));
+                    match constraint {
+                        TableConstraint::ForeignKey { columns, ref_table, ref_columns, on_delete, on_update } => {
+                            assert_eq!(*columns, vec!["city_id"]);
+                            assert_eq!(ref_table.join("."), "public.city");
+                            assert_eq!(*ref_columns, vec!["city_id"]);
+                            assert!(matches!(on_delete, Some(ReferentialAction::Restrict)));
+                            assert!(on_update.is_none());
+                        }
+                        other => panic!("expected ForeignKey, got {:?}", other),
+                    }
+                }
+                other => panic!("expected AddConstraint, got {:?}", other),
+            }
+        }
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_alter_table_add_constraint_fk_on_update_cascade() {
+    // 正例: ON UPDATE CASCADE (单个动作，先 UPDATE)
+    let sql = "ALTER TABLE t ADD CONSTRAINT fk_f FOREIGN KEY (a) REFERENCES r(a) ON UPDATE CASCADE";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => {
+            let action = a.actions.first().unwrap();
+            match action {
+                AlterTableAction::AddConstraint { constraint, .. } => match constraint {
+                    TableConstraint::ForeignKey { on_delete, on_update, .. } => {
+                        assert!(on_delete.is_none());
+                        assert!(matches!(on_update, Some(ReferentialAction::Cascade)));
+                    }
+                    other => panic!("expected ForeignKey, got {:?}", other),
+                },
+                other => panic!("expected AddConstraint, got {:?}", other),
+            }
+        }
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_alter_table_add_constraint_fk_on_update_then_on_delete() {
+    // 正例: ON UPDATE ... ON DELETE ... (UPDATE 先出现 — issue 中报告的精确顺序)
+    let sql = "ALTER TABLE ONLY public.address ADD CONSTRAINT address_city_id_fkey FOREIGN KEY (city_id) REFERENCES public.city(city_id) ON UPDATE CASCADE ON DELETE RESTRICT";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => {
+            let action = a.actions.first().unwrap();
+            match action {
+                AlterTableAction::AddConstraint { name, constraint } => {
+                    assert_eq!(name.as_deref(), Some("address_city_id_fkey"));
+                    match constraint {
+                        TableConstraint::ForeignKey { columns, ref_table, ref_columns, on_delete, on_update } => {
+                            assert_eq!(*columns, vec!["city_id"]);
+                            assert_eq!(ref_table.join("."), "public.city");
+                            assert_eq!(*ref_columns, vec!["city_id"]);
+                            assert!(
+                                matches!(on_update, Some(ReferentialAction::Cascade)),
+                                "expected ON UPDATE CASCADE, got: {:?}",
+                                on_update
+                            );
+                            assert!(
+                                matches!(on_delete, Some(ReferentialAction::Restrict)),
+                                "expected ON DELETE RESTRICT, got: {:?}",
+                                on_delete
+                            );
+                        }
+                        other => panic!("expected ForeignKey, got {:?}", other),
+                    }
+                }
+                other => panic!("expected AddConstraint, got {:?}", other),
+            }
+        }
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_alter_table_add_constraint_fk_on_delete_then_on_update() {
+    // 正例: ON DELETE ... ON UPDATE ... (DELETE 先出现 — 反向顺序)
+    let sql = "ALTER TABLE t ADD CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES r(a) ON DELETE CASCADE ON UPDATE RESTRICT";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => {
+            let action = a.actions.first().unwrap();
+            match action {
+                AlterTableAction::AddConstraint { constraint, .. } => match constraint {
+                    TableConstraint::ForeignKey { on_delete, on_update, .. } => {
+                        assert!(matches!(on_delete, Some(ReferentialAction::Cascade)));
+                        assert!(matches!(on_update, Some(ReferentialAction::Restrict)));
+                    }
+                    other => panic!("expected ForeignKey, got {:?}", other),
+                },
+                other => panic!("expected AddConstraint, got {:?}", other),
+            }
+        }
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_alter_table_add_constraint_fk_all_referential_actions() {
+    // 正例: 覆盖所有 referential action 类型 (ON DELETE SET NULL, ON UPDATE SET DEFAULT, NO ACTION)
+    let sql =
+        "ALTER TABLE t ADD CONSTRAINT fk_full FOREIGN KEY (a) REFERENCES r(a) ON DELETE SET NULL ON UPDATE NO ACTION";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => match a.actions.first().unwrap() {
+            AlterTableAction::AddConstraint { constraint, .. } => match constraint {
+                TableConstraint::ForeignKey { on_delete, on_update, .. } => {
+                    assert!(matches!(on_delete, Some(ReferentialAction::SetNull)));
+                    assert!(matches!(on_update, Some(ReferentialAction::NoAction)));
+                }
+                other => panic!("expected ForeignKey, got {:?}", other),
+            },
+            other => panic!("expected AddConstraint, got {:?}", other),
+        },
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_alter_table_add_constraint_fk_on_delete_set_default() {
+    // 正例: ON DELETE SET DEFAULT
+    let sql = "ALTER TABLE t ADD CONSTRAINT fk_d FOREIGN KEY (a) REFERENCES r(a) ON DELETE SET DEFAULT";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => match a.actions.first().unwrap() {
+            AlterTableAction::AddConstraint { constraint, .. } => match constraint {
+                TableConstraint::ForeignKey { on_delete, on_update, .. } => {
+                    assert!(matches!(on_delete, Some(ReferentialAction::SetDefault)));
+                    assert!(on_update.is_none());
+                }
+                other => panic!("expected ForeignKey, got {:?}", other),
+            },
+            other => panic!("expected AddConstraint, got {:?}", other),
+        },
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+// ══ Regression: Issue #264 反例 — 确保无 ON DELETE/UPDATE 的 FK 不受影响 ══
+
+#[test]
+fn test_alter_table_add_constraint_fk_no_referential_actions() {
+    // 反例: 不带 ON DELETE/UPDATE 的 FK 仍应正常解析
+    let sql = "ALTER TABLE t ADD CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES r(a)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::AlterTable(a) => match a.actions.first().unwrap() {
+            AlterTableAction::AddConstraint { constraint, .. } => match constraint {
+                TableConstraint::ForeignKey { on_delete, on_update, .. } => {
+                    assert!(on_delete.is_none());
+                    assert!(on_update.is_none());
+                }
+                other => panic!("expected ForeignKey, got {:?}", other),
+            },
+            other => panic!("expected AddConstraint, got {:?}", other),
+        },
+        other => panic!("expected AlterTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_table_fk_with_referential_actions_still_works() {
+    // 反例: CREATE TABLE 中的 FK + ON DELETE/UPDATE 不应受影响
+    let sql = "CREATE TABLE t (a INT REFERENCES r(a) ON DELETE CASCADE ON UPDATE RESTRICT)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            let col = &s.node.columns[0];
+            assert!(col.constraints.iter().any(|c| matches!(
+                c,
+                ColumnConstraint::References {
+                    on_delete: Some(ReferentialAction::Cascade),
+                    on_update: Some(ReferentialAction::Restrict),
+                    ..
+                }
+            )));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_create_table_table_fk_with_referential_actions_still_works() {
+    // 反例: CREATE TABLE 表级 FK + ON DELETE/UPDATE 不应受影响
+    let sql = "CREATE TABLE t (a INT, FOREIGN KEY (a) REFERENCES r(a) ON DELETE CASCADE ON UPDATE RESTRICT)";
+    let stmt = parse_one(sql);
+    match stmt {
+        Statement::CreateTable(s) => {
+            assert!(s.node.constraints.iter().any(|c| match c {
+                TableConstraint::ForeignKey { on_delete, on_update, .. } =>
+                    matches!(on_delete, Some(ReferentialAction::Cascade))
+                        && matches!(on_update, Some(ReferentialAction::Restrict)),
+                _ => false,
+            }));
+        }
+        other => panic!("expected CreateTable, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary

Fixes three parser/validator bugs discovered through the `ogagila` schema test suite.

### #263 — Inline `CONSTRAINT name` in column definition causes PARSE-SYNTAX

`try_parse_column_constraint()` did not handle the optional `CONSTRAINT [name]` prefix before column-level constraints (CHECK, UNIQUE, PRIMARY KEY, REFERENCES, DEFAULT, NOT NULL, NULL). When `CONSTRAINT` appeared after a column type, the parser failed to recognize it as a column constraint and expected `)` or `,` instead.

**Fix**: Added `CONSTRAINT` keyword matching at the top of `try_parse_column_constraint()` — optionally consumes the constraint name, then continues to parse the underlying constraint type.

### #264 — `ON UPDATE/DELETE` clauses in ALTER TABLE ADD CONSTRAINT FK not parsed

`parse_referential_action()` was called twice sequentially (first DELETE_P, then UPDATE). When SQL used `ON UPDATE ... ON DELETE ...` order, the DELETE_P call rolled back the entire `ON` keyword (including its position), leaving the ON DELETE clause unconsumed in the token stream.

**Fix**: Replaced the sequential calls with `parse_referential_actions()` — a single-pass loop that parses both ON DELETE and ON UPDATE in any order.

### #265 — NEW/OLD trigger variables flagged as undefined (VAL-PL-VAR)

PL/pgSQL trigger context variables (NEW, OLD, TG_OP, TG_NAME, TG_WHEN, TG_LEVEL, TG_RELID, TG_TABLE_NAME, TG_TABLE_SCHEMA, TG_ARGV, TG_NARGS) were not in `PL_BUILTIN_VALUES`, causing `validate_pl_variables()` to flag them as undefined in trigger functions.

**Fix**: Added all 11 trigger context variables to `PL_BUILTIN_VALUES`.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `src/parser/ddl/table.rs` | +75 / -38 | CONSTRAINT handling in column defs + referential actions rewrite |
| `src/analyzer/mod.rs` | +14 | Trigger variables added to PL_BUILTIN_VALUES |
| `src/parser/tests.rs` | +393 | 20 parser regression tests |
| `src/analyzer/tests.rs` | +136 | 11 variable validation regression tests |

## Verification

```
cargo fmt --all -- --check     ✅
cargo clippy --all-features    ✅ (0 warnings)
cargo test --all-features      ✅ (1980 passed, 0 failed)
```

## Related

Closes #263, closes #264, closes #265