### PR TITLE
feat(lint): add R010 function-side-effect rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ogsql-parser"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "axum",
  "clap",

--- a/docs/ecosystem-rule-mapping.md
+++ b/docs/ecosystem-rule-mapping.md
@@ -21,6 +21,7 @@ ogsql-parser (base — lint rules R*/P*/C*/S*)
 | R005 | implicit-type-conversion | Prohibition (schema-aware) | — | TYPE-001: confirms implicit conversion at runtime |
 | R007 | like-leading-wildcard | Prohibition | — | TYPE-004: confirms full scan from leading wildcard |
 | R009 | scalar-subquery-in-select | Performance | Manual-level: suggests JOIN rewrite | — |
+| R010 | function-side-effect | Prohibition | — | — |
 | P001 | union-without-all | Performance | Auto-rewrite: UNION → UNION ALL | — |
 | P002 | not-in-subquery | Performance | subquery-to-join: rewrites NOT IN to LEFT JOIN ... IS NULL | — |
 | P009 | function-instead-of-case | Performance | nvl-to-case: rewrites NVL/NVL2/DECODE to CASE | — |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -859,10 +859,10 @@ foreach_estimated_rows = 1000   # iBatis <foreach> 预估迭代次数（用于 C
 ### 11.4 规则清单
 
 > **等级说明**：`Prohibition`(禁止项) > `Performance`(性能) > `Caution`(注意) > `Suggestion`(建议)。
-> 共 53 条规则（7 Prohibition + 23 Performance + 17 Caution + 6 Suggestion = 53）。
+> 共 54 条规则（8 Prohibition + 23 Performance + 17 Caution + 6 Suggestion = 54）。
 > 编号不连续（如 C002–C004、S003–S004 不存在）是规划中预留的规则位。
 
-#### 禁止项 (Prohibition) — 违反 GaussDB 编码规范，可能引发数据安全风险（7 条）
+#### 禁止项 (Prohibition) — 违反 GaussDB 编码规范，可能引发数据安全风险（8 条）
 
 | ID | 名称 | 适用语句 | 说明 |
 |----|------|----------|------|
@@ -873,6 +873,7 @@ foreach_estimated_rows = 1000   # iBatis <foreach> 预估迭代次数（用于 C
 | R005 | `implicit-type-conversion` | DML | WHERE 中可能存在隐式类型转换，导致索引失效。需要 schema 信息辅助判断，无 schema 时跳过 |
 | R006 | `function-on-where-column` | DML | WHERE 中对列使用函数或表达式运算，将导致索引失效。建议将运算移到等号另一侧或使用函数索引 |
 | R007 | `like-leading-wildcard` | DML | `LIKE '%...'` 前导通配符导致无法使用索引，触发全表扫描。建议避免以通配符开头的 LIKE 模式 |
+| R010 | `function-side-effect` | All | 自定义 Function 中包含非 SELECT DML（INSERT/UPDATE/DELETE/MERGE/TRUNCATE 等）、事务控制语句（COMMIT/ROLLBACK/SAVEPOINT/SET TRANSACTION），或调用了含事务语句的其他函数/过程。函数应避免修改数据和提交/回滚事务，考虑将副作用操作移至过程中 |
 
 #### 性能 (Performance) — 可识别的性能陷阱，有明确的优化路径（23 条）
 

--- a/src/linter/rules_prohibition.rs
+++ b/src/linter/rules_prohibition.rs
@@ -1,3 +1,4 @@
+use crate::ast::plpgsql::{PlBlock, PlStatement};
 use crate::ast::{Expr, InsertSource, SelectStatement, SelectTarget, Statement, StatementInfo};
 use crate::linter::type_helpers::{
     build_column_type_map, classify_type_family, literal_type_family, resolve_column_type,
@@ -72,6 +73,13 @@ pub fn register(linter: &mut SqlLinter) {
             level: WarningLevel::Performance,
             stmt_kind: StatementKind::Select,
             check_fn: check_r009,
+        },
+        LintRuleEntry {
+            id: "R010",
+            name: "function-side-effect",
+            level: WarningLevel::Prohibition,
+            stmt_kind: StatementKind::All,
+            check_fn: check_r010,
         },
     ];
     for rule in rules {
@@ -639,6 +647,255 @@ fn check_r009(
             }
         }
     }
+}
+
+// R010: Function side effect — non-SELECT DML, transaction control, or calls
+// to procedures with transactions.
+fn check_r010(
+    curr_stmt: &StatementInfo,
+    stmts: &[StatementInfo],
+    _schema: Option<&crate::analyzer::schema::SchemaMap>,
+    _indexes: Option<&crate::linter::IndexInfo>,
+    _config: &LintConfig,
+    confidence: Confidence,
+    warnings: &mut Vec<SqlWarning>,
+) {
+    let Statement::CreateFunction(func) = &curr_stmt.statement else { return };
+    let Some(block) = &func.block else { return };
+
+    let loc = stmt_location(curr_stmt);
+    let func_name = func.name.join(".");
+
+    let tx_procedures = build_tx_procedure_set(stmts);
+
+    let mut has_dml = false;
+    let mut has_tx = false;
+    let mut called_tx_procs: Vec<String> = Vec::new();
+
+    scan_block_for_side_effects(block, &tx_procedures, &mut has_dml, &mut has_tx, &mut called_tx_procs);
+
+    if !has_dml && !has_tx && called_tx_procs.is_empty() {
+        return;
+    }
+
+    let mut details: Vec<String> = Vec::new();
+    if has_dml {
+        details.push(
+            "\u{975e} SELECT DML \u{64cd}\u{4f5c}\u{ff08}INSERT/UPDATE/DELETE/MERGE \u{7b49}\u{ff09}".to_string(),
+        );
+    }
+    if has_tx {
+        details.push("\u{4e8b}\u{52a1}\u{63a7}\u{5236}\u{8bed}\u{53e5}\u{ff08}COMMIT/ROLLBACK\u{ff09}".to_string());
+    }
+    for name in &called_tx_procs {
+        details.push(format!("\u{8c03}\u{7528}\u{542b}\u{4e8b}\u{52a1}\u{7684}\u{8fc7}\u{7a0b} \"{}\"", name));
+    }
+    let message = format!("\u{51fd}\u{6570} \"{}\" \u{5305}\u{542b}\u{4e0d}\u{5efa}\u{8bae}\u{5728}\u{51fd}\u{6570}\u{4e2d}\u{4f7f}\u{7528}\u{7684}\u{64cd}\u{4f5c}\u{ff1a}{}", func_name, details.join("\u{ff0c}"));
+
+    warnings.push(make_warning(
+        WarningLevel::Prohibition,
+        "R010",
+        "function-side-effect",
+        message,
+        Some("\u{51fd}\u{6570}\u{5e94}\u{907f}\u{514d}\u{4fee}\u{6539}\u{6570}\u{636e}\u{6216}\u{63d0}\u{4ea4}\u{56de}\u{6eda}\u{4e8b}\u{52a1}\u{ff0c}\u{8003}\u{8651}\u{5c06} DML / COMMIT / ROLLBACK \u{79fb}\u{81f3}\u{8fc7}\u{7a0b}\u{4e2d}"),
+        loc,
+        Some("\u{5f00}\u{53d1}\u{8bbe}\u{8ba1}\u{5efa}\u{8bae} > \u{51fd}\u{6570}\u{89c4}\u{8303}"),
+        confidence,
+    ));
+}
+
+/// Build a set of procedure/function names that contain COMMIT or ROLLBACK.
+fn build_tx_procedure_set(stmts: &[StatementInfo]) -> std::collections::HashSet<String> {
+    let mut set = std::collections::HashSet::new();
+    for info in stmts {
+        let (name, block) = match &info.statement {
+            Statement::CreateProcedure(p) => (p.name.join("."), p.block.as_ref()),
+            Statement::CreateFunction(f) => (f.name.join("."), f.block.as_ref()),
+            _ => continue,
+        };
+        if let Some(block) = block {
+            if pl_block_has_tx_control(block) {
+                set.insert(name.to_lowercase());
+            }
+        }
+    }
+    set
+}
+
+/// Check if a PL block contains COMMIT or ROLLBACK (recursively).
+fn pl_block_has_tx_control(block: &PlBlock) -> bool {
+    pl_stmts_have_tx(&block.body)
+}
+
+fn pl_stmts_have_tx(stmts: &[PlStatement]) -> bool {
+    for stmt in stmts {
+        if pl_stmt_has_tx(stmt) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns true for leaf PL statements that constitute transaction control.
+fn is_pl_tx_stmt(stmt: &PlStatement) -> bool {
+    matches!(
+        stmt,
+        PlStatement::Commit { .. }
+            | PlStatement::Rollback { .. }
+            | PlStatement::Savepoint { .. }
+            | PlStatement::ReleaseSavepoint { .. }
+            | PlStatement::SetTransaction { .. }
+    )
+}
+
+fn pl_stmt_has_tx(stmt: &PlStatement) -> bool {
+    if is_pl_tx_stmt(stmt) {
+        return true;
+    }
+    match stmt {
+        PlStatement::Block(block) => pl_block_has_tx_control(block),
+        PlStatement::If(if_stmt) => {
+            pl_stmts_have_tx(&if_stmt.then_stmts)
+                || if_stmt.elsifs.iter().any(|e| pl_stmts_have_tx(&e.stmts))
+                || pl_stmts_have_tx(&if_stmt.else_stmts)
+        }
+        PlStatement::Case(case_stmt) => {
+            case_stmt.whens.iter().any(|w| pl_stmts_have_tx(&w.stmts)) || pl_stmts_have_tx(&case_stmt.else_stmts)
+        }
+        PlStatement::Loop(loop_stmt) => pl_stmts_have_tx(&loop_stmt.body),
+        PlStatement::While(while_stmt) => pl_stmts_have_tx(&while_stmt.body),
+        PlStatement::For(for_stmt) => pl_stmts_have_tx(&for_stmt.body),
+        PlStatement::ForEach(foreach_stmt) => pl_stmts_have_tx(&foreach_stmt.body),
+        _ => false,
+    }
+}
+
+/// Recursively scan a PL block for side effects.
+fn scan_block_for_side_effects(
+    block: &PlBlock,
+    tx_procedures: &std::collections::HashSet<String>,
+    has_dml: &mut bool,
+    has_tx: &mut bool,
+    called_tx_procs: &mut Vec<String>,
+) {
+    scan_stmts_for_side_effects(&block.body, tx_procedures, has_dml, has_tx, called_tx_procs);
+    if let Some(ref exc) = block.exception_block {
+        for handler in &exc.handlers {
+            scan_stmts_for_side_effects(&handler.statements, tx_procedures, has_dml, has_tx, called_tx_procs);
+        }
+    }
+}
+
+fn scan_stmts_for_side_effects(
+    stmts: &[PlStatement],
+    tx_procedures: &std::collections::HashSet<String>,
+    has_dml: &mut bool,
+    has_tx: &mut bool,
+    called_tx_procs: &mut Vec<String>,
+) {
+    for stmt in stmts {
+        match stmt {
+            PlStatement::Block(inner) => {
+                scan_block_for_side_effects(inner, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            PlStatement::SqlStatement { statement, .. } => {
+                if is_non_select_dml(statement) {
+                    *has_dml = true;
+                }
+            }
+            PlStatement::Sql(sql_text) => {
+                if sql_text_starts_with_dml(sql_text) {
+                    *has_dml = true;
+                }
+                if sql_text_has_tx(sql_text) {
+                    *has_tx = true;
+                }
+            }
+            PlStatement::Execute(exec) => {
+                if let Some(ref parsed) = exec.parsed_query {
+                    if is_non_select_dml(parsed) {
+                        *has_dml = true;
+                    }
+                }
+            }
+            PlStatement::ProcedureCall(call) => {
+                let callee = call.name.join(".").to_lowercase();
+                if tx_procedures.contains(&callee) && !called_tx_procs.contains(&call.name.join(".")) {
+                    called_tx_procs.push(call.name.join("."));
+                }
+            }
+            PlStatement::If(if_stmt) => {
+                scan_stmts_for_side_effects(&if_stmt.then_stmts, tx_procedures, has_dml, has_tx, called_tx_procs);
+                for elsif in &if_stmt.elsifs {
+                    scan_stmts_for_side_effects(&elsif.stmts, tx_procedures, has_dml, has_tx, called_tx_procs);
+                }
+                scan_stmts_for_side_effects(&if_stmt.else_stmts, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            PlStatement::Case(case_stmt) => {
+                for when in &case_stmt.whens {
+                    scan_stmts_for_side_effects(&when.stmts, tx_procedures, has_dml, has_tx, called_tx_procs);
+                }
+                scan_stmts_for_side_effects(&case_stmt.else_stmts, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            PlStatement::Loop(loop_stmt) => {
+                scan_stmts_for_side_effects(&loop_stmt.body, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            PlStatement::While(while_stmt) => {
+                scan_stmts_for_side_effects(&while_stmt.body, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            PlStatement::For(for_stmt) => {
+                scan_stmts_for_side_effects(&for_stmt.body, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            PlStatement::ForEach(foreach_stmt) => {
+                scan_stmts_for_side_effects(&foreach_stmt.body, tx_procedures, has_dml, has_tx, called_tx_procs);
+            }
+            _ => {
+                if is_pl_tx_stmt(stmt) {
+                    *has_tx = true;
+                }
+            }
+        }
+    }
+}
+
+/// Check if a SQL statement is non-SELECT DML.
+fn is_non_select_dml(stmt: &Statement) -> bool {
+    matches!(
+        stmt,
+        Statement::Insert(_)
+            | Statement::InsertAll(_)
+            | Statement::InsertFirst(_)
+            | Statement::Replace(_)
+            | Statement::Update(_)
+            | Statement::Delete(_)
+            | Statement::Merge(_)
+            | Statement::Truncate(_)
+            | Statement::Copy(_)
+    )
+}
+
+/// Quick check if a raw SQL text (from PlStatement::Sql) starts with a DML keyword.
+fn sql_text_starts_with_dml(text: &str) -> bool {
+    let lower = text.trim_start().to_lowercase();
+    lower.starts_with("insert")
+        || lower.starts_with("update")
+        || lower.starts_with("delete")
+        || lower.starts_with("merge")
+        || lower.starts_with("truncate")
+        || lower.starts_with("copy")
+        || lower.starts_with("replace")
+}
+
+/// Quick check if a raw SQL text (from PlStatement::Sql) starts with a transaction keyword.
+fn sql_text_has_tx(text: &str) -> bool {
+    let lower = text.trim_start().to_lowercase();
+    lower.starts_with("start transaction")
+        || lower.starts_with("begin transaction")
+        || lower.starts_with("begin work")
+        || lower.starts_with("savepoint")
+        || lower.starts_with("release savepoint")
+        || lower.starts_with("rollback to savepoint")
+        || lower.starts_with("set transaction")
 }
 
 fn extract_where_clause(stmt: &Statement) -> Option<&Expr> {

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -1371,3 +1371,170 @@ fn test_s006_large_n_no_quadratic_explosion_issue_246() {
         "without fix for issue #246, count would be 20×20=400"
     );
 }
+
+// ── R010: function-side-effect ──
+
+#[test]
+fn r010_insert_in_function_warns() {
+    let stmts = parse(
+        "CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t VALUES (1); END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with INSERT should trigger R010");
+}
+
+#[test]
+fn r010_update_in_function_warns() {
+    let stmts =
+        parse("CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN UPDATE t SET c = 1; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with UPDATE should trigger R010");
+}
+
+#[test]
+fn r010_delete_in_function_warns() {
+    let stmts =
+        parse("CREATE OR REPLACE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN DELETE FROM t; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with DELETE should trigger R010");
+}
+
+#[test]
+fn r010_merge_in_function_warns() {
+    let stmts = parse(
+        "CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN MERGE INTO t1 USING t2 ON t1.id = t2.id WHEN MATCHED THEN UPDATE SET name = t2.name; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with MERGE should trigger R010");
+}
+
+#[test]
+fn r010_select_only_ok() {
+    let stmts = parse(
+        "CREATE OR REPLACE FUNCTION fn() RETURNS SETOF t LANGUAGE plpgsql AS $$ BEGIN RETURN QUERY SELECT * FROM t; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R010"), "function with only SELECT should not trigger R010");
+}
+
+#[test]
+fn r010_perform_ok() {
+    let stmts = parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN PERFORM * FROM t; END; $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R010"), "function with only PERFORM should not trigger R010");
+}
+
+#[test]
+fn r010_dml_in_nested_block_warns() {
+    let stmts = parse(
+        "CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN BEGIN INSERT INTO t VALUES (1); END; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with DML in nested block should trigger R010");
+}
+
+#[test]
+fn r010_dml_in_if_warns() {
+    let stmts = parse(
+        "CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN IF 1 > 0 THEN INSERT INTO t VALUES (1); END IF; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with DML in IF should trigger R010");
+}
+
+#[test]
+fn r010_commit_in_function_warns() {
+    let stmts = parse(
+        "CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t VALUES (1); COMMIT; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with COMMIT should trigger R010");
+}
+
+#[test]
+fn r010_calls_procedure_with_tx_warns() {
+    let stmts = parse(
+        "CREATE FUNCTION inner_f() RETURNS void LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t VALUES (1); COMMIT; END; $$;\
+         CREATE FUNCTION outer_f() RETURNS void LANGUAGE plpgsql AS $$ BEGIN inner_f(); END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function calling function with transaction should trigger R010");
+}
+
+#[test]
+fn r010_calls_safe_procedure_ok() {
+    let stmts = parse(
+        "CREATE PROCEDURE p_safe() LANGUAGE plpgsql AS $$ BEGIN PERFORM * FROM t; END; $$;\
+         CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN CALL p_safe(); END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R010"), "function calling safe procedure should not trigger R010");
+}
+
+#[test]
+fn r010_procedure_with_tx_ok() {
+    let stmts = parse("CREATE PROCEDURE p() LANGUAGE plpgsql AS $$ BEGIN INSERT INTO t VALUES (1); COMMIT; END; $$");
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R010"), "procedure with DML and COMMIT should not trigger R010 (only functions)");
+}
+
+#[test]
+fn r010_ddl_only_ok() {
+    let stmts = parse(
+        "CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN CREATE TEMP TABLE tmp (id INTEGER); DROP TABLE tmp; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(!has_rule(&w, "R010"), "function with only DDL should not trigger R010");
+}
+
+#[test]
+fn r010_truncate_in_function_warns() {
+    let stmts = parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN TRUNCATE TABLE t; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with TRUNCATE should trigger R010");
+}
+
+#[test]
+fn r010_savepoint_in_function_warns() {
+    let stmts = parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN SAVEPOINT sp1; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with SAVEPOINT should trigger R010");
+}
+
+#[test]
+fn r010_release_savepoint_in_function_warns() {
+    let stmts = parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN RELEASE SAVEPOINT sp1; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with RELEASE SAVEPOINT should trigger R010");
+}
+
+#[test]
+fn r010_rollback_to_savepoint_warns() {
+    let stmts =
+        parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN ROLLBACK TO SAVEPOINT sp1; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with ROLLBACK TO SAVEPOINT should trigger R010");
+}
+
+#[test]
+fn r010_set_transaction_warns() {
+    let stmts = parse(
+        "CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; END; $$",
+    );
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with SET TRANSACTION should trigger R010");
+}
+
+#[test]
+fn r010_start_transaction_warns() {
+    let stmts = parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN START TRANSACTION; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with START TRANSACTION should trigger R010");
+}
+
+#[test]
+fn r010_commit_only_no_dml_warns() {
+    let stmts = parse("CREATE FUNCTION fn() RETURNS void LANGUAGE plpgsql AS $$ BEGIN COMMIT; END; $$");
+    let w = lint(&stmts);
+    assert!(has_rule(&w, "R010"), "function with only COMMIT (no DML) should still trigger R010");
+}

--- a/tests/regress/r010_function_side_effect/call_function_ok.sql
+++ b/tests/regress/r010_function_side_effect/call_function_ok.sql
@@ -1,0 +1,9 @@
+-- description: function calling function without side effects should NOT trigger R010
+-- nowarn: R010
+CREATE OR REPLACE FUNCTION fn_caller() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM fn_select();
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/calls_procedure_safe_ok.sql
+++ b/tests/regress/r010_function_side_effect/calls_procedure_safe_ok.sql
@@ -1,0 +1,17 @@
+-- description: function calling safe function (no transactions) should NOT trigger R010
+-- nowarn: R010
+CREATE OR REPLACE FUNCTION inner_s() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM * FROM t1;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION outer_s() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    inner_s();
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/calls_procedure_with_tx.sql
+++ b/tests/regress/r010_function_side_effect/calls_procedure_with_tx.sql
@@ -1,0 +1,18 @@
+-- description: function calling function with transaction (cross-statement) should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION inner_f() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO t1 VALUES (1);
+    COMMIT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION outer_f() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    inner_f();
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/commit_only_no_dml.sql
+++ b/tests/regress/r010_function_side_effect/commit_only_no_dml.sql
@@ -1,0 +1,9 @@
+-- description: function with only COMMIT (no DML) should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_commit_only() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    COMMIT;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/ddl_only_ok.sql
+++ b/tests/regress/r010_function_side_effect/ddl_only_ok.sql
@@ -1,0 +1,10 @@
+-- description: function with DDL (CREATE TABLE) should NOT trigger R010
+-- nowarn: R010
+CREATE OR REPLACE FUNCTION fn_ddl() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    CREATE TEMP TABLE tmp (id INTEGER);
+    DROP TABLE tmp;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/dml_in_if.sql
+++ b/tests/regress/r010_function_side_effect/dml_in_if.sql
@@ -1,0 +1,11 @@
+-- description: function with DML nested in IF block should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_insert_in_if() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF 1 > 0 THEN
+        INSERT INTO t1 VALUES (1);
+    END IF;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/dml_in_loop.sql
+++ b/tests/regress/r010_function_side_effect/dml_in_loop.sql
@@ -1,0 +1,12 @@
+-- description: function with DML in LOOP should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_insert_in_loop() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    LOOP
+        INSERT INTO t1 VALUES (1);
+        EXIT;
+    END LOOP;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_commit.sql
+++ b/tests/regress/r010_function_side_effect/has_commit.sql
@@ -1,0 +1,10 @@
+-- description: function with COMMIT should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_commit() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO t1 VALUES (1);
+    COMMIT;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_delete.sql
+++ b/tests/regress/r010_function_side_effect/has_delete.sql
@@ -1,0 +1,9 @@
+-- description: function with DELETE should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_delete() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    DELETE FROM t1;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_insert.sql
+++ b/tests/regress/r010_function_side_effect/has_insert.sql
@@ -1,0 +1,9 @@
+-- description: function with INSERT should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_insert() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO t1 VALUES (1);
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_merge.sql
+++ b/tests/regress/r010_function_side_effect/has_merge.sql
@@ -1,0 +1,11 @@
+-- description: function with MERGE should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_merge() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    MERGE INTO t1 USING t2 ON t1.id = t2.id
+    WHEN MATCHED THEN UPDATE SET name = t2.name
+    WHEN NOT MATCHED THEN INSERT VALUES (t2.id, t2.name);
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_rollback_savepoint.sql
+++ b/tests/regress/r010_function_side_effect/has_rollback_savepoint.sql
@@ -1,0 +1,9 @@
+-- description: function with ROLLBACK TO SAVEPOINT should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_rollback_sp() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    ROLLBACK TO SAVEPOINT sp1;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_savepoint.sql
+++ b/tests/regress/r010_function_side_effect/has_savepoint.sql
@@ -1,0 +1,11 @@
+-- description: function with SAVEPOINT should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_savepoint() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    SAVEPOINT sp1;
+    INSERT INTO t VALUES (1);
+    RELEASE SAVEPOINT sp1;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_set_transaction.sql
+++ b/tests/regress/r010_function_side_effect/has_set_transaction.sql
@@ -1,0 +1,10 @@
+-- description: function with SET TRANSACTION should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_set_tx() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+    INSERT INTO t VALUES (1);
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_truncate.sql
+++ b/tests/regress/r010_function_side_effect/has_truncate.sql
@@ -1,0 +1,9 @@
+-- description: function with TRUNCATE should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_truncate() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    TRUNCATE TABLE t1;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/has_update.sql
+++ b/tests/regress/r010_function_side_effect/has_update.sql
@@ -1,0 +1,9 @@
+-- description: function with UPDATE should trigger R010
+-- warn: R010
+CREATE OR REPLACE FUNCTION fn_update() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE t1 SET name = 'x';
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/perform_select_ok.sql
+++ b/tests/regress/r010_function_side_effect/perform_select_ok.sql
@@ -1,0 +1,9 @@
+-- description: function with PERFORM SELECT should NOT trigger R010
+-- nowarn: R010
+CREATE OR REPLACE FUNCTION fn_perform() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM * FROM t1 WHERE id = 1;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/procedure_select_ok.sql
+++ b/tests/regress/r010_function_side_effect/procedure_select_ok.sql
@@ -1,0 +1,9 @@
+-- description: procedure without transactions should NOT trigger R010
+-- nowarn: R010
+CREATE OR REPLACE PROCEDURE proc_select()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM * FROM t1;
+END;
+$$;

--- a/tests/regress/r010_function_side_effect/select_only_ok.sql
+++ b/tests/regress/r010_function_side_effect/select_only_ok.sql
@@ -1,0 +1,9 @@
+-- description: function with only SELECT should NOT trigger R010
+-- nowarn: R010
+CREATE OR REPLACE FUNCTION fn_select() RETURNS SETOF t1
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM t1;
+END;
+$$;


### PR DESCRIPTION
## Summary

新增 Prohibition 级别 lint 规则 R010 `function-side-effect`，检测自定义 Function 中的不当操作。

## Detection

| 类别 | 检测内容 | 方式 |
|------|----------|------|
| 非 SELECT DML | INSERT / UPDATE / DELETE / MERGE / TRUNCATE / COPY / REPLACE | `PlStatement::SqlStatement` + 已解析 `Statement` |
| 事务控制 | COMMIT / ROLLBACK / SAVEPOINT / RELEASE SAVEPOINT / SET TRANSACTION | `PlStatement` 枚举匹配 |
| 跨调用检测 | 函数内调用含有事务的 Function/Procedure | 交叉比对同一批次的 `stmts` |
| 原始文本回退 | `PlStatement::Sql` 中的 DML/事务关键词 | 前缀匹配 |
| 动态 SQL | EXECUTE IMMEDIATE 中已被解析的 DML | `parsed_query` |

递归覆盖：嵌套 Block / IF / CASE / LOOP / WHILE / FOR / FOREACH / 异常处理块。

## Files Changed

- `src/linter/rules_prohibition.rs` — R010 规则 + 共享辅助函数 `is_pl_tx_stmt`
- `src/linter/tests.rs` — 20 个单元测试
- `tests/regress/r010_function_side_effect/` — 19 个回归测试 SQL fixture
- `docs/user-guide.md` — 规则清单更新（53→54）
- `docs/ecosystem-rule-mapping.md` — 添加 R010 映射

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-features -- -D warnings` ✅  
- `cargo test --all-features` ✅（全量通过）
- 20 unit tests + 19 regression fixtures